### PR TITLE
Fix a font fallback issue in song selection.

### DIFF
--- a/TJAPlayer3/Common/CConfigIni.cs
+++ b/TJAPlayer3/Common/CConfigIni.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Diagnostics;
 using FDK;
 using FDK.ExtensionMethods;
+using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
@@ -1273,7 +1274,7 @@ namespace TJAPlayer3
 			this.n表示可能な最小コンボ数.Guitar = 2;
 			this.n表示可能な最小コンボ数.Bass = 2;
 			this.n表示可能な最小コンボ数.Taiko = 3;
-            this.FontName = "MS UI Gothic";
+            this.FontName = FontUtilities.FallbackFontName;
 		    this.ApplyLoudnessMetadata = true;
 
 		    // 2018-08-28 twopointzero:

--- a/TJAPlayer3/Common/CPrivateFont.cs
+++ b/TJAPlayer3/Common/CPrivateFont.cs
@@ -4,37 +4,10 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Diagnostics;
 using FDK.ExtensionMethods;
+using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
-    /// <summary>
-    /// プライベートフォントでの描画を扱うクラス。
-    /// </summary>
-    /// <exception cref="FileNotFoundException">フォントファイルが見つからない時に例外発生</exception>
-    /// <exception cref="ArgumentException">スタイル指定不正時に例外発生</exception>
-    /// <remarks>
-    /// 簡単な使い方
-    /// CPrivateFont prvFont = new CPrivateFont( CSkin.Path( @"Graphics\fonts\mplus-1p-bold.ttf" ), 36 );	// プライベートフォント
-    /// とか
-    /// CPrivateFont prvFont = new CPrivateFont( new FontFamily("MS UI Gothic"), 36, FontStyle.Bold );		// システムフォント
-    /// とかした上で、
-    /// Bitmap bmp = prvFont.DrawPrivateFont( "ABCDE", Color.White, Color.Black );							// フォント色＝白、縁の色＝黒の例。縁の色は省略可能
-    /// とか
-    /// Bitmap bmp = prvFont.DrawPrivateFont( "ABCDE", Color.White, Color.Black, Color.Yellow, Color.OrangeRed ); // 上下グラデーション(Yellow→OrangeRed)
-    /// とかして、
-    /// CTexture ctBmp = CDTXMania.tテクスチャの生成( bmp, false );
-    /// ctBMP.t2D描画( ～～～ );
-    /// で表示してください。
-    /// 
-    /// 注意点
-    /// 任意のフォントでのレンダリングは結構負荷が大きいので、なるべｋなら描画フレーム毎にフォントを再レンダリングするようなことはせず、
-    /// 一旦レンダリングしたものを描画に使い回すようにしてください。
-    /// また、長い文字列を与えると、返されるBitmapも横長になります。この横長画像をそのままテクスチャとして使うと、
-    /// 古いPCで問題を発生させやすいです。これを回避するには、一旦Bitmapとして取得したのち、256pixや512pixで分割して
-    /// テクスチャに定義するようにしてください。
-    /// </remarks>
-
-
     public class CPrivateFont : IDisposable
 	{
 		#region [ コンストラクタ ]
@@ -73,26 +46,11 @@ namespace TJAPlayer3
 				}
 				catch (System.IO.FileNotFoundException)
 				{
-					Trace.TraceWarning("プライベートフォントの追加に失敗しました({0})。代わりにMS UI Gothicの使用を試みます。", fontpath);
+					Trace.TraceWarning($"プライベートフォントの追加に失敗しました({fontpath})。代わりに{FontUtilities.FallbackFontName}の使用を試みます。");
 					//throw new FileNotFoundException( "プライベートフォントの追加に失敗しました。({0})", Path.GetFileName( fontpath ) );
 					//return;
 					_fontfamily = null;
 				}
-
-				//foreach ( FontFamily ff in _pfc.Families )
-				//{
-				//	Debug.WriteLine( "fontname=" + ff.Name );
-				//	if ( ff.Name == Path.GetFileNameWithoutExtension( fontpath ) )
-				//	{
-				//		_fontfamily = ff;
-				//		break;
-				//	}
-				//}
-				//if ( _fontfamily == null )
-				//{
-				//	Trace.TraceError( "プライベートフォントの追加後、検索に失敗しました。({0})", fontpath );
-				//	return;
-				//}
 			}
 
 			// 指定されたフォントスタイルが適用できない場合は、フォント内で定義されているスタイルから候補を選んで使用する
@@ -123,24 +81,19 @@ namespace TJAPlayer3
 				//HighDPI対応のため、pxサイズで指定
 			}
 			else
