### PR TITLE
Add anonymized skin name to Sentry error reports.

### DIFF
--- a/TJAPlayer3.Tests/ErrorReporting/ErrorReporterTests.cs
+++ b/TJAPlayer3.Tests/ErrorReporting/ErrorReporterTests.cs
@@ -7,6 +7,12 @@ namespace TJAPlayer3.Tests.ErrorReporting
     public sealed class ErrorReporterTests
     {
         [Test]
+        [TestCase(ErrorReporter.GetCurrentSkinNameOrNullFallbackForNullSkin, "dX+hmseHos63UjL7n6bocIEgSZxo+qZ1szIFljYJf0k=")]
+        [TestCase(ErrorReporter.GetCurrentSkinNameOrNullFallbackForExceptionEncountered, "RJ1TZ22uELG4WVEWkfitV2PGE6xjdzoY4zXYqQvS/UY=")]
+        [TestCase("", "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")]
+        [TestCase(" ", "Nqnn8clbgv+5l0PgxcTOldg8mkMKrFn4TvPL+rYUUGg=")]
+        [TestCase("Default", "IbERy/5uj8otGBxD9TrVSLIuOKypVbmCRwalBLCgei0=")]
+        [TestCase("SimpleStyle", "U6QVPvJpFuDf1y6cxYbW9D+LvrG7PYLVFwDRY4xdLeM=")]
         [TestCase("This is only a test", "pPi+NdUkNVp81f+/9Vi7dvgVdtr6f6WpdqqjVD8ptCo=")]
         public void TestToSha256InBase64(string input, string expected)
         {

--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -452,6 +452,11 @@ namespace TJAPlayer3
         private static string strSystemSkinSubfolderFullName;           // Config画面で設定されたスキン
         private static string strBoxDefSkinSubfolderFullName = "";      // box.defで指定されているスキン
 
+        public string GetCurrentSkinName(bool fromUserConfig = false)
+        {
+            return GetSkinName(TJAPlayer3.Skin.GetCurrentSkinSubfolderFullName(fromUserConfig));
+        }
+
         /// <summary>
         /// スキンパス名をフルパスで取得する
         /// </summary>


### PR DESCRIPTION
It is suspected that a great many exceptions occur during creation,
modification, or general use of custom skins. While arbitrary anonymized
skin names cannot be de-anonymized, we can at least determine the
anonymized values for SimpleStyle and other well-known skins. And, while
the name alone cannot tell us if the user has modified the skin, there
is a great deal more likelihood of an actual application issue if we can
tell the user is at least running SimpleStyle, under the assumption
they've not modified it. If this new Sentry tagging still leaves too
much ambiguity in error reports, especially those associated with
SimpleStyle, we can add further detail (e.g. a hash of skin file
content.)