### PR TITLE
Fix a crash due to a missing (or otherwise unloadable) font file.

### DIFF
--- a/TJAPlayer3/Common/CPrivateFont.cs
+++ b/TJAPlayer3/Common/CPrivateFont.cs
@@ -183,7 +183,7 @@ namespace TJAPlayer3
 		/// <returns>描画済テクスチャ</returns>
 		protected Bitmap DrawPrivateFont( string drawstr, DrawMode drawmode, Color fontColor, Color edgeColor, Color gradationTopColor, Color gradationBottomColor )
 		{
-			if ( this._fontfamily == null || drawstr == null || drawstr == "" )
+			if ( this._fontfamily == null || _font == null || drawstr == null || drawstr == "" )
 			{
 				// nullを返すと、その後bmp→texture処理や、textureのサイズを見て__の処理で全部例外が発生することになる。
 				// それは非常に面倒なので、最小限のbitmapを返してしまう。
@@ -290,7 +290,7 @@ namespace TJAPlayer3
 		/// <returns>描画済テクスチャ</returns>
 		protected Bitmap DrawPrivateFont_V( string drawstr, Color fontColor, Color edgeColor, bool bVertical )
 		{
-			if ( this._fontfamily == null || drawstr == null || drawstr == "" )
+			if ( this._fontfamily == null || _font == null || drawstr == null || drawstr == "" )
 			{
 				// nullを返すと、その後bmp→texture処理や、textureのサイズを見て__の処理で全部例外が発生することになる。
 				// それは非常に面倒なので、最小限のbitmapを返してしまう。


### PR DESCRIPTION
Check for non-null font instance in CPrivateFont.DrawPrivateFont and DrawPrivateFont_V

The code was checking for non-null font family but now checks both. This prevents an exception from the precise string measurement code which then causes an application crash. Fixes TJAPLAYER3-8