-			// フォントファイルが見つからなかった場合 (MS PGothicを代わりに指定する)
-			{
-				float emSize = pt * 96.0f / 72.0f;
-				this._font = new Font("MS UI Gothic", emSize, style, GraphicsUnit.Pixel);	//MS PGothicのFontオブジェクトを作成する
-				FontFamily[] ffs = new System.Drawing.Text.InstalledFontCollection().Families;
-				int lcid = System.Globalization.CultureInfo.GetCultureInfo("en-us").LCID;
-				foreach (FontFamily ff in ffs)
-				{
-					// Trace.WriteLine( lcid ) );
-					if (ff.GetName(lcid) == "MS UI Gothic")
-					{
-						this._fontfamily = ff;
-						Trace.TraceInformation("MS UI Gothicを代わりに指定しました。");
-						return;
-					}
-				}
-				throw new FileNotFoundException("プライベートフォントの追加に失敗し、MS UI Gothicでの代替処理にも失敗しました。({0})", Path.GetFileName(fontpath));
-			}
+            {
+                try
+                {
+                    _fontfamily = new FontFamily(FontUtilities.FallbackFontName);
+                    float emSize = pt * 96.0f / 72.0f;
+                    _font = new Font(_fontfamily, emSize, style, GraphicsUnit.Pixel);
+                    Trace.TraceInformation($"{FontUtilities.FallbackFontName}を代わりに指定しました。");
+                }
+                catch (Exception e)
+                {
+                    throw new FileNotFoundException($"プライベートフォントの追加に失敗し、{FontUtilities.FallbackFontName}での代替処理にも失敗しました。({Path.GetFileName(fontpath)})", e);
+                }
+            }
 		}
 
 		[Flags]

--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using FDK;
 using System.Drawing;
 using System.Linq;
+using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
@@ -2507,7 +2508,7 @@ namespace TJAPlayer3
         public int[] Game_Lyric_XY = new int[] { 640, 630 };
         public int Game_MusicName_FontSize = 30;
         public ReferencePoint Game_MusicName_ReferencePoint = ReferencePoint.Right;
-        public string Game_Lyric_FontName = "MS UI Gothic";
+        public string Game_Lyric_FontName = FontUtilities.FallbackFontName;
         public int Game_Lyric_FontSize = 38;
         public ReferencePoint Game_Lyric_ReferencePoint = ReferencePoint.Center;
 

--- a/TJAPlayer3/Common/FontUtilities.cs
+++ b/TJAPlayer3/Common/FontUtilities.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Diagnostics;
+using System.Drawing;
+
+namespace TJAPlayer3.Common
+{
+    internal class FontUtilities
+    {
+        public const string FallbackFontName = "MS UI Gothic";
+
+        public static FontFamily GetFontFamilyOrFallback(string fontName)
+        {
+            if (string.IsNullOrWhiteSpace(fontName))
+            {
+                fontName = FallbackFontName;
+            }
+
+            try
+            {
+                return new FontFamily(fontName);
+            }
+            catch (ArgumentException e)
+            {
+                Trace.TraceError(e.Message);
+
+                return new FontFamily(FallbackFontName);
+            }
+        }
+    }
+}

--- a/TJAPlayer3/Stages/02.Title/CActEnumSongs.cs
+++ b/TJAPlayer3/Stages/02.Title/CActEnumSongs.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Globalization;
 using SlimDX;
 using FDK;
+using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
@@ -79,7 +80,7 @@ namespace TJAPlayer3
 
 			try
 			{
-				System.Drawing.Font ftMessage = new System.Drawing.Font("MS UI Gothic", 40f, FontStyle.Bold, GraphicsUnit.Pixel );
+				System.Drawing.Font ftMessage = new System.Drawing.Font(FontUtilities.FallbackFontName, 40f, FontStyle.Bold, GraphicsUnit.Pixel );
 				string[] strMessage = 
 				{
 					"     曲データの一覧を\n       取得しています。\n   しばらくお待ちください。",

--- a/TJAPlayer3/Stages/04.Config/CActConfigList.cs
+++ b/TJAPlayer3/Stages/04.Config/CActConfigList.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Threading;
 using FDK;
+using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
@@ -1481,7 +1482,7 @@ namespace TJAPlayer3
             if ( !string.IsNullOrEmpty(TJAPlayer3.ConfigIni.FontName))
 			    this.prvFont = new CPrivateFastFont(new FontFamily(TJAPlayer3.ConfigIni.FontName), 20 );	// t項目リストの設定 の前に必要
             else
-                this.prvFont = new CPrivateFastFont(new FontFamily("MS UI Gothic"), 20);
+                this.prvFont = new CPrivateFastFont(new FontFamily(FontUtilities.FallbackFontName), 20);
 
             //			this.listMenu = new List<stMenuItemRight>();
 

--- a/TJAPlayer3/Stages/04.Config/CActConfigList.cs
+++ b/TJAPlayer3/Stages/04.Config/CActConfigList.cs
@@ -1479,10 +1479,7 @@ namespace TJAPlayer3
 			nSkinSampleIndex = -1;
 			#endregion
 
-            if ( !string.IsNullOrEmpty(TJAPlayer3.ConfigIni.FontName))
-			    this.prvFont = new CPrivateFastFont(new FontFamily(TJAPlayer3.ConfigIni.FontName), 20 );	// t項目リストの設定 の前に必要
-            else
-                this.prvFont = new CPrivateFastFont(new FontFamily(FontUtilities.FallbackFontName), 20);
+            this.prvFont = new CPrivateFastFont(FontUtilities.GetFontFamilyOrFallback(TJAPlayer3.ConfigIni.FontName), 20); // t項目リストの設定 の前に必要
 
             //			this.listMenu = new List<stMenuItemRight>();
 

--- a/TJAPlayer3/Stages/04.Config/CStageコンフィグ.cs
+++ b/TJAPlayer3/Stages/04.Config/CStageコンフィグ.cs
@@ -57,20 +57,13 @@ namespace TJAPlayer3
 			Trace.Indent();
 			try
 			{
-				this.n現在のメニュー番号 = 0;                                                    //
-                if (!string.IsNullOrEmpty(TJAPlayer3.ConfigIni.FontName))
-                {
-                    this.ftフォント = new Font(TJAPlayer3.ConfigIni.FontName, 18.0f, FontStyle.Bold, GraphicsUnit.Pixel);
-                }
-                else
-                {
-                    this.ftフォント = new Font(FontUtilities.FallbackFontName, 18.0f, FontStyle.Bold, GraphicsUnit.Pixel);
-                }
-				for( int i = 0; i < 4; i++ )													//
-				{																				//
-					this.ctキー反復用[ i ] = new CCounter( 0, 0, 0, TJAPlayer3.Timer );			//
-				}																				//
-				this.bメニューにフォーカス中 = true;											// ここまでOPTIONと共通
+				this.n現在のメニュー番号 = 0;
+                this.ftフォント = new Font(FontUtilities.GetFontFamilyOrFallback(TJAPlayer3.ConfigIni.FontName), 18.0f, FontStyle.Bold, GraphicsUnit.Pixel);
+				for( int i = 0; i < 4; i++ )
+				{
+					this.ctキー反復用[ i ] = new CCounter( 0, 0, 0, TJAPlayer3.Timer );
+				}
+				this.bメニューにフォーカス中 = true;
 				this.eItemPanelモード = EItemPanelモード.パッド一覧;
 			}
 			finally
@@ -115,42 +108,42 @@ namespace TJAPlayer3
 				Trace.Unindent();
 			}
 		}
-		public override void OnManagedリソースの作成()											// OPTIONと画像以外共通
-		{
-			if( !base.b活性化してない )
-			{
-				//this.tx背景 = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\4_background.jpg" ), false );
-				//this.tx上部パネル = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\4_header panel.png" ) );
-				//this.tx下部パネル = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\4_footer panel.png" ) );
-				//this.txMenuカーソル = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\ScreenConfig menu cursor.png" ) );
-			    string[] strMenuItem = {"System", "Drums", "Exit"};
-			    txMenuItemLeft = new CTexture[strMenuItem.Length, 2];
-			    using (var prvFont = new CPrivateFastFont(CSkin.Path(@"mplus-1p-heavy.ttf"), 20))
-			    {
-			        for (int i = 0; i < strMenuItem.Length; i++)
-			        {
-			            using (var bmpStr = prvFont.DrawPrivateFont(strMenuItem[i], Color.White, Color.Black))
-			            {
-			                txMenuItemLeft[i, 0] = TJAPlayer3.tテクスチャの生成(bmpStr, false);
-			            }
-			            using (var bmpStr = prvFont.DrawPrivateFont(strMenuItem[i], Color.White, Color.Black, Color.Yellow, Color.OrangeRed))
-			            {
-			                txMenuItemLeft[i, 1] = TJAPlayer3.tテクスチャの生成(bmpStr, false);
-			            }
-			        }
-			    }
 
-			    if( this.bメニューにフォーカス中 )
-				{
-					this.t説明文パネルに現在選択されているメニューの説明を描画する();
-				}
-				else
-				{
-					this.t説明文パネルに現在選択されている項目の説明を描画する();
-				}
-				base.OnManagedリソースの作成();
-			}
-		}
+        public override void OnManagedリソースの作成()
+        {
+            if (!b活性化してない)
+            {
+                string[] strMenuItem = {"System", "Drums", "Exit"};
+                txMenuItemLeft = new CTexture[strMenuItem.Length, 2];
+                using (var prvFont = new CPrivateFastFont(CSkin.Path(@"mplus-1p-heavy.ttf"), 20))
+                {
+                    for (var i = 0; i < strMenuItem.Length; i++)
+                    {
+                        using (var bmpStr = prvFont.DrawPrivateFont(strMenuItem[i], Color.White, Color.Black))
+                        {
+                            txMenuItemLeft[i, 0] = TJAPlayer3.tテクスチャの生成(bmpStr, false);
+                        }
+
+                        using (var bmpStr = prvFont.DrawPrivateFont(strMenuItem[i], Color.White, Color.Black, Color.Yellow, Color.OrangeRed))
+                        {
+                            txMenuItemLeft[i, 1] = TJAPlayer3.tテクスチャの生成(bmpStr, false);
+                        }
+                    }
+                }
+
+                if (bメニューにフォーカス中)
+                {
+                    t説明文パネルに現在選択されているメニューの説明を描画する();
+                }
+                else
+                {
+                    t説明文パネルに現在選択されている項目の説明を描画する();
+                }
+
+                base.OnManagedリソースの作成();
+            }
+        }
+
 		public override void OnManagedリソースの解放()											// OPTIONと同じ(COnfig.iniの書き出しタイミングのみ異なるが、無視して良い)
 		{
 			if( !base.b活性化してない )

--- a/TJAPlayer3/Stages/04.Config/CStageコンフィグ.cs
+++ b/TJAPlayer3/Stages/04.Config/CStageコンフィグ.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Drawing;
 using System.Diagnostics;
 using FDK;
+using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
@@ -63,7 +64,7 @@ namespace TJAPlayer3
                 }
                 else
                 {
-                    this.ftフォント = new Font("MS UI Gothic", 18.0f, FontStyle.Bold, GraphicsUnit.Pixel);
+                    this.ftフォント = new Font(FontUtilities.FallbackFontName, 18.0f, FontStyle.Bold, GraphicsUnit.Pixel);
                 }
 				for( int i = 0; i < 4; i++ )													//
 				{																				//

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using CSharpTest.Net.Collections;
 using SlimDX;
 using FDK;
+using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
@@ -519,18 +520,12 @@ namespace TJAPlayer3
             // enter or return to the song select screen.
             TJAPlayer3.IsPerformingCalibration = false;
 
-            if (!string.IsNullOrEmpty(TJAPlayer3.ConfigIni.FontName))
-            {
-                this.pfMusicName = new CPrivateFastFont(new FontFamily(TJAPlayer3.ConfigIni.FontName), 28);
-                this.pfSubtitle = new CPrivateFastFont(new FontFamily(TJAPlayer3.ConfigIni.FontName), 20);
-            }
-            else
-            {
-                this.pfMusicName = new CPrivateFastFont(new FontFamily("MS UI Gothic"), 28);
-                this.pfSubtitle = new CPrivateFastFont(new FontFamily("MS UI Gothic"), 20);
-            }
+            var fontFamily = FontUtilities.GetFontFamilyOrFallback(TJAPlayer3.ConfigIni.FontName);
 
-		    _titleTextures.ItemRemoved += OnTitleTexturesOnItemRemoved;
+            this.pfMusicName = new CPrivateFastFont(fontFamily, 28);
+            this.pfSubtitle = new CPrivateFastFont(fontFamily, 20);
+
+            _titleTextures.ItemRemoved += OnTitleTexturesOnItemRemoved;
 		    _titleTextures.ItemUpdated += OnTitleTexturesOnItemUpdated;
 
             this.e楽器パート = E楽器パート.DRUMS;
@@ -543,7 +538,7 @@ namespace TJAPlayer3
 			// 曲リスト文字は２倍（面積４倍）でテクスチャに描画してから縮小表示するので、フォントサイズは２倍とする。
 
 			FontStyle regular = FontStyle.Regular;
-			this.ft曲リスト用フォント = new Font( TJAPlayer3.ConfigIni.FontName, 40f, regular, GraphicsUnit.Pixel );
+			this.ft曲リスト用フォント = new Font( fontFamily, 40f, regular, GraphicsUnit.Pixel );
 			
 
 			// 現在選択中の曲がない（＝はじめての活性化）なら、現在選択中の曲をルートの先頭ノードに設定する。
@@ -564,7 +559,8 @@ namespace TJAPlayer3
 
 			this.t選択曲が変更された(true);		// #27648 2012.3.31 yyagi 選曲画面に入った直後の 現在位置/全アイテム数 の表示を正しく行うため
 		}
