### PR TITLE
Add a Result BGM to CStage結果

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,14 +10,5 @@
 *.swp
 *.DotSettings.user
 /packages
-/Test/Capture_img
-/Test/Config*.ini
-/Test/bs1770gain**
-/Test/dll/CSharpTest.Net.Collections.*
-/Test/dll/FDK.*
-/Test/dll/Newtonsoft.Json.*
-/Test/dll/Sentry.*
-/Test/dll/SlimDX.*
-/Test/dll/System.*
-/Test/TJAPlayer3.exe.config
+/Test
 

--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -16,7 +16,8 @@ namespace TJAPlayer3
 		BGMコンフィグ画面,
 		BGM起動画面,
 		BGM選曲画面,
-		SOUNDステージ失敗音,
+        BGM結果画面,
+        SOUNDステージ失敗音,
 		SOUNDカーソル移動音,
 		SOUNDゲーム開始音,
 		SOUNDゲーム終了音,
@@ -302,6 +303,7 @@ namespace TJAPlayer3
         public Cシステムサウンド bgmコンフィグ画面 = null;
         public Cシステムサウンド bgm起動画面 = null;
         public Cシステムサウンド bgm選曲画面 = null;
+        public Cシステムサウンド bgm結果画面 = null;
         public Cシステムサウンド soundSTAGEFAILED音 = null;
         public Cシステムサウンド soundカーソル移動音 = null;
         public Cシステムサウンド soundゲーム開始音 = null;
@@ -380,6 +382,9 @@ namespace TJAPlayer3
                     case Eシステムサウンド.BGM選曲画面:
                         return this.bgm選曲画面;
 
+                    case Eシステムサウンド.BGM結果画面:
+                        return this.bgm結果画面;
+
                     //case Eシステムサウンド.SOUND赤:
                     //    return this.soundRed;
 
@@ -452,19 +457,22 @@ namespace TJAPlayer3
                     case 15:
                         return this.bgm選曲画面;
 
+                    case 16:
+                        return this.bgm結果画面;
+
                     //case 16:
                     //    return this.soundRed;
 
                     //case 17:
                     //    return this.soundBlue;
 
-                    case 16:
+                    case 17:
                         return this.soundBalloon;
 
-                    case 17:
+                    case 18:
                         return this.sound曲決定音;
 
-                    case 18:
+                    case 19:
                         return this.sound成績発表;
                 }
                 throw new IndexOutOfRangeException();
@@ -614,6 +622,7 @@ namespace TJAPlayer3
             this.bgmオプション画面 = new Cシステムサウンド(@"Sounds\Option BGM.ogg", true, true, ESoundGroup.SongPlayback);
             this.bgmコンフィグ画面 = new Cシステムサウンド(@"Sounds\Config BGM.ogg", true, true,  ESoundGroup.SongPlayback);
             this.bgm選曲画面 = new Cシステムサウンド(@"Sounds\Select BGM.ogg", true, true, ESoundGroup.SongPreview);
+            this.bgm結果画面 = new Cシステムサウンド(@"Sounds\Result BGM.ogg", true, true, ESoundGroup.SongPreview);
 
             //this.soundRed               = new Cシステムサウンド( @"Sounds\dong.ogg",            false, false, ESoundType.SoundEffect );
             //this.soundBlue              = new Cシステムサウンド( @"Sounds\ka.ogg",              false, false, ESoundType.SoundEffect );

--- a/TJAPlayer3/Stages/08.Result/CStage結果.cs
+++ b/TJAPlayer3/Stages/08.Result/CStage結果.cs
@@ -272,7 +272,7 @@ namespace TJAPlayer3
 		}
 		public override int On進行描画()
 		{
-			if( !base.b活性化してない )
+            if ( !base.b活性化してない )
 			{
 				int num;
 				if( base.b初めての進行描画 )
@@ -285,7 +285,7 @@ namespace TJAPlayer3
 						this.rResultSound.t再生を開始する();
 					}
 					base.b初めての進行描画 = false;
-				}
+                }
 				this.bアニメが完了 = true;
 				if( this.ct登場用.b進行中 )
 				{
@@ -349,6 +349,7 @@ namespace TJAPlayer3
 					if( this.actFI.On進行描画() != 0 )
 					{
 						base.eフェーズID = CStage.Eフェーズ.共通_通常状態;
+                        TJAPlayer3.Skin.bgm結果画面.t再生する();
 					}
 				}
 				else if( ( base.eフェーズID == CStage.Eフェーズ.共通_フェードアウト ) )			//&& ( this.actFO.On進行描画() != 0 ) )


### PR DESCRIPTION
This PR adds a new BGM type for result BGMs and plays it on the Result scene.

Additionally, it includes all files in Test/ in gitignore to allow for own configuration/songs for testing.

I'm not sure how you want to handle code style on this project in the future, and if you want to have new code in Japanese as well, though I believe I am now entitled to financial compensation due to eyeball damage.