### PR TITLE
Add a Result BGM to CStage結果

### DIFF
--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -16,7 +16,8 @@ namespace TJAPlayer3
 		BGMコンフィグ画面,
 		BGM起動画面,
 		BGM選曲画面,
-		SOUNDステージ失敗音,
+        BGM結果画面,
+        SOUNDステージ失敗音,
 		SOUNDカーソル移動音,
 		SOUNDゲーム開始音,
 		SOUNDゲーム終了音,
@@ -302,6 +303,7 @@ namespace TJAPlayer3
         public Cシステムサウンド bgmコンフィグ画面 = null;
         public Cシステムサウンド bgm起動画面 = null;
         public Cシステムサウンド bgm選曲画面 = null;
+        public Cシステムサウンド bgm結果画面 = null;
         public Cシステムサウンド soundSTAGEFAILED音 = null;
         public Cシステムサウンド soundカーソル移動音 = null;
         public Cシステムサウンド soundゲーム開始音 = null;
@@ -381,19 +383,22 @@ namespace TJAPlayer3
                     case 15:
                         return this.bgm選曲画面;
 
+                    case 16:
+                        return this.bgm結果画面;
+
                     //case 16:
                     //    return this.soundRed;
 
                     //case 17:
                     //    return this.soundBlue;
 
-                    case 16:
+                    case 17:
                         return this.soundBalloon;
 
-                    case 17:
+                    case 18:
                         return this.sound曲決定音;
 
-                    case 18:
+                    case 19:
                         return this.sound成績発表;
                 }
                 throw new IndexOutOfRangeException();
@@ -536,6 +541,7 @@ namespace TJAPlayer3
             this.bgmオプション画面 = new Cシステムサウンド(@"Sounds\Option BGM.ogg", true, true, ESoundGroup.SongPlayback);
             this.bgmコンフィグ画面 = new Cシステムサウンド(@"Sounds\Config BGM.ogg", true, true,  ESoundGroup.SongPlayback);
             this.bgm選曲画面 = new Cシステムサウンド(@"Sounds\Select BGM.ogg", true, true, ESoundGroup.SongPreview);
+            this.bgm結果画面 = new Cシステムサウンド(@"Sounds\Result BGM.ogg", true, true, ESoundGroup.SongPreview);
 
             //this.soundRed               = new Cシステムサウンド( @"Sounds\dong.ogg",            false, false, ESoundType.SoundEffect );
             //this.soundBlue              = new Cシステムサウンド( @"Sounds\ka.ogg",              false, false, ESoundType.SoundEffect );

--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -17,7 +17,7 @@ namespace TJAPlayer3
 		BGM起動画面,
 		BGM選曲画面,
         BGM結果画面,
-        SOUNDステージ失敗音,
+		SOUNDステージ失敗音,
 		SOUNDカーソル移動音,
 		SOUNDゲーム開始音,
 		SOUNDゲーム終了音,

--- a/TJAPlayer3/Stages/08.Result/CStage結果.cs
+++ b/TJAPlayer3/Stages/08.Result/CStage結果.cs
@@ -272,7 +272,7 @@ namespace TJAPlayer3
 		}
 		public override int On進行描画()
 		{
-			if( !base.b活性化してない )
+            if ( !base.b活性化してない )
 			{
 				int num;
 				if( base.b初めての進行描画 )
@@ -285,7 +285,7 @@ namespace TJAPlayer3
 						this.rResultSound.t再生を開始する();
 					}
 					base.b初めての進行描画 = false;
-				}
+                }
 				this.bアニメが完了 = true;
 				if( this.ct登場用.b進行中 )
 				{
@@ -349,6 +349,7 @@ namespace TJAPlayer3
 					if( this.actFI.On進行描画() != 0 )
 					{
 						base.eフェーズID = CStage.Eフェーズ.共通_通常状態;
+                        TJAPlayer3.Skin.bgm結果画面.t再生する();
 					}
 				}
 				else if( ( base.eフェーズID == CStage.Eフェーズ.共通_フェードアウト ) )			//&& ( this.actFO.On進行描画() != 0 ) )

--- a/TJAPlayer3/Stages/08.Result/CStage結果.cs
+++ b/TJAPlayer3/Stages/08.Result/CStage結果.cs
@@ -272,7 +272,7 @@ namespace TJAPlayer3
 		}
 		public override int On進行描画()
 		{
-            if ( !base.b活性化してない )
+			if ( !base.b活性化してない )
 			{
 				int num;
 				if( base.b初めての進行描画 )
@@ -285,7 +285,7 @@ namespace TJAPlayer3
 						this.rResultSound.t再生を開始する();
 					}
 					base.b初めての進行描画 = false;
-                }
+				}
 				this.bアニメが完了 = true;
 				if( this.ct登場用.b進行中 )
 				{

--- a/TJAPlayer3/Stages/08.Result/CStage結果.cs
+++ b/TJAPlayer3/Stages/08.Result/CStage結果.cs
@@ -272,7 +272,7 @@ namespace TJAPlayer3
 		}
 		public override int On進行描画()
 		{
-			if ( !base.b活性化してない )
+			if( !base.b活性化してない )
 			{
 				int num;
 				if( base.b初めての進行描画 )

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@
 - [Song Selection](#song-selection)
   - [Song Ratings / Favorites](#song-ratings--favorites)
   - [Song List Files](#song-list-files)
+- [Skinning](#skinning)
 
 ## The Current State of TJAPlayer3 Documentation
 
@@ -30,3 +31,9 @@ Required: TJAPlayer3 v4.7.0 or greater
 You might want one song to appear in multiple locations within the song selection tree. You might want a set of songs to appear in a completely customized order. Instead of copying files and renaming them to control the order in which they appear, you can create and use Song List Files.
 
 Read more in [Song List Files](song-list-files.md).
+
+## [Skinning](skinning.md)
+
+TJAPlayer3 supports skinning of its user interface via image, audio, and configuration files.
+
+Read more in [Skinning](skinning.md).

--- a/docs/skinning.md
+++ b/docs/skinning.md
@@ -1,0 +1,28 @@
+<!-- omit in toc -->
+# Skinning
+
+<!-- omit in toc -->
+## Table of Contents
+
+- [Overview](#overview)
+- [Stages](#stages)
+  - [The Result Stage](#the-result-stage)
+    - [Sounds](#sounds)
+
+## Overview
+
+TJAPlayer3 supports skinning of its user interface via image, audio, and configuration files.
+
+Skinning is currently more limited and difficult than would be desired, but is flexible enough to approximate many console and arcade taiko rhythm game user interfaces.
+
+Unfortunately, up-to-date documentation regarding all current skinning support does not exist at this time. In the document below you will instead only find information regarding skinning capabilities added and/or changed in TJAPlayer3 v5.2.0 or greater.
+
+If you would like to help expand this documentation, please get in touch with the TJAPlayer3 contributors.
+
+## Stages
+
+### The Result Stage
+
+#### Sounds
+
+- `Sounds\Result BGM.ogg` is looped indefinitely while the Result stage is shown. (Required: TJAPlayer3 v5.2.0 or greater)


### PR DESCRIPTION
Adapted from @goaaats #22 "This PR adds a new BGM type for result BGMs and plays it on the Result scene."

Excludes #22s changes to .gitignore, due to "I'd like to retain the previous .gitignore for now as there are sadly still some files within the Test folder that are under source control and need to be monitored. Work on #10, especially if supported by library updates, should help open things up for improvement in that area."

Closes #22