-		public override void On非活性化()
+
+        public override void On非活性化()
 		{
 			if( this.b活性化してない )
 				return;

--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using System.Drawing;
 using System.Diagnostics;
 using FDK;
-using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
@@ -148,7 +147,6 @@ namespace TJAPlayer3
 			{
                 this.eフェードアウト完了時の戻り値 = E戻り値.継続;
 				this.bBGM再生済み = false;
-				this.ftフォント = new Font(FontUtilities.FallbackFontName, 26f, GraphicsUnit.Pixel );
 				for( int i = 0; i < 4; i++ )
 					this.ctキー反復用[ i ] = new CCounter( 0, 0, 0, TJAPlayer3.Timer );
 
@@ -173,11 +171,6 @@ namespace TJAPlayer3
 			Trace.Indent();
 			try
 			{
-				if( this.ftフォント != null )
-				{
-					this.ftフォント.Dispose();
-					this.ftフォント = null;
-				}
 				for( int i = 0; i < 4; i++ )
 				{
 					this.ctキー反復用[ i ] = null;
@@ -772,7 +765,6 @@ namespace TJAPlayer3
 		public CCounter ct登場時アニメ用共通;
 		private CCounter ct背景スクロール用タイマー;
 		private E戻り値 eフェードアウト完了時の戻り値;
-		private Font ftフォント;
 		//private CTexture tx下部パネル;
 		//private CTexture tx上部パネル;
 		//private CTexture tx背景;

--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Drawing;
 using System.Diagnostics;
 using FDK;
+using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
@@ -147,7 +148,7 @@ namespace TJAPlayer3
 			{
                 this.eフェードアウト完了時の戻り値 = E戻り値.継続;
 				this.bBGM再生済み = false;
-				this.ftフォント = new Font("MS UI Gothic", 26f, GraphicsUnit.Pixel );
+				this.ftフォント = new Font(FontUtilities.FallbackFontName, 26f, GraphicsUnit.Pixel );
 				for( int i = 0; i < 4; i++ )
 					this.ctキー反復用[ i ] = new CCounter( 0, 0, 0, TJAPlayer3.Timer );
 

--- a/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
+++ b/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
@@ -33,16 +33,11 @@ namespace TJAPlayer3
 			{
 				this.str曲タイトル = "";
 				this.strSTAGEFILE = "";
-                if( !string.IsNullOrEmpty( TJAPlayer3.ConfigIni.FontName ) )
-                {
-                    this.pfTITLE = new CPrivateFastFont( new FontFamily( TJAPlayer3.ConfigIni.FontName ), TJAPlayer3.Skin.SongLoading_Title_FontSize );
-                    this.pfSUBTITLE = new CPrivateFastFont( new FontFamily( TJAPlayer3.ConfigIni.FontName ), TJAPlayer3.Skin.SongLoading_SubTitle_FontSize);
-                }
-                else
-                {
-                    this.pfTITLE = new CPrivateFastFont( new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.SongLoading_Title_FontSize);
-                    this.pfSUBTITLE = new CPrivateFastFont( new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.SongLoading_SubTitle_FontSize);
-                }
+
+                var fontFamily = FontUtilities.GetFontFamilyOrFallback(TJAPlayer3.ConfigIni.FontName);
+                this.pfTITLE = new CPrivateFastFont(fontFamily, TJAPlayer3.Skin.SongLoading_Title_FontSize);
+                this.pfSUBTITLE = new CPrivateFastFont(fontFamily, TJAPlayer3.Skin.SongLoading_SubTitle_FontSize);
+
 				this.nBGM再生開始時刻 = -1;
 				this.nBGMの総再生時間ms = 0;
 				if( this.sd読み込み音 != null )
@@ -340,48 +335,36 @@ namespace TJAPlayer3
                             // 段位認定モード用。
                             if (TJAPlayer3.stage選曲.n確定された曲の難易度 == (int)Difficulty.Dan && TJAPlayer3.DTX.List_DanSongs != null)
                             {
-                                CPrivateFont pfTitle;
-                                CPrivateFont pfSubTitle;
-                                if (!string.IsNullOrEmpty(TJAPlayer3.ConfigIni.FontName))
+                                var fontFamily = FontUtilities.GetFontFamilyOrFallback(TJAPlayer3.ConfigIni.FontName);
+                                using (var pfTitle = new CPrivateFont(fontFamily, 30))
+                                using (var pfSubTitle = new CPrivateFont(fontFamily, 22))
                                 {
-                                    pfTitle = new CPrivateFont(new FontFamily(TJAPlayer3.ConfigIni.FontName), 30);
-                                    pfSubTitle = new CPrivateFont(new FontFamily(TJAPlayer3.ConfigIni.FontName), 22);
-                                }
-                                else
-                                {
-                                    pfTitle = new CPrivateFont(new FontFamily(FontUtilities.FallbackFontName), 30);
-                                    pfSubTitle = new CPrivateFont(new FontFamily(FontUtilities.FallbackFontName), 22);
-                                }
+                                    var titleForeColor = TJAPlayer3.Skin.Game_DanC_Title_ForeColor;
+                                    var titleBackColor = TJAPlayer3.Skin.Game_DanC_Title_BackColor;
+                                    var subtitleForeColor = TJAPlayer3.Skin.Game_DanC_SubTitle_ForeColor;
+                                    var subtitleBackColor = TJAPlayer3.Skin.Game_DanC_SubTitle_BackColor;
 
-                                var titleForeColor = TJAPlayer3.Skin.Game_DanC_Title_ForeColor;
-                                var titleBackColor = TJAPlayer3.Skin.Game_DanC_Title_BackColor;
-                                var subtitleForeColor = TJAPlayer3.Skin.Game_DanC_SubTitle_ForeColor;
-                                var subtitleBackColor = TJAPlayer3.Skin.Game_DanC_SubTitle_BackColor;
-
-                                for (int i = 0; i < TJAPlayer3.DTX.List_DanSongs.Count; i++)
-                                {
-                                    if (!string.IsNullOrEmpty(TJAPlayer3.DTX.List_DanSongs[i].Title))
+                                    foreach (var danSong in TJAPlayer3.DTX.List_DanSongs)
                                     {
-                                        using (var bmpSongTitle = pfTitle.DrawPrivateFont(TJAPlayer3.DTX.List_DanSongs[i].Title, titleForeColor, titleBackColor))
+                                        if (!string.IsNullOrEmpty(danSong.Title))
                                         {
-                                            TJAPlayer3.DTX.List_DanSongs[i].TitleTex = TJAPlayer3.tテクスチャの生成(bmpSongTitle, false);
-                                            TJAPlayer3.DTX.List_DanSongs[i].TitleTex.vc拡大縮小倍率.X = TJAPlayer3.GetSongNameXScaling(ref TJAPlayer3.DTX.List_DanSongs[i].TitleTex, 710);
+                                            using (var bmpSongTitle = pfTitle.DrawPrivateFont(danSong.Title, titleForeColor, titleBackColor))
+                                            {
+                                                danSong.TitleTex = TJAPlayer3.tテクスチャの生成(bmpSongTitle, false);
+                                                danSong.TitleTex.vc拡大縮小倍率.X = TJAPlayer3.GetSongNameXScaling(ref danSong.TitleTex, 710);
+                                            }
+                                        }
+
+                                        if (!string.IsNullOrEmpty(danSong.SubTitle))
+                                        {
+                                            using (var bmpSongSubTitle = pfSubTitle.DrawPrivateFont(danSong.SubTitle, subtitleForeColor, subtitleBackColor))
+                                            {
+                                                danSong.SubTitleTex = TJAPlayer3.tテクスチャの生成(bmpSongSubTitle, false);
+                                                danSong.SubTitleTex.vc拡大縮小倍率.X = TJAPlayer3.GetSongNameXScaling(ref danSong.SubTitleTex, 710);
+                                            }
                                         }
                                     }
-
-                                    if (!string.IsNullOrEmpty(TJAPlayer3.DTX.List_DanSongs[i].SubTitle))
-                                    {
-                                        using (var bmpSongSubTitle = pfSubTitle.DrawPrivateFont(TJAPlayer3.DTX.List_DanSongs[i].SubTitle, subtitleForeColor, subtitleBackColor))
-                                        {
-                                            TJAPlayer3.DTX.List_DanSongs[i].SubTitleTex = TJAPlayer3.tテクスチャの生成(bmpSongSubTitle, false);
-                                            TJAPlayer3.DTX.List_DanSongs[i].SubTitleTex.vc拡大縮小倍率.X = TJAPlayer3.GetSongNameXScaling(ref TJAPlayer3.DTX.List_DanSongs[i].SubTitleTex, 710);
-                                        }
-                                    }
-
                                 }
-
-                                pfTitle?.Dispose();
-                                pfSubTitle?.Dispose();
                             }
                         }
 

--- a/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
+++ b/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
@@ -5,6 +5,7 @@ using System.IO;
 using SlimDX;
 using System.Drawing.Text;
 using FDK;
+using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
@@ -39,8 +40,8 @@ namespace TJAPlayer3
                 }
                 else
                 {
-                    this.pfTITLE = new CPrivateFastFont( new FontFamily("MS UI Gothic"), TJAPlayer3.Skin.SongLoading_Title_FontSize);
-                    this.pfSUBTITLE = new CPrivateFastFont( new FontFamily("MS UI Gothic" ), TJAPlayer3.Skin.SongLoading_SubTitle_FontSize);
+                    this.pfTITLE = new CPrivateFastFont( new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.SongLoading_Title_FontSize);
+                    this.pfSUBTITLE = new CPrivateFastFont( new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.SongLoading_SubTitle_FontSize);
                 }
 				this.nBGM再生開始時刻 = -1;
 				this.nBGMの総再生時間ms = 0;
@@ -211,7 +212,7 @@ namespace TJAPlayer3
 				bitmapFilename = new Bitmap( 640, 24 );
 				graphicsFilename = Graphics.FromImage( bitmapFilename );
 				graphicsFilename.TextRenderingHint = TextRenderingHint.AntiAlias;
-				ftFilename = new Font("MS UI Gothic", 24f, FontStyle.Bold, GraphicsUnit.Pixel );
+				ftFilename = new Font(FontUtilities.FallbackFontName, 24f, FontStyle.Bold, GraphicsUnit.Pixel );
 			}
 			//-----------------------------
 			#endregion
@@ -348,8 +349,8 @@ namespace TJAPlayer3
                                 }
                                 else
                                 {
-                                    pfTitle = new CPrivateFont(new FontFamily("MS UI Gothic"), 30);
-                                    pfSubTitle = new CPrivateFont(new FontFamily("MS UI Gothic"), 22);
+                                    pfTitle = new CPrivateFont(new FontFamily(FontUtilities.FallbackFontName), 30);
+                                    pfSubTitle = new CPrivateFont(new FontFamily(FontUtilities.FallbackFontName), 22);
                                 }
 
                                 var titleForeColor = TJAPlayer3.Skin.Game_DanC_Title_ForeColor;

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.Diagnostics;
 using FDK;
+using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
@@ -143,7 +144,7 @@ namespace TJAPlayer3
                 //this.pf縦書きテスト = new CPrivateFastFont( new FontFamily( CDTXMania.ConfigIni.strPrivateFontで使うフォント名 ), 22 );
             }
             else
-                this.pfMusicName = new CPrivateFastFont( new FontFamily("MS UI Gothic"), TJAPlayer3.Skin.Game_MusicName_FontSize);
+                this.pfMusicName = new CPrivateFastFont( new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.Game_MusicName_FontSize);
 
             if( !string.IsNullOrEmpty(TJAPlayer3.Skin.Game_Lyric_FontName))
             {
@@ -151,7 +152,7 @@ namespace TJAPlayer3
             }
             else
             {
-                this.pf歌詞フォント = new CPrivateFastFont(new FontFamily("MS UI Gothic"), TJAPlayer3.Skin.Game_Lyric_FontSize);
+                this.pf歌詞フォント = new CPrivateFastFont(new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.Game_Lyric_FontSize);
             }
 
 			this.txPanel = null;

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -138,22 +138,8 @@ namespace TJAPlayer3
 
 		public override void On活性化()
 		{
-            if( !string.IsNullOrEmpty( TJAPlayer3.ConfigIni.FontName ) )
-            {
-                this.pfMusicName = new CPrivateFastFont( new FontFamily( TJAPlayer3.ConfigIni.FontName), TJAPlayer3.Skin.Game_MusicName_FontSize);
-                //this.pf縦書きテスト = new CPrivateFastFont( new FontFamily( CDTXMania.ConfigIni.strPrivateFontで使うフォント名 ), 22 );
-            }
-            else
-                this.pfMusicName = new CPrivateFastFont( new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.Game_MusicName_FontSize);
-
-            if( !string.IsNullOrEmpty(TJAPlayer3.Skin.Game_Lyric_FontName))
-            {
-                this.pf歌詞フォント = new CPrivateFastFont(new FontFamily(TJAPlayer3.Skin.Game_Lyric_FontName), TJAPlayer3.Skin.Game_Lyric_FontSize);
-            }
-            else
-            {
-                this.pf歌詞フォント = new CPrivateFastFont(new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.Game_Lyric_FontSize);
-            }
+            this.pfMusicName = new CPrivateFastFont(FontUtilities.GetFontFamilyOrFallback(TJAPlayer3.ConfigIni.FontName), TJAPlayer3.Skin.Game_MusicName_FontSize);
+            this.pf歌詞フォント = new CPrivateFastFont(FontUtilities.GetFontFamilyOrFallback(TJAPlayer3.Skin.Game_Lyric_FontName), TJAPlayer3.Skin.Game_Lyric_FontSize);
 
 			this.txPanel = null;
 			this.ct進行用 = new CCounter();

--- a/TJAPlayer3/Stages/08.Result/CActResultSongBar.cs
+++ b/TJAPlayer3/Stages/08.Result/CActResultSongBar.cs
@@ -1,5 +1,4 @@
-﻿using System.Drawing;
-using FDK;
+﻿using FDK;
 using TJAPlayer3.Common;
 
 namespace TJAPlayer3
@@ -24,42 +23,34 @@ namespace TJAPlayer3
 
 		// CActivity 実装
 
-		public override void On活性化()
-		{
-            if( !string.IsNullOrEmpty( TJAPlayer3.ConfigIni.FontName) )
+        public override void On活性化()
+        {
+            var fontFamily = FontUtilities.GetFontFamilyOrFallback(TJAPlayer3.ConfigIni.FontName);
+
+            // After performing calibration, inform the player that
+            // calibration has been completed, rather than
+            // displaying the song title as usual.
+			var title = TJAPlayer3.IsPerformingCalibration
+                ? $"Calibration complete. InputAdjustTime is now {TJAPlayer3.ConfigIni.nInputAdjustTimeMs}ms"
+                : TJAPlayer3.DTX.TITLE;
+
+            using (var pfMusicName = new CPrivateFastFont(fontFamily, TJAPlayer3.Skin.Result_MusicName_FontSize))
+            using (var bmpSongTitle = pfMusicName.DrawPrivateFont(title, TJAPlayer3.Skin.Result_MusicName_ForeColor, TJAPlayer3.Skin.Result_MusicName_BackColor))
+
             {
-                this.pfMusicName = new CPrivateFastFont(new FontFamily(TJAPlayer3.ConfigIni.FontName), TJAPlayer3.Skin.Result_MusicName_FontSize);
-                this.pfStageText = new CPrivateFastFont(new FontFamily(TJAPlayer3.ConfigIni.FontName), TJAPlayer3.Skin.Result_StageText_FontSize);
+                txMusicName = TJAPlayer3.tテクスチャの生成(bmpSongTitle, false);
+                txMusicName.vc拡大縮小倍率.X = TJAPlayer3.GetSongNameXScaling(ref txMusicName);
             }
-            else
+
+            using (var pfStageText = new CPrivateFastFont(fontFamily, TJAPlayer3.Skin.Result_StageText_FontSize))
+            using (var bmpStageText = pfStageText.DrawPrivateFont(TJAPlayer3.Skin.Game_StageText, TJAPlayer3.Skin.Result_StageText_ForeColor, TJAPlayer3.Skin.Result_StageText_BackColor))
             {
-                this.pfMusicName = new CPrivateFastFont(new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.Result_MusicName_FontSize);
-                this.pfStageText = new CPrivateFastFont(new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.Result_StageText_FontSize);
+                txStageText = TJAPlayer3.tテクスチャの生成(bmpStageText, false);
             }
 
-		    // After performing calibration, inform the player that
-		    // calibration has been completed, rather than
-		    // displaying the song title as usual.
+            base.On活性化();
+        }
 
-
-		    var title = TJAPlayer3.IsPerformingCalibration
-		        ? $"Calibration complete. InputAdjustTime is now {TJAPlayer3.ConfigIni.nInputAdjustTimeMs}ms"
-		        : TJAPlayer3.DTX.TITLE;
-
-		    using (var bmpSongTitle = pfMusicName.DrawPrivateFont(title, TJAPlayer3.Skin.Result_MusicName_ForeColor, TJAPlayer3.Skin.Result_MusicName_BackColor))
-
-		    {
-		        this.txMusicName = TJAPlayer3.tテクスチャの生成(bmpSongTitle, false);
-		        txMusicName.vc拡大縮小倍率.X = TJAPlayer3.GetSongNameXScaling(ref txMusicName);
-		    }
-
-		    using (var bmpStageText = pfStageText.DrawPrivateFont(TJAPlayer3.Skin.Game_StageText, TJAPlayer3.Skin.Result_StageText_ForeColor, TJAPlayer3.Skin.Result_StageText_BackColor))
-		    {
-		        this.txStageText = TJAPlayer3.tテクスチャの生成(bmpStageText, false);
-		    }
-
-			base.On活性化();
-		}
 		public override void On非活性化()
 		{
 			if( this.ct登場用 != null )
@@ -79,10 +70,7 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-                TJAPlayer3.t安全にDisposeする(ref this.pfMusicName);
                 TJAPlayer3.tテクスチャの解放( ref this.txMusicName );
-
-                TJAPlayer3.t安全にDisposeする(ref this.pfStageText);
                 TJAPlayer3.tテクスチャの解放(ref this.txStageText);
                 base.OnManagedリソースの解放();
 			}
@@ -145,10 +133,7 @@ namespace TJAPlayer3
 		private CCounter ct登場用;
 
         private CTexture txMusicName;
-        private CPrivateFastFont pfMusicName;
-
         private CTexture txStageText;
-        private CPrivateFont pfStageText;
         //-----------------
 		#endregion
 	}

--- a/TJAPlayer3/Stages/08.Result/CActResultSongBar.cs
+++ b/TJAPlayer3/Stages/08.Result/CActResultSongBar.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Drawing;
-using System.Diagnostics;
-using SlimDX;
+﻿using System.Drawing;
 using FDK;
+using TJAPlayer3.Common;
 
 namespace TJAPlayer3
 {
@@ -37,8 +33,8 @@ namespace TJAPlayer3
             }
             else
             {
-                this.pfMusicName = new CPrivateFastFont(new FontFamily("MS UI Gothic"), TJAPlayer3.Skin.Result_MusicName_FontSize);
-                this.pfStageText = new CPrivateFastFont(new FontFamily("MS UI Gothic"), TJAPlayer3.Skin.Result_StageText_FontSize);
+                this.pfMusicName = new CPrivateFastFont(new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.Result_MusicName_FontSize);
+                this.pfStageText = new CPrivateFastFont(new FontFamily(FontUtilities.FallbackFontName), TJAPlayer3.Skin.Result_StageText_FontSize);
             }
 
 		    // After performing calibration, inform the player that

--- a/TJAPlayer3/TJAPlayer3.csproj
+++ b/TJAPlayer3/TJAPlayer3.csproj
@@ -132,6 +132,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\FontUtilities.cs" />
     <Compile Include="Common\PreciseStringMeasurement\CPreciseStringMeasurer.cs" />
     <Compile Include="Animations\Animator.cs" />
     <Compile Include="Animations\FadeOut.cs" />


### PR DESCRIPTION
Some stages were fine with the configured font not being installed and loadable, and would fall back on `MS UI Gothic` but parts of the song selection stage could not handle that. This has now been addressed and a bunch of font fallback handling code de-duplicated while near this kind of code.