### PR TITLE
Fix a pile of crash-inducing texture mismanagement

### DIFF
--- a/TJAPlayer3/Common/TJAPlayer3.cs
+++ b/TJAPlayer3/Common/TJAPlayer3.cs
@@ -1357,15 +1357,17 @@ for (int i = 0; i < 3; i++) {
         /// <summary>プロパティ、インデクサには ref は使用できないので注意。</summary>
         public static void t安全にDisposeする<T>(ref T obj)
         {
-            if (obj == null)
+            if (EqualityComparer<T>.Default.Equals(obj, default))
+            {
                 return;
+            }
 
-            var d = obj as IDisposable;
-
-            if (d != null)
+            if (obj is IDisposable d)
+            {
                 d.Dispose();
+            }
 
-            obj = default(T);
+            obj = default;
         }
 
         /// <summary>

--- a/TJAPlayer3/Common/TJAPlayer3.cs
+++ b/TJAPlayer3/Common/TJAPlayer3.cs
@@ -1366,6 +1366,20 @@ for (int i = 0; i < 3; i++) {
             obj = null;
         }
 
+        public static void t安全にDisposeする<T>(T[] array) where T : class, IDisposable
+        {
+            if (array == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < array.Length; i++)
+            {
+                array[i]?.Dispose();
+                array[i] = null;
+            }
+        }
+
         /// <summary>
         /// そのフォルダの連番画像の最大値を返す。
         /// </summary>

--- a/TJAPlayer3/Common/TJAPlayer3.cs
+++ b/TJAPlayer3/Common/TJAPlayer3.cs
@@ -1298,10 +1298,7 @@ for (int i = 0; i < 3; i++) {
 				return null;
 			}
 		}
-		public static void tテクスチャの解放(ref CTexture tx )
-		{
-			TJAPlayer3.t安全にDisposeする( ref tx );
-		}
+
 		public static CTexture tテクスチャの生成( Bitmap bitmap )
 		{
 			return tテクスチャの生成( bitmap, false );

--- a/TJAPlayer3/Common/TJAPlayer3.cs
+++ b/TJAPlayer3/Common/TJAPlayer3.cs
@@ -1355,19 +1355,15 @@ for (int i = 0; i < 3; i++) {
 		}
 
         /// <summary>プロパティ、インデクサには ref は使用できないので注意。</summary>
-        public static void t安全にDisposeする<T>(ref T obj)
+        public static void t安全にDisposeする<T>(ref T obj) where T : class, IDisposable
         {
-            if (EqualityComparer<T>.Default.Equals(obj, default))
+            if (obj == null)
             {
                 return;
             }
 
-            if (obj is IDisposable d)
-            {
-                d.Dispose();
-            }
-
-            obj = default;
+            obj.Dispose();
+            obj = null;
         }
 
         /// <summary>

--- a/TJAPlayer3/Stages/01.StartUp/CStage起動.cs
+++ b/TJAPlayer3/Stages/01.StartUp/CStage起動.cs
@@ -71,7 +71,7 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-				TJAPlayer3.tテクスチャの解放( ref this.tx背景 );
+				TJAPlayer3.t安全にDisposeする(ref this.tx背景);
 				base.OnManagedリソースの解放();
 			}
 		}

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -693,15 +693,15 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Runner);
             #endregion
             #region DanC
-            DanC_Background?.Dispose();
+            TJAPlayer3.t安全にDisposeする(ref DanC_Background);
             TJAPlayer3.t安全にDisposeする(DanC_Gauge);
-            DanC_Base?.Dispose();
-            DanC_Failed?.Dispose();
-            DanC_Number?.Dispose();
-            DanC_ExamRange?.Dispose(); // TODO DanC texture management is likely bugged, as its assignment and disposal are conditional but its usage is not.
-            DanC_ExamUnit?.Dispose();
-            DanC_ExamType?.Dispose();
-            DanC_Screen?.Dispose();
+            TJAPlayer3.t安全にDisposeする(ref DanC_Base);
+            TJAPlayer3.t安全にDisposeする(ref DanC_Failed);
+            TJAPlayer3.t安全にDisposeする(ref DanC_Number);
+            TJAPlayer3.t安全にDisposeする(ref DanC_ExamRange);
+            TJAPlayer3.t安全にDisposeする(ref DanC_ExamUnit);
+            TJAPlayer3.t安全にDisposeする(ref DanC_ExamType);
+            TJAPlayer3.t安全にDisposeする(ref DanC_Screen);
             #endregion
             #region PuchiChara
             TJAPlayer3.t安全にDisposeする(ref PuchiChara);

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -538,10 +538,7 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Enum_Song);
             TJAPlayer3.t安全にDisposeする(ref Scanning_Loudness);
             TJAPlayer3.t安全にDisposeする(ref Overlay);
-            for (int i = 0; i < 2; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref NamePlate[i]);
-            }
+            TJAPlayer3.t安全にDisposeする(NamePlate);
 
             #endregion
             #region 1_タイトル画面

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -528,146 +528,146 @@ namespace TJAPlayer3
 
         public void DisposeTexture()
         {
-            TJAPlayer3.tテクスチャの解放(ref Title_Background);
-            TJAPlayer3.tテクスチャの解放(ref Title_Menu);
+            TJAPlayer3.t安全にDisposeする(ref Title_Background);
+            TJAPlayer3.t安全にDisposeする(ref Title_Menu);
             #region 共通
-            TJAPlayer3.tテクスチャの解放(ref Tile_Black);
-            TJAPlayer3.tテクスチャの解放(ref Tile_White);
-            TJAPlayer3.tテクスチャの解放(ref Menu_Title);
-            TJAPlayer3.tテクスチャの解放(ref Menu_Highlight);
-            TJAPlayer3.tテクスチャの解放(ref Enum_Song);
-            TJAPlayer3.tテクスチャの解放(ref Scanning_Loudness);
-            TJAPlayer3.tテクスチャの解放(ref Overlay);
+            TJAPlayer3.t安全にDisposeする(ref Tile_Black);
+            TJAPlayer3.t安全にDisposeする(ref Tile_White);
+            TJAPlayer3.t安全にDisposeする(ref Menu_Title);
+            TJAPlayer3.t安全にDisposeする(ref Menu_Highlight);
+            TJAPlayer3.t安全にDisposeする(ref Enum_Song);
+            TJAPlayer3.t安全にDisposeする(ref Scanning_Loudness);
+            TJAPlayer3.t安全にDisposeする(ref Overlay);
             for (int i = 0; i < 2; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref NamePlate[i]);
+                TJAPlayer3.t安全にDisposeする(ref NamePlate[i]);
             }
 
             #endregion
             #region 1_タイトル画面
-            TJAPlayer3.tテクスチャの解放(ref Title_Background);
-            TJAPlayer3.tテクスチャの解放(ref Title_Menu);
+            TJAPlayer3.t安全にDisposeする(ref Title_Background);
+            TJAPlayer3.t安全にDisposeする(ref Title_Menu);
             #endregion
 
             #region 2_コンフィグ画面
-            TJAPlayer3.tテクスチャの解放(ref Config_Background);
-            TJAPlayer3.tテクスチャの解放(ref Config_Cursor);
-            TJAPlayer3.tテクスチャの解放(ref Config_ItemBox);
-            TJAPlayer3.tテクスチャの解放(ref Config_Arrow);
-            TJAPlayer3.tテクスチャの解放(ref Config_KeyAssign);
-            TJAPlayer3.tテクスチャの解放(ref Config_Font);
-            TJAPlayer3.tテクスチャの解放(ref Config_Font_Bold);
-            TJAPlayer3.tテクスチャの解放(ref Config_Enum_Song);
+            TJAPlayer3.t安全にDisposeする(ref Config_Background);
+            TJAPlayer3.t安全にDisposeする(ref Config_Cursor);
+            TJAPlayer3.t安全にDisposeする(ref Config_ItemBox);
+            TJAPlayer3.t安全にDisposeする(ref Config_Arrow);
+            TJAPlayer3.t安全にDisposeする(ref Config_KeyAssign);
+            TJAPlayer3.t安全にDisposeする(ref Config_Font);
+            TJAPlayer3.t安全にDisposeする(ref Config_Font_Bold);
+            TJAPlayer3.t安全にDisposeする(ref Config_Enum_Song);
             #endregion
 
             #region 3_選曲画面
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Background);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Header);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Footer);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Difficulty);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Auto);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Level);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Branch);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Branch_Text);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Bar_Center);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Frame_Score);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Frame_BackBox);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Frame_Random);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Score_Select);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_GenreText);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Cursor_Left);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Cursor_Right);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Background);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Header);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Footer);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Difficulty);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Auto);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Level);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Branch);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Branch_Text);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Bar_Center);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Frame_Score);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Frame_BackBox);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Frame_Random);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Score_Select);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_GenreText);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Cursor_Left);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Cursor_Right);
             for (int i = 0; i < SongSelect_Bar_Genre.Length; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref SongSelect_Bar_Genre[i]);
+                TJAPlayer3.t安全にDisposeする(ref SongSelect_Bar_Genre[i]);
             }
             for (int i = 0; i < 9; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref SongSelect_Frame_Box[i]);
+                TJAPlayer3.t安全にDisposeする(ref SongSelect_Frame_Box[i]);
             }
             for (int i = 0; i < (int)Difficulty.Total; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref SongSelect_ScoreWindow[i]);
+                TJAPlayer3.t安全にDisposeする(ref SongSelect_ScoreWindow[i]);
             }
 
             for (int i = 0; i < SongSelect_GenreBack.Length; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref SongSelect_GenreBack[i]);
+                TJAPlayer3.t安全にDisposeする(ref SongSelect_GenreBack[i]);
             }
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_ScoreWindow_Text);
-            TJAPlayer3.tテクスチャの解放(ref SongSelect_Rating);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_ScoreWindow_Text);
+            TJAPlayer3.t安全にDisposeする(ref SongSelect_Rating);
             #endregion
 
             #region 4_読み込み画面
-            TJAPlayer3.tテクスチャの解放(ref SongLoading_Plate);
-            TJAPlayer3.tテクスチャの解放(ref SongLoading_FadeIn);
-            TJAPlayer3.tテクスチャの解放(ref SongLoading_FadeOut);
+            TJAPlayer3.t安全にDisposeする(ref SongLoading_Plate);
+            TJAPlayer3.t安全にDisposeする(ref SongLoading_FadeIn);
+            TJAPlayer3.t安全にDisposeする(ref SongLoading_FadeOut);
             #endregion
 
             #region 5_演奏画面
             #region 共通
-            TJAPlayer3.tテクスチャの解放(ref Notes);
-            TJAPlayer3.tテクスチャの解放(ref Judge_Frame);
-            TJAPlayer3.tテクスチャの解放(ref SENotes);
-            TJAPlayer3.tテクスチャの解放(ref Notes_Arm);
-            TJAPlayer3.tテクスチャの解放(ref Judge);
+            TJAPlayer3.t安全にDisposeする(ref Notes);
+            TJAPlayer3.t安全にDisposeする(ref Judge_Frame);
+            TJAPlayer3.t安全にDisposeする(ref SENotes);
+            TJAPlayer3.t安全にDisposeする(ref Notes_Arm);
+            TJAPlayer3.t安全にDisposeする(ref Judge);
 
-            TJAPlayer3.tテクスチャの解放(ref Judge_Meter);
-            TJAPlayer3.tテクスチャの解放(ref Bar);
-            TJAPlayer3.tテクスチャの解放(ref Bar_Branch);
+            TJAPlayer3.t安全にDisposeする(ref Judge_Meter);
+            TJAPlayer3.t安全にDisposeする(ref Bar);
+            TJAPlayer3.t安全にDisposeする(ref Bar_Branch);
 
             #endregion
             #region キャラクター
 
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Normal; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_Normal[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_Normal[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Clear; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_Normal_Cleared[i]);
-                TJAPlayer3.tテクスチャの解放(ref Chara_Normal_Maxed[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_Normal_Cleared[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_Normal_Maxed[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_GoGo; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_GoGoTime[i]);
-                TJAPlayer3.tテクスチャの解放(ref Chara_GoGoTime_Maxed[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_GoGoTime[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_GoGoTime_Maxed[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_10combo; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_10Combo[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_10Combo[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_10Combo_Maxed[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_10Combo_Maxed[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_GoGoStart[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_GoGoStart_Maxed[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart_Maxed[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_Become_Cleared[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_Become_Cleared[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_Become_Maxed[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_Become_Maxed[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_Balloon_Breaking[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Breaking[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_Balloon_Broke[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Broke[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Chara_Balloon_Miss[i]);
+                TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Miss[i]);
             }
             #endregion
             #region 踊り子
@@ -675,150 +675,150 @@ namespace TJAPlayer3
             {
                 for (int p = 0; p < TJAPlayer3.Skin.Game_Dancer_Ptn; p++)
                 {
-                    TJAPlayer3.tテクスチャの解放(ref Dancer[i][p]);
+                    TJAPlayer3.t安全にDisposeする(ref Dancer[i][p]);
                 }
             }
             #endregion
             #region モブ
             for (int i = 0; i < TJAPlayer3.Skin.Game_Mob_Ptn; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Mob[i]);
+                TJAPlayer3.t安全にDisposeする(ref Mob[i]);
             }
             #endregion
             #region フッター
-            TJAPlayer3.tテクスチャの解放(ref Mob_Footer);
+            TJAPlayer3.t安全にDisposeする(ref Mob_Footer);
             #endregion
             #region 背景
-            TJAPlayer3.tテクスチャの解放(ref Background);
-            TJAPlayer3.tテクスチャの解放(ref Background_Up[0]);
-            TJAPlayer3.tテクスチャの解放(ref Background_Up[1]);
-            TJAPlayer3.tテクスチャの解放(ref Background_Up_Clear[0]);
-            TJAPlayer3.tテクスチャの解放(ref Background_Up_Clear[1]);
-            TJAPlayer3.tテクスチャの解放(ref Background_Down);
-            TJAPlayer3.tテクスチャの解放(ref Background_Down_Clear);
-            TJAPlayer3.tテクスチャの解放(ref Background_Down_Scroll);
+            TJAPlayer3.t安全にDisposeする(ref Background);
+            TJAPlayer3.t安全にDisposeする(ref Background_Up[0]);
+            TJAPlayer3.t安全にDisposeする(ref Background_Up[1]);
+            TJAPlayer3.t安全にDisposeする(ref Background_Up_Clear[0]);
+            TJAPlayer3.t安全にDisposeする(ref Background_Up_Clear[1]);
+            TJAPlayer3.t安全にDisposeする(ref Background_Down);
+            TJAPlayer3.t安全にDisposeする(ref Background_Down_Clear);
+            TJAPlayer3.t安全にDisposeする(ref Background_Down_Scroll);
 
             #endregion
             #region 太鼓
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Background[0]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Background[1]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Frame[0]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Frame[1]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_PlayerNumber[0]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_PlayerNumber[1]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_NamePlate[0]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_NamePlate[1]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Base);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Don_Left);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Don_Right);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Ka_Left);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Ka_Right);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_LevelUp);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_LevelDown);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Background[0]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Background[1]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Frame[0]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Frame[1]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_PlayerNumber[0]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_PlayerNumber[1]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_NamePlate[0]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_NamePlate[1]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Base);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Don_Left);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Don_Right);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Ka_Left);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Ka_Right);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_LevelUp);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_LevelDown);
             for (int i = 0; i < 6; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Couse_Symbol[i]);
+                TJAPlayer3.t安全にDisposeする(ref Couse_Symbol[i]);
             }
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Score[0]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Score[1]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Score[2]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Combo[0]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Combo[1]);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Combo_Effect);
-            TJAPlayer3.tテクスチャの解放(ref Taiko_Combo_Text);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Score[0]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Score[1]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Score[2]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Combo[0]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Combo[1]);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Combo_Effect);
+            TJAPlayer3.t安全にDisposeする(ref Taiko_Combo_Text);
             #endregion
             #region ゲージ
-            TJAPlayer3.tテクスチャの解放(ref Gauge[0]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge[1]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Hard[0]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Hard[1]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Base[0]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Base[1]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Base_Hard[0]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Base_Hard[1]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Base_ExHard[0]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Base_ExHard[1]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Line[0]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Line[1]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Line_Hard[0]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Line_Hard[1]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge[0]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge[1]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Hard[0]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Hard[1]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Base[0]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Base[1]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Base_Hard[0]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Base_Hard[1]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Base_ExHard[0]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Base_ExHard[1]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Line[0]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Line[1]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Line_Hard[0]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Line_Hard[1]);
             for (int i = 0; i < TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Gauge_Rainbow[i]);
+                TJAPlayer3.t安全にDisposeする(ref Gauge_Rainbow[i]);
             }
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Soul);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Soul_Fire);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Soul_Explosion[0]);
-            TJAPlayer3.tテクスチャの解放(ref Gauge_Soul_Explosion[1]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Soul);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Soul_Fire);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Soul_Explosion[0]);
+            TJAPlayer3.t安全にDisposeする(ref Gauge_Soul_Explosion[1]);
             #endregion
             #region 吹き出し
-            TJAPlayer3.tテクスチャの解放(ref Balloon_Combo[0]);
-            TJAPlayer3.tテクスチャの解放(ref Balloon_Combo[1]);
-            TJAPlayer3.tテクスチャの解放(ref Balloon_Roll);
-            TJAPlayer3.tテクスチャの解放(ref Balloon_Balloon);
-            TJAPlayer3.tテクスチャの解放(ref Balloon_Number_Roll);
-            TJAPlayer3.tテクスチャの解放(ref Balloon_Number_Combo);
+            TJAPlayer3.t安全にDisposeする(ref Balloon_Combo[0]);
+            TJAPlayer3.t安全にDisposeする(ref Balloon_Combo[1]);
+            TJAPlayer3.t安全にDisposeする(ref Balloon_Roll);
+            TJAPlayer3.t安全にDisposeする(ref Balloon_Balloon);
+            TJAPlayer3.t安全にDisposeする(ref Balloon_Number_Roll);
+            TJAPlayer3.t安全にDisposeする(ref Balloon_Number_Combo);
 
             for (int i = 0; i < 6; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Balloon_Breaking[i]);
+                TJAPlayer3.t安全にDisposeする(ref Balloon_Breaking[i]);
             }
             #endregion
             #region エフェクト
-            TJAPlayer3.tテクスチャの解放(ref Effects_Hit_Explosion);
-            TJAPlayer3.tテクスチャの解放(ref  Effects_Hit_Explosion_Big);
-            TJAPlayer3.tテクスチャの解放(ref Effects_Hit_FireWorks);
+            TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Explosion);
+            TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Explosion_Big);
+            TJAPlayer3.t安全にDisposeする(ref Effects_Hit_FireWorks);
 
-            TJAPlayer3.tテクスチャの解放(ref Effects_Fire);
-            TJAPlayer3.tテクスチャの解放(ref Effects_Rainbow);
+            TJAPlayer3.t安全にDisposeする(ref Effects_Fire);
+            TJAPlayer3.t安全にDisposeする(ref Effects_Rainbow);
 
-            TJAPlayer3.tテクスチャの解放(ref Effects_GoGoSplash);
+            TJAPlayer3.t安全にDisposeする(ref Effects_GoGoSplash);
 
             for (int i = 0; i < 15; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Effects_Hit_Great[i]);
-                TJAPlayer3.tテクスチャの解放(ref Effects_Hit_Great_Big[i]);
-                TJAPlayer3.tテクスチャの解放(ref Effects_Hit_Good[i]);
-                TJAPlayer3.tテクスチャの解放(ref Effects_Hit_Good_Big[i]);
+                TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Great[i]);
+                TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Great_Big[i]);
+                TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Good[i]);
+                TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Good_Big[i]);
             }
             for (int i = 0; i < TJAPlayer3.Skin.Game_Effect_Roll_Ptn; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Effects_Roll[i]);
+                TJAPlayer3.t安全にDisposeする(ref Effects_Roll[i]);
             }
             #endregion
             #region レーン
             for (int i = 0; i < 3; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref Lane_Base[i]);
-                TJAPlayer3.tテクスチャの解放(ref Lane_Text[i]);
+                TJAPlayer3.t安全にDisposeする(ref Lane_Base[i]);
+                TJAPlayer3.t安全にDisposeする(ref Lane_Text[i]);
             }
-            TJAPlayer3.tテクスチャの解放(ref Lane_Red);
-            TJAPlayer3.tテクスチャの解放(ref Lane_Blue);
-            TJAPlayer3.tテクスチャの解放(ref Lane_Yellow);
-            TJAPlayer3.tテクスチャの解放(ref Lane_Background_Main);
-            TJAPlayer3.tテクスチャの解放(ref Lane_Background_Sub);
-            TJAPlayer3.tテクスチャの解放(ref Lane_Background_GoGo);
+            TJAPlayer3.t安全にDisposeする(ref Lane_Red);
+            TJAPlayer3.t安全にDisposeする(ref Lane_Blue);
+            TJAPlayer3.t安全にDisposeする(ref Lane_Yellow);
+            TJAPlayer3.t安全にDisposeする(ref Lane_Background_Main);
+            TJAPlayer3.t安全にDisposeする(ref Lane_Background_Sub);
+            TJAPlayer3.t安全にDisposeする(ref Lane_Background_GoGo);
 
             #endregion
             #region 終了演出
             for (int i = 0; i < 5; i++)
             {
-                TJAPlayer3.tテクスチャの解放(ref End_Clear_L[i]);
-                TJAPlayer3.tテクスチャの解放(ref End_Clear_R[i]);
+                TJAPlayer3.t安全にDisposeする(ref End_Clear_L[i]);
+                TJAPlayer3.t安全にDisposeする(ref End_Clear_R[i]);
             }
-            TJAPlayer3.tテクスチャの解放(ref End_Clear_Text);
-            TJAPlayer3.tテクスチャの解放(ref End_Clear_Text_Effect);
+            TJAPlayer3.t安全にDisposeする(ref End_Clear_Text);
+            TJAPlayer3.t安全にDisposeする(ref End_Clear_Text_Effect);
             #endregion
             #region ゲームモード
-            TJAPlayer3.tテクスチャの解放(ref GameMode_Timer_Tick);
-            TJAPlayer3.tテクスチャの解放(ref GameMode_Timer_Frame);
+            TJAPlayer3.t安全にDisposeする(ref GameMode_Timer_Tick);
+            TJAPlayer3.t安全にDisposeする(ref GameMode_Timer_Frame);
             #endregion
             #region ステージ失敗
-            TJAPlayer3.tテクスチャの解放(ref Failed_Game);
-            TJAPlayer3.tテクスチャの解放(ref Failed_Stage);
+            TJAPlayer3.t安全にDisposeする(ref Failed_Game);
+            TJAPlayer3.t安全にDisposeする(ref Failed_Stage);
             #endregion
             #region ランナー
-            TJAPlayer3.tテクスチャの解放(ref Runner);
+            TJAPlayer3.t安全にDisposeする(ref Runner);
             #endregion
             #region DanC
             DanC_Background?.Dispose();
@@ -835,30 +835,30 @@ namespace TJAPlayer3
             DanC_Screen?.Dispose();
             #endregion
             #region PuchiChara
-            TJAPlayer3.tテクスチャの解放(ref PuchiChara);
+            TJAPlayer3.t安全にDisposeする(ref PuchiChara);
             #endregion
             #endregion
 
             #region 6_結果発表
-            TJAPlayer3.tテクスチャの解放(ref Result_Background);
-            TJAPlayer3.tテクスチャの解放(ref Result_FadeIn);
-            TJAPlayer3.tテクスチャの解放(ref Result_Gauge);
-            TJAPlayer3.tテクスチャの解放(ref Result_Gauge_Base);
-            TJAPlayer3.tテクスチャの解放(ref Result_Gauge_Hard);
-            TJAPlayer3.tテクスチャの解放(ref Result_Gauge_ExHard);
-            TJAPlayer3.tテクスチャの解放(ref Result_Gauge_Base_Hard);
-            TJAPlayer3.tテクスチャの解放(ref Result_Gauge_Base_ExHard);
-            TJAPlayer3.tテクスチャの解放(ref Result_Judge);
-            TJAPlayer3.tテクスチャの解放(ref Result_Header);
-            TJAPlayer3.tテクスチャの解放(ref Result_Number);
-            TJAPlayer3.tテクスチャの解放(ref Result_Panel);
-            TJAPlayer3.tテクスチャの解放(ref Result_Score_Text);
-            TJAPlayer3.tテクスチャの解放(ref Result_Score_Number);
-            TJAPlayer3.tテクスチャの解放(ref Result_Dan);
+            TJAPlayer3.t安全にDisposeする(ref Result_Background);
+            TJAPlayer3.t安全にDisposeする(ref Result_FadeIn);
+            TJAPlayer3.t安全にDisposeする(ref Result_Gauge);
+            TJAPlayer3.t安全にDisposeする(ref Result_Gauge_Base);
+            TJAPlayer3.t安全にDisposeする(ref Result_Gauge_Hard);
+            TJAPlayer3.t安全にDisposeする(ref Result_Gauge_ExHard);
+            TJAPlayer3.t安全にDisposeする(ref Result_Gauge_Base_Hard);
+            TJAPlayer3.t安全にDisposeする(ref Result_Gauge_Base_ExHard);
+            TJAPlayer3.t安全にDisposeする(ref Result_Judge);
+            TJAPlayer3.t安全にDisposeする(ref Result_Header);
+            TJAPlayer3.t安全にDisposeする(ref Result_Number);
+            TJAPlayer3.t安全にDisposeする(ref Result_Panel);
+            TJAPlayer3.t安全にDisposeする(ref Result_Score_Text);
+            TJAPlayer3.t安全にDisposeする(ref Result_Score_Number);
+            TJAPlayer3.t安全にDisposeする(ref Result_Dan);
             #endregion
 
             #region 7_終了画面
-            TJAPlayer3.tテクスチャの解放(ref Exit_Background);
+            TJAPlayer3.t安全にDisposeする(ref Exit_Background);
             #endregion
 
         }

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -336,11 +336,11 @@ namespace TJAPlayer3
             Taiko_Ka_Right = TxC(GAME + TAIKO + @"Ka.png");
             Taiko_LevelUp = TxC(GAME + TAIKO + @"LevelUp.png");
             Taiko_LevelDown = TxC(GAME + TAIKO + @"LevelDown.png");
-            Couse_Symbol = new CTexture[(int)Difficulty.Total + 1]; // +1は真打ちモードの分
-            string[] Couse_Symbols = new string[(int)Difficulty.Total + 1] { "Easy", "Normal", "Hard", "Oni", "Edit", "Tower", "Dan", "Shin" };
+            Course_Symbol = new CTexture[(int)Difficulty.Total + 1]; // +1は真打ちモードの分
+            string[] course_Symbols = new string[(int)Difficulty.Total + 1] { "Easy", "Normal", "Hard", "Oni", "Edit", "Tower", "Dan", "Shin" };
             for (int i = 0; i < (int)Difficulty.Total + 1; i++)
             {
-                Couse_Symbol[i] = TxC(GAME + COURSESYMBOL + Couse_Symbols[i] + ".png");
+                Course_Symbol[i] = TxC(GAME + COURSESYMBOL + course_Symbols[i] + ".png");
             }
             Taiko_Score = new CTexture[3];
             Taiko_Score[0] = TxC(GAME + TAIKO + @"Score.png");
@@ -574,23 +574,10 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref SongSelect_GenreText);
             TJAPlayer3.t安全にDisposeする(ref SongSelect_Cursor_Left);
             TJAPlayer3.t安全にDisposeする(ref SongSelect_Cursor_Right);
-            for (int i = 0; i < SongSelect_Bar_Genre.Length; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref SongSelect_Bar_Genre[i]);
-            }
-            for (int i = 0; i < 9; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref SongSelect_Frame_Box[i]);
-            }
-            for (int i = 0; i < (int)Difficulty.Total; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref SongSelect_ScoreWindow[i]);
-            }
-
-            for (int i = 0; i < SongSelect_GenreBack.Length; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref SongSelect_GenreBack[i]);
-            }
+            TJAPlayer3.t安全にDisposeする(SongSelect_Bar_Genre);
+            TJAPlayer3.t安全にDisposeする(SongSelect_Frame_Box);
+            TJAPlayer3.t安全にDisposeする(SongSelect_ScoreWindow);
+            TJAPlayer3.t安全にDisposeする(SongSelect_GenreBack);
             TJAPlayer3.t安全にDisposeする(ref SongSelect_ScoreWindow_Text);
             TJAPlayer3.t安全にDisposeする(ref SongSelect_Rating);
             #endregion
@@ -616,95 +603,47 @@ namespace TJAPlayer3
             #endregion
             #region キャラクター
 
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Normal; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_Normal[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Clear; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_Normal_Cleared[i]);
-                TJAPlayer3.t安全にDisposeする(ref Chara_Normal_Maxed[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_GoGo; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_GoGoTime[i]);
-                TJAPlayer3.t安全にDisposeする(ref Chara_GoGoTime_Maxed[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_10combo; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_10Combo[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_10Combo_Maxed[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart_Maxed[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_Become_Cleared[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_Become_Maxed[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Breaking[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Broke[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Miss[i]);
-            }
+            TJAPlayer3.t安全にDisposeする(Chara_Normal);
+            TJAPlayer3.t安全にDisposeする(Chara_Normal_Cleared);
+            TJAPlayer3.t安全にDisposeする(Chara_Normal_Maxed);
+            TJAPlayer3.t安全にDisposeする(Chara_GoGoTime);
+            TJAPlayer3.t安全にDisposeする(Chara_GoGoTime_Maxed);
+            TJAPlayer3.t安全にDisposeする(Chara_10Combo);
+            TJAPlayer3.t安全にDisposeする(Chara_10Combo_Maxed);
+            TJAPlayer3.t安全にDisposeする(Chara_GoGoStart);
+            TJAPlayer3.t安全にDisposeする(Chara_GoGoStart_Maxed);
+            TJAPlayer3.t安全にDisposeする(Chara_Become_Cleared);
+            TJAPlayer3.t安全にDisposeする(Chara_Become_Maxed);
+            TJAPlayer3.t安全にDisposeする(Chara_Balloon_Breaking);
+            TJAPlayer3.t安全にDisposeする(Chara_Balloon_Broke);
+            TJAPlayer3.t安全にDisposeする(Chara_Balloon_Miss);
             #endregion
             #region 踊り子
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < Dancer.Length; i++)
             {
-                for (int p = 0; p < TJAPlayer3.Skin.Game_Dancer_Ptn; p++)
-                {
-                    TJAPlayer3.t安全にDisposeする(ref Dancer[i][p]);
-                }
+                TJAPlayer3.t安全にDisposeする(Dancer[i]);
             }
             #endregion
             #region モブ
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Mob_Ptn; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Mob[i]);
-            }
+            TJAPlayer3.t安全にDisposeする(Mob);
             #endregion
             #region フッター
             TJAPlayer3.t安全にDisposeする(ref Mob_Footer);
             #endregion
             #region 背景
             TJAPlayer3.t安全にDisposeする(ref Background);
-            TJAPlayer3.t安全にDisposeする(ref Background_Up[0]);
-            TJAPlayer3.t安全にDisposeする(ref Background_Up[1]);
-            TJAPlayer3.t安全にDisposeする(ref Background_Up_Clear[0]);
-            TJAPlayer3.t安全にDisposeする(ref Background_Up_Clear[1]);
+            TJAPlayer3.t安全にDisposeする(Background_Up);
+            TJAPlayer3.t安全にDisposeする(Background_Up_Clear);
             TJAPlayer3.t安全にDisposeする(ref Background_Down);
             TJAPlayer3.t安全にDisposeする(ref Background_Down_Clear);
             TJAPlayer3.t安全にDisposeする(ref Background_Down_Scroll);
 
             #endregion
             #region 太鼓
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Background[0]);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Background[1]);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Frame[0]);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Frame[1]);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_PlayerNumber[0]);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_PlayerNumber[1]);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_NamePlate[0]);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_NamePlate[1]);
+            TJAPlayer3.t安全にDisposeする(Taiko_Background);
+            TJAPlayer3.t安全にDisposeする(Taiko_Frame);
+            TJAPlayer3.t安全にDisposeする(Taiko_PlayerNumber);
+            TJAPlayer3.t安全にDisposeする(Taiko_NamePlate);
             TJAPlayer3.t安全にDisposeする(ref Taiko_Base);
             TJAPlayer3.t安全にDisposeする(ref Taiko_Don_Left);
             TJAPlayer3.t安全にDisposeする(ref Taiko_Don_Right);
@@ -712,54 +651,32 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Taiko_Ka_Right);
             TJAPlayer3.t安全にDisposeする(ref Taiko_LevelUp);
             TJAPlayer3.t安全にDisposeする(ref Taiko_LevelDown);
-            for (int i = 0; i < 6; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Couse_Symbol[i]);
-            }
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Score[0]);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Score[1]);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Score[2]);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Combo[0]);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Combo[1]);
+            TJAPlayer3.t安全にDisposeする(Course_Symbol);
+            TJAPlayer3.t安全にDisposeする(Taiko_Score);
+            TJAPlayer3.t安全にDisposeする(Taiko_Combo);
             TJAPlayer3.t安全にDisposeする(ref Taiko_Combo_Effect);
             TJAPlayer3.t安全にDisposeする(ref Taiko_Combo_Text);
             #endregion
             #region ゲージ
-            TJAPlayer3.t安全にDisposeする(ref Gauge[0]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge[1]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Hard[0]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Hard[1]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Base[0]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Base[1]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Base_Hard[0]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Base_Hard[1]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Base_ExHard[0]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Base_ExHard[1]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Line[0]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Line[1]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Line_Hard[0]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Line_Hard[1]);
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Gauge_Rainbow[i]);
-            }
+            TJAPlayer3.t安全にDisposeする(Gauge);
+            TJAPlayer3.t安全にDisposeする(Gauge_Hard);
+            TJAPlayer3.t安全にDisposeする(Gauge_Base);
+            TJAPlayer3.t安全にDisposeする(Gauge_Base_Hard);
+            TJAPlayer3.t安全にDisposeする(Gauge_Base_ExHard);
+            TJAPlayer3.t安全にDisposeする(Gauge_Line);
+            TJAPlayer3.t安全にDisposeする(Gauge_Line_Hard);
+            TJAPlayer3.t安全にDisposeする(Gauge_Rainbow);
             TJAPlayer3.t安全にDisposeする(ref Gauge_Soul);
             TJAPlayer3.t安全にDisposeする(ref Gauge_Soul_Fire);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Soul_Explosion[0]);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Soul_Explosion[1]);
+            TJAPlayer3.t安全にDisposeする(Gauge_Soul_Explosion);
             #endregion
             #region 吹き出し
-            TJAPlayer3.t安全にDisposeする(ref Balloon_Combo[0]);
-            TJAPlayer3.t安全にDisposeする(ref Balloon_Combo[1]);
+            TJAPlayer3.t安全にDisposeする(Balloon_Combo);
             TJAPlayer3.t安全にDisposeする(ref Balloon_Roll);
             TJAPlayer3.t安全にDisposeする(ref Balloon_Balloon);
             TJAPlayer3.t安全にDisposeする(ref Balloon_Number_Roll);
             TJAPlayer3.t安全にDisposeする(ref Balloon_Number_Combo);
-
-            for (int i = 0; i < 6; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Balloon_Breaking[i]);
-            }
+            TJAPlayer3.t安全にDisposeする(Balloon_Breaking);
             #endregion
             #region エフェクト
             TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Explosion);
@@ -771,24 +688,16 @@ namespace TJAPlayer3
 
             TJAPlayer3.t安全にDisposeする(ref Effects_GoGoSplash);
 
-            for (int i = 0; i < 15; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Great[i]);
-                TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Great_Big[i]);
-                TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Good[i]);
-                TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Good_Big[i]);
-            }
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Effect_Roll_Ptn; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Effects_Roll[i]);
-            }
+            TJAPlayer3.t安全にDisposeする(Effects_Hit_Great);
+            TJAPlayer3.t安全にDisposeする(Effects_Hit_Great_Big);
+            TJAPlayer3.t安全にDisposeする(Effects_Hit_Good);
+            TJAPlayer3.t安全にDisposeする(Effects_Hit_Good_Big);
+
+            TJAPlayer3.t安全にDisposeする(Effects_Roll);
             #endregion
             #region レーン
-            for (int i = 0; i < 3; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref Lane_Base[i]);
-                TJAPlayer3.t安全にDisposeする(ref Lane_Text[i]);
-            }
+            TJAPlayer3.t安全にDisposeする(Lane_Base);
+            TJAPlayer3.t安全にDisposeする(Lane_Text);
             TJAPlayer3.t安全にDisposeする(ref Lane_Red);
             TJAPlayer3.t安全にDisposeする(ref Lane_Blue);
             TJAPlayer3.t安全にDisposeする(ref Lane_Yellow);
@@ -798,11 +707,8 @@ namespace TJAPlayer3
 
             #endregion
             #region 終了演出
-            for (int i = 0; i < 5; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(ref End_Clear_L[i]);
-                TJAPlayer3.t安全にDisposeする(ref End_Clear_R[i]);
-            }
+            TJAPlayer3.t安全にDisposeする(End_Clear_L);
+            TJAPlayer3.t安全にDisposeする(End_Clear_R);
             TJAPlayer3.t安全にDisposeする(ref End_Clear_Text);
             TJAPlayer3.t安全にDisposeする(ref End_Clear_Text_Effect);
             #endregion
@@ -819,14 +725,11 @@ namespace TJAPlayer3
             #endregion
             #region DanC
             DanC_Background?.Dispose();
-            for (int i = 0; i < 4; i++)
-            {
-                DanC_Gauge[i]?.Dispose();
-            }
+            TJAPlayer3.t安全にDisposeする(DanC_Gauge);
             DanC_Base?.Dispose();
             DanC_Failed?.Dispose();
             DanC_Number?.Dispose();
-            DanC_ExamRange?.Dispose();
+            DanC_ExamRange?.Dispose(); // TODO DanC texture management is likely bugged, as its assignment and disposal are conditional but its usage is not.
             DanC_ExamUnit?.Dispose();
             DanC_ExamType?.Dispose();
             DanC_Screen?.Dispose();
@@ -905,10 +808,12 @@ namespace TJAPlayer3
             SongSelect_Cursor_Right,
             SongSelect_ScoreWindow_Text,
             SongSelect_Rating;
-        public CTexture[] SongSelect_GenreBack = new CTexture[9],
-            SongSelect_ScoreWindow = new CTexture[(int)Difficulty.Total],
-            SongSelect_Bar_Genre = new CTexture[9],
-            SongSelect_Frame_Box = new CTexture[9];
+
+        public readonly CTexture[] SongSelect_GenreBack = new CTexture[9];
+        public readonly CTexture[] SongSelect_ScoreWindow = new CTexture[(int)Difficulty.Total];
+        public readonly CTexture[] SongSelect_Bar_Genre = new CTexture[9];
+        public readonly CTexture[] SongSelect_Frame_Box = new CTexture[9];
+
         #endregion
 
         #region 4_読み込み画面
@@ -971,7 +876,7 @@ namespace TJAPlayer3
             Taiko_LevelDown,
             Taiko_Combo_Effect,
             Taiko_Combo_Text;
-        public CTexture[] Couse_Symbol, // コースシンボル
+        public CTexture[] Course_Symbol, // コースシンボル
             Taiko_PlayerNumber,
             Taiko_NamePlate; // ネームプレート
         public CTexture[] Taiko_Score,

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -71,7 +71,6 @@ namespace TJAPlayer3
             Enum_Song = TxC(@"Enum_Song.png");
             Scanning_Loudness = TxC(@"Scanning_Loudness.png");
             Overlay = TxC(@"Overlay.png");
-            NamePlate = new CTexture[2];
             NamePlate[0] = TxC(@"1P_NamePlate.png");
             NamePlate[1] = TxC(@"2P_NamePlate.png");
             #endregion
@@ -281,8 +280,7 @@ namespace TJAPlayer3
             TJAPlayer3.Skin.Game_Dancer_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + DANCER + @"1\"));
             if (TJAPlayer3.Skin.Game_Dancer_Ptn != 0)
             {
-                Dancer = new CTexture[5][];
-                for (int i = 0; i < 5; i++)
+                for (int i = 0; i < Dancer.Length; i++)
                 {
                     Dancer[i] = new CTexture[TJAPlayer3.Skin.Game_Dancer_Ptn];
                     for (int p = 0; p < TJAPlayer3.Skin.Game_Dancer_Ptn; p++)
@@ -305,10 +303,8 @@ namespace TJAPlayer3
             #endregion
             #region 背景
             Background = TxC(GAME + Background + @"0\" + @"Background.png");
-            Background_Up = new CTexture[2];
             Background_Up[0] = TxC(GAME + BACKGROUND + @"0\" + @"1P_Up.png");
             Background_Up[1] = TxC(GAME + BACKGROUND + @"0\" + @"2P_Up.png");
-            Background_Up_Clear = new CTexture[2];
             Background_Up_Clear[0] = TxC(GAME + BACKGROUND + @"0\" + @"1P_Up_Clear.png");
             Background_Up_Clear[1] = TxC(GAME + BACKGROUND + @"0\" + @"2P_Up_Clear.png");
             Background_Down = TxC(GAME + BACKGROUND + @"0\" + @"Down.png");
@@ -317,16 +313,12 @@ namespace TJAPlayer3
 
             #endregion
             #region 太鼓
-            Taiko_Background = new CTexture[2];
             Taiko_Background[0] = TxC(GAME + TAIKO + @"1P_Background.png");
             Taiko_Background[1] = TxC(GAME + TAIKO + @"2P_Background.png");
-            Taiko_Frame = new CTexture[2];
             Taiko_Frame[0] = TxC(GAME + TAIKO + @"1P_Frame.png");
             Taiko_Frame[1] = TxC(GAME + TAIKO + @"2P_Frame.png");
-            Taiko_PlayerNumber = new CTexture[2];
             Taiko_PlayerNumber[0] = TxC(GAME + TAIKO + @"1P_PlayerNumber.png");
             Taiko_PlayerNumber[1] = TxC(GAME + TAIKO + @"2P_PlayerNumber.png");
-            Taiko_NamePlate = new CTexture[2];
             Taiko_NamePlate[0] = TxC(GAME + TAIKO + @"1P_NamePlate.png");
             Taiko_NamePlate[1] = TxC(GAME + TAIKO + @"2P_NamePlate.png");
             Taiko_Base = TxC(GAME + TAIKO + @"Base.png");
@@ -336,45 +328,33 @@ namespace TJAPlayer3
             Taiko_Ka_Right = TxC(GAME + TAIKO + @"Ka.png");
             Taiko_LevelUp = TxC(GAME + TAIKO + @"LevelUp.png");
             Taiko_LevelDown = TxC(GAME + TAIKO + @"LevelDown.png");
-            Course_Symbol = new CTexture[(int)Difficulty.Total + 1]; // +1は真打ちモードの分
-            string[] course_Symbols = new string[(int)Difficulty.Total + 1] { "Easy", "Normal", "Hard", "Oni", "Edit", "Tower", "Dan", "Shin" };
-            for (int i = 0; i < (int)Difficulty.Total + 1; i++)
+            for (int i = 0; i < Course_Symbol.Length; i++)
             {
-                Course_Symbol[i] = TxC(GAME + COURSESYMBOL + course_Symbols[i] + ".png");
+                Course_Symbol[i] = TxC(GAME + COURSESYMBOL + Course_Symbols[i] + ".png");
             }
-            Taiko_Score = new CTexture[3];
             Taiko_Score[0] = TxC(GAME + TAIKO + @"Score.png");
             Taiko_Score[1] = TxC(GAME + TAIKO + @"Score_1P.png");
             Taiko_Score[2] = TxC(GAME + TAIKO + @"Score_2P.png");
-            Taiko_Combo = new CTexture[2];
             Taiko_Combo[0] = TxC(GAME + TAIKO + @"Combo.png");
             Taiko_Combo[1] = TxC(GAME + TAIKO + @"Combo_Big.png");
             Taiko_Combo_Effect = TxC(GAME + TAIKO + @"Combo_Effect.png");
             Taiko_Combo_Text = TxC(GAME + TAIKO + @"Combo_Text.png");
             #endregion
             #region ゲージ
-            Gauge = new CTexture[2];
             Gauge[0] = TxC(GAME + GAUGE + @"1P.png");
             Gauge[1] = TxC(GAME + GAUGE + @"2P.png");
-            Gauge_Hard = new CTexture[2];
             Gauge_Hard[0] = TxC(GAME + GAUGE + @"1P_Hard.png");
             Gauge_Hard[1] = TxC(GAME + GAUGE + @"2P_Hard.png");
-            Gauge_ExHard = new CTexture[2];
             Gauge_ExHard[0] = TxC(GAME + GAUGE + @"1P_ExHard.png");
             Gauge_ExHard[1] = TxC(GAME + GAUGE + @"2P_ExHard.png");
-            Gauge_Base = new CTexture[2];
             Gauge_Base[0] = TxC(GAME + GAUGE + @"1P_Base.png");
             Gauge_Base[1] = TxC(GAME + GAUGE + @"2P_Base.png");
-            Gauge_Base_Hard = new CTexture[2];
             Gauge_Base_Hard[0] = TxC(GAME + GAUGE + @"1P_Base_Hard.png");
             Gauge_Base_Hard[1] = TxC(GAME + GAUGE + @"2P_Base_Hard.png");
-            Gauge_Base_ExHard = new CTexture[2];
             Gauge_Base_ExHard[0] = TxC(GAME + GAUGE + @"1P_Base_ExHard.png");
             Gauge_Base_ExHard[1] = TxC(GAME + GAUGE + @"2P_Base_ExHard.png");
-            Gauge_Line = new CTexture[2];
             Gauge_Line[0] = TxC(GAME + GAUGE + @"1P_Line.png");
             Gauge_Line[1] = TxC(GAME + GAUGE + @"2P_Line.png");
-            Gauge_Line_Hard = new CTexture[2];
             Gauge_Line_Hard[0] = TxC(GAME + GAUGE + @"1P_Line_Hard.png");
             Gauge_Line_Hard[1] = TxC(GAME + GAUGE + @"2P_Line_Hard.png");
             TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + GAUGE + @"Rainbow\"));
@@ -388,12 +368,10 @@ namespace TJAPlayer3
             }
             Gauge_Soul = TxC(GAME + GAUGE + @"Soul.png");
             Gauge_Soul_Fire = TxC(GAME + GAUGE + @"Fire.png");
-            Gauge_Soul_Explosion = new CTexture[2];
             Gauge_Soul_Explosion[0] = TxC(GAME + GAUGE + @"1P_Explosion.png");
             Gauge_Soul_Explosion[1] = TxC(GAME + GAUGE + @"2P_Explosion.png");
             #endregion
             #region 吹き出し
-            Balloon_Combo = new CTexture[2];
             Balloon_Combo[0] = TxC(GAME + BALLOON + @"Combo_1P.png");
             Balloon_Combo[1] = TxC(GAME + BALLOON + @"Combo_2P.png");
             Balloon_Roll = TxC(GAME + BALLOON + @"Roll.png");
@@ -401,8 +379,7 @@ namespace TJAPlayer3
             Balloon_Number_Roll = TxC(GAME + BALLOON + @"Number_Roll.png");
             Balloon_Number_Combo = TxC(GAME + BALLOON + @"Number_Combo.png");
 
-            Balloon_Breaking = new CTexture[6];
-            for (int i = 0; i < 6; i++)
+            for (int i = 0; i < Balloon_Breaking.Length; i++)
             {
                 Balloon_Breaking[i] = TxC(GAME + BALLOON + @"Breaking_" + i.ToString() + ".png");
             }
@@ -423,16 +400,12 @@ namespace TJAPlayer3
 
             Effects_GoGoSplash = TxC(GAME + EFFECTS + @"GoGoSplash.png");
             if (Effects_GoGoSplash != null) Effects_GoGoSplash.b加算合成 = TJAPlayer3.Skin.Game_Effect_GoGoSplash_AddBlend;
-            Effects_Hit_Great = new CTexture[15];
-            Effects_Hit_Great_Big = new CTexture[15];
-            Effects_Hit_Good = new CTexture[15];
-            Effects_Hit_Good_Big = new CTexture[15];
-            for (int i = 0; i < 15; i++)
+            for (int i = 0; i < Effects_Hit_Good.Length; i++)
             {
-                Effects_Hit_Great[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Great\" + i.ToString() + ".png");
-                Effects_Hit_Great_Big[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Great_Big\" + i.ToString() + ".png");
                 Effects_Hit_Good[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Good\" + i.ToString() + ".png");
                 Effects_Hit_Good_Big[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Good_Big\" + i.ToString() + ".png");
+                Effects_Hit_Great[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Great\" + i.ToString() + ".png");
+                Effects_Hit_Great_Big[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Great_Big\" + i.ToString() + ".png");
             }
             TJAPlayer3.Skin.Game_Effect_Roll_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + EFFECTS + @"Roll\"));
             Effects_Roll = new CTexture[TJAPlayer3.Skin.Game_Effect_Roll_Ptn];
@@ -442,10 +415,8 @@ namespace TJAPlayer3
             }
             #endregion
             #region レーン
-            Lane_Base = new CTexture[3];
-            Lane_Text = new CTexture[3];
             string[] Lanes = new string[3] { "Normal", "Expert", "Master" };
-            for (int i = 0; i < 3; i++)
+            for (int i = 0; i < Lane_Base.Length; i++)
             {
                 Lane_Base[i] = TxC(GAME + LANE + "Base_" + Lanes[i] + ".png");
                 Lane_Text[i] = TxC(GAME + LANE + "Text_" + Lanes[i] + ".png");
@@ -459,9 +430,7 @@ namespace TJAPlayer3
 
             #endregion
             #region 終了演出
-            End_Clear_L = new CTexture[5];
-            End_Clear_R = new CTexture[5];
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < End_Clear_L.Length; i++)
             {
                 End_Clear_L[i] = TxC(GAME + END + @"Clear_L_" + i.ToString() + ".png");
                 End_Clear_R[i] = TxC(GAME + END + @"Clear_R_" + i.ToString() + ".png");
@@ -688,10 +657,10 @@ namespace TJAPlayer3
 
             TJAPlayer3.t安全にDisposeする(ref Effects_GoGoSplash);
 
-            TJAPlayer3.t安全にDisposeする(Effects_Hit_Great);
-            TJAPlayer3.t安全にDisposeする(Effects_Hit_Great_Big);
             TJAPlayer3.t安全にDisposeする(Effects_Hit_Good);
             TJAPlayer3.t安全にDisposeする(Effects_Hit_Good_Big);
+            TJAPlayer3.t安全にDisposeする(Effects_Hit_Great);
+            TJAPlayer3.t安全にDisposeする(Effects_Hit_Great_Big);
 
             TJAPlayer3.t安全にDisposeする(Effects_Roll);
             #endregion
@@ -771,7 +740,7 @@ namespace TJAPlayer3
             Enum_Song,
             Scanning_Loudness,
             Overlay;
-        public CTexture[] NamePlate;
+        public readonly CTexture[] NamePlate = new CTexture[2];
         #endregion
         #region 1_タイトル画面
         public CTexture Title_Background,
@@ -850,7 +819,7 @@ namespace TJAPlayer3
             Chara_Balloon_Miss;
         #endregion
         #region 踊り子
-        public CTexture[][] Dancer;
+        public readonly CTexture[][] Dancer = new CTexture[5][];
         #endregion
         #region モブ
         public CTexture[] Mob;
@@ -861,12 +830,14 @@ namespace TJAPlayer3
             Background_Down,
             Background_Down_Clear,
             Background_Down_Scroll;
-        public CTexture[] Background_Up,
-            Background_Up_Clear;
+        public readonly CTexture[] Background_Up = new CTexture[2];
+        public readonly CTexture[] Background_Up_Clear = new CTexture[2];
+
         #endregion
         #region 太鼓
-        public CTexture[] Taiko_Frame, // MTaiko下敷き
-            Taiko_Background;
+
+        public readonly CTexture[] Taiko_Frame = new CTexture[2]; // MTaiko下敷き
+        public readonly CTexture[] Taiko_Background = new CTexture[2];
         public CTexture Taiko_Base,
             Taiko_Don_Left,
             Taiko_Don_Right,
@@ -876,34 +847,37 @@ namespace TJAPlayer3
             Taiko_LevelDown,
             Taiko_Combo_Effect,
             Taiko_Combo_Text;
-        public CTexture[] Course_Symbol, // コースシンボル
-            Taiko_PlayerNumber,
-            Taiko_NamePlate; // ネームプレート
-        public CTexture[] Taiko_Score,
-            Taiko_Combo;
+
+        private static readonly string[] Course_Symbols = { "Easy", "Normal", "Hard", "Oni", "Edit", "Tower", "Dan", "Shin" };
+        public readonly CTexture[] Course_Symbol = new CTexture[Course_Symbols.Length];
+        public readonly CTexture[] Taiko_PlayerNumber = new CTexture[2];
+        public readonly CTexture[] Taiko_NamePlate = new CTexture[2]; // ネームプレート
+        public readonly CTexture[] Taiko_Score = new CTexture[3];
+        public readonly CTexture[] Taiko_Combo = new CTexture[2];
         #endregion
         #region ゲージ
-        public CTexture[] Gauge,
-            Gauge_Hard,
-            Gauge_ExHard,
-            Gauge_Base,
-            Gauge_Base_Hard,
-            Gauge_Base_ExHard,
-            Gauge_Line,
-            Gauge_Line_Hard,
-            Gauge_Rainbow,
-            Gauge_Soul_Explosion;
+        public readonly CTexture[] Gauge = new CTexture[2];
+        public readonly CTexture[] Gauge_Hard = new CTexture[2];
+        public readonly CTexture[] Gauge_ExHard = new CTexture[2];
+        public readonly CTexture[] Gauge_Base = new CTexture[2];
+        public readonly CTexture[] Gauge_Base_Hard = new CTexture[2];
+        public readonly CTexture[] Gauge_Base_ExHard = new CTexture[2];
+        public readonly CTexture[] Gauge_Line = new CTexture[2];
+        public readonly CTexture[] Gauge_Line_Hard = new CTexture[2];
+        public CTexture[] Gauge_Rainbow;
+        public readonly CTexture[] Gauge_Soul_Explosion = new CTexture[2];
+
         public CTexture Gauge_Soul,
             Gauge_Soul_Fire;
         #endregion
         #region 吹き出し
-        public CTexture[] Balloon_Combo;
+        public readonly CTexture[] Balloon_Combo = new CTexture[2];
         public CTexture Balloon_Roll,
             Balloon_Balloon,
             Balloon_Number_Roll,
             Balloon_Number_Combo/*,*/
                                 /*Balloon_Broken*/;
-        public CTexture[] Balloon_Breaking;
+        public readonly CTexture[] Balloon_Breaking = new CTexture[6];
         #endregion
         #region エフェクト
         public CTexture Effects_Hit_Explosion,
@@ -912,15 +886,18 @@ namespace TJAPlayer3
             Effects_Rainbow,
             Effects_GoGoSplash,
             Effects_Hit_FireWorks;
-        public CTexture[] Effects_Hit_Great,
-            Effects_Hit_Good,
-            Effects_Hit_Great_Big,
-            Effects_Hit_Good_Big;
+
+        public readonly CTexture[] Effects_Hit_Good = new CTexture[15];
+        public readonly CTexture[] Effects_Hit_Good_Big = new CTexture[15];
+        public readonly CTexture[] Effects_Hit_Great = new CTexture[15];
+        public readonly CTexture[] Effects_Hit_Great_Big = new CTexture[15];
+
         public CTexture[] Effects_Roll;
         #endregion
         #region レーン
-        public CTexture[] Lane_Base,
-            Lane_Text;
+        public readonly CTexture[] Lane_Base = new CTexture[3];
+        public readonly CTexture[] Lane_Text = new CTexture[3];
+
         public CTexture Lane_Red,
             Lane_Blue,
             Lane_Yellow;
@@ -929,8 +906,9 @@ namespace TJAPlayer3
             Lane_Background_GoGo;
         #endregion
         #region 終了演出
-        public CTexture[] End_Clear_L,
-            End_Clear_R;
+        public readonly CTexture[] End_Clear_L = new CTexture[5];
+        public readonly CTexture[] End_Clear_R = new CTexture[5];
+
         public CTexture End_Clear_Text,
             End_Clear_Text_Effect;
         #endregion

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -911,8 +911,7 @@ namespace TJAPlayer3
         public CTexture[] SongSelect_GenreBack = new CTexture[9],
             SongSelect_ScoreWindow = new CTexture[(int)Difficulty.Total],
             SongSelect_Bar_Genre = new CTexture[9],
-            SongSelect_Frame_Box = new CTexture[9],
-            SongSelect_NamePlate = new CTexture[1];
+            SongSelect_Frame_Box = new CTexture[9];
         #endregion
 
         #region 4_読み込み画面

--- a/TJAPlayer3/Stages/04.Config/CActConfigList.cs
+++ b/TJAPlayer3/Stages/04.Config/CActConfigList.cs
@@ -1573,7 +1573,7 @@ namespace TJAPlayer3
 			if( this.b活性化してない )
 				return;
 
-			TJAPlayer3.tテクスチャの解放( ref this.txSkinSample1 );
+			TJAPlayer3.t安全にDisposeする(ref this.txSkinSample1);
 			//CDTXMania.tテクスチャの解放( ref this.tx通常項目行パネル );
 			//CDTXMania.tテクスチャの解放( ref this.txその他項目行パネル );
 			//CDTXMania.tテクスチャの解放( ref this.tx三角矢印 );

--- a/TJAPlayer3/Stages/04.Config/CActConfigList.cs
+++ b/TJAPlayer3/Stages/04.Config/CActConfigList.cs
@@ -1186,10 +1186,7 @@ namespace TJAPlayer3
 				g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
 				g.DrawImage( bmSrc, new Rectangle( 0, 0, bmSrc.Width / 4, bmSrc.Height / 4 ),
 					0, 0, bmSrc.Width, bmSrc.Height, GraphicsUnit.Pixel );
-				if ( txSkinSample1 != null )
-				{
-					TJAPlayer3.t安全にDisposeする( ref txSkinSample1 );
-				}
+				TJAPlayer3.t安全にDisposeする( ref txSkinSample1 );
 				txSkinSample1 = TJAPlayer3.tテクスチャの生成( bmDest, false );
 				g.Dispose();
 				bmDest.Dispose();

--- a/TJAPlayer3/Stages/04.Config/CStageコンフィグ.cs
+++ b/TJAPlayer3/Stages/04.Config/CStageコンフィグ.cs
@@ -152,7 +152,7 @@ namespace TJAPlayer3
 				//CDTXMania.tテクスチャの解放( ref this.tx上部パネル );
 				//CDTXMania.tテクスチャの解放( ref this.tx下部パネル );
 				//CDTXMania.tテクスチャの解放( ref this.txMenuカーソル );
-				TJAPlayer3.tテクスチャの解放( ref this.tx説明文パネル );
+				TJAPlayer3.t安全にDisposeする(ref this.tx説明文パネル);
 				for ( int i = 0; i < txMenuItemLeft.GetLength( 0 ); i++ )
 				{
 					txMenuItemLeft[ i, 0 ].Dispose();

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelectInformation.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelectInformation.cs
@@ -49,9 +49,9 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-				TJAPlayer3.tテクスチャの解放( ref this.txInfo_Back );
-				TJAPlayer3.tテクスチャの解放( ref this.txInfo[ 0 ] );
-				TJAPlayer3.tテクスチャの解放( ref this.txInfo[ 1 ] );
+				TJAPlayer3.t安全にDisposeする(ref this.txInfo_Back);
+				TJAPlayer3.t安全にDisposeする(ref this.txInfo[ 0 ]);
+				TJAPlayer3.t安全にDisposeする(ref this.txInfo[ 1 ]);
 				base.OnManagedリソースの解放();
 			}
 		}

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelectInformation.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelectInformation.cs
@@ -50,8 +50,7 @@ namespace TJAPlayer3
 			if( !base.b活性化してない )
 			{
 				TJAPlayer3.t安全にDisposeする(ref this.txInfo_Back);
-				TJAPlayer3.t安全にDisposeする(ref this.txInfo[ 0 ]);
-				TJAPlayer3.t安全にDisposeする(ref this.txInfo[ 1 ]);
+				TJAPlayer3.t安全にDisposeする(txInfo);
 				base.OnManagedリソースの解放();
 			}
 		}
@@ -142,7 +141,7 @@ namespace TJAPlayer3
 			new STINFO( 1, 0, 147 )
 		};
         private CTexture txInfo_Back;
-		private CTexture[] txInfo = new CTexture[ 2 ];
+		private readonly CTexture[] txInfo = new CTexture[ 2 ];
         private bool bFirst;
         private CCounter ct進行用;
 		//-----------------

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelectPreimageパネル.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelectPreimageパネル.cs
@@ -73,9 +73,9 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-				TJAPlayer3.tテクスチャの解放( ref this.txパネル本体 );
-				TJAPlayer3.tテクスチャの解放( ref this.txプレビュー画像 );
-				TJAPlayer3.tテクスチャの解放( ref this.txプレビュー画像がないときの画像 );
+				TJAPlayer3.t安全にDisposeする(ref this.txパネル本体);
+				TJAPlayer3.t安全にDisposeする(ref this.txプレビュー画像);
+				TJAPlayer3.t安全にDisposeする(ref this.txプレビュー画像がないときの画像);
 				if( this.sfAVI画像 != null )
 				{
 					this.sfAVI画像.Dispose();
@@ -240,7 +240,7 @@ namespace TJAPlayer3
 			string str = cスコア.ファイル情報.フォルダの絶対パス + cスコア.譜面情報.Preimage;
 			if( !str.Equals( this.str現在のファイル名 ) )
 			{
-				TJAPlayer3.tテクスチャの解放( ref this.txプレビュー画像 );
+				TJAPlayer3.t安全にDisposeする(ref this.txプレビュー画像);
 				this.str現在のファイル名 = str;
 				if( !File.Exists( this.str現在のファイル名 ) )
 				{
@@ -314,7 +314,7 @@ namespace TJAPlayer3
 					Trace.TraceWarning( "ファイルが存在しません。({0})", new object[] { path } );
 					return false;
 				}
-				TJAPlayer3.tテクスチャの解放( ref this.txプレビュー画像 );
+				TJAPlayer3.t安全にDisposeする(ref this.txプレビュー画像);
 				this.str現在のファイル名 = path;
 				Bitmap image = null;
 				Bitmap bitmap2 = null;

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelectQuickConfig.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelectQuickConfig.cs
@@ -227,7 +227,7 @@ namespace TJAPlayer3
 			if ( !base.b活性化してない )
 			{
 				//CDTXMania.tテクスチャの解放( ref this.txパネル本体 );
-				TJAPlayer3.tテクスチャの解放( ref this.tx文字列パネル );
+				TJAPlayer3.t安全にDisposeする(ref this.tx文字列パネル);
 				base.OnManagedリソースの解放();
 			}
 		}

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -694,15 +694,15 @@ namespace TJAPlayer3
 
 			for( int i = 0; i < 13; i++ )
             {
-                TJAPlayer3.tテクスチャの解放( ref this.stバー情報[ i ].txタイトル名 );
+                TJAPlayer3.t安全にDisposeする(ref this.stバー情報[ i ].txタイトル名);
                 this.stバー情報[ i ].ttkタイトル = null;
             }
 
 		    ClearTitleTextureCache();
 
             //CDTXMania.t安全にDisposeする( ref this.txスキル数字 );
-            TJAPlayer3.tテクスチャの解放( ref this.txEnumeratingSongs );
-            TJAPlayer3.tテクスチャの解放( ref this.txSongNotFound );
+            TJAPlayer3.t安全にDisposeする(ref this.txEnumeratingSongs);
+            TJAPlayer3.t安全にDisposeする(ref this.txSongNotFound);
             //CDTXMania.t安全にDisposeする( ref this.tx曲名バー.Score );
             //CDTXMania.t安全にDisposeする( ref this.tx曲名バー.Box );
             //CDTXMania.t安全にDisposeする( ref this.tx曲名バー.Other );

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -692,7 +692,7 @@ namespace TJAPlayer3
 
 			//CDTXMania.t安全にDisposeする( ref this.txアイテム数数字 );
 
-			for( int i = 0; i < 13; i++ )
+			for( int i = 0; i < stバー情報.Length; i++ )
             {
                 TJAPlayer3.t安全にDisposeする(ref this.stバー情報[ i ].txタイトル名);
                 this.stバー情報[ i ].ttkタイトル = null;

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect難易度選択画面.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect難易度選択画面.cs
@@ -138,18 +138,18 @@ namespace TJAPlayer3
 			if( this.b活性化してない )
 				return;
 
-            TJAPlayer3.tテクスチャの解放( ref this.tx背景 );
-            TJAPlayer3.tテクスチャの解放( ref this.txヘッダー );
-            TJAPlayer3.tテクスチャの解放( ref this.txフッター );
+            TJAPlayer3.t安全にDisposeする(ref this.tx背景);
+            TJAPlayer3.t安全にDisposeする(ref this.txヘッダー);
+            TJAPlayer3.t安全にDisposeする(ref this.txフッター);
 
-            TJAPlayer3.tテクスチャの解放( ref this.tx説明背景 );
-            TJAPlayer3.tテクスチャの解放( ref this.tx説明1 );
+            TJAPlayer3.t安全にDisposeする(ref this.tx説明背景);
+            TJAPlayer3.t安全にDisposeする(ref this.tx説明1);
 
             TJAPlayer3.t安全にDisposeする( ref this.soundSelectAnnounce );
 
             for( int i = 0; i < (int)Difficulty.Total; i++ )
             {
-                TJAPlayer3.tテクスチャの解放( ref this.tx踏み台[ i ] );
+                TJAPlayer3.t安全にDisposeする(ref this.tx踏み台[ i ]);
             }
 
 			base.OnManagedリソースの解放();

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect難易度選択画面.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect難易度選択画面.cs
@@ -147,10 +147,7 @@ namespace TJAPlayer3
 
             TJAPlayer3.t安全にDisposeする( ref this.soundSelectAnnounce );
 
-            for( int i = 0; i < (int)Difficulty.Total; i++ )
-            {
-                TJAPlayer3.t安全にDisposeする(ref this.tx踏み台[ i ]);
-            }
+            TJAPlayer3.t安全にDisposeする(tx踏み台);
 
 			base.OnManagedリソースの解放();
 		}
@@ -342,7 +339,7 @@ namespace TJAPlayer3
 		private int n現在の選択行;
 		private int n目標のスクロールカウンタ;
 
-        private CTexture[] tx踏み台 = new CTexture[(int)Difficulty.Total];
+        private readonly CTexture[] tx踏み台 = new CTexture[(int)Difficulty.Total];
 
         private CTexture tx背景;
         private CTexture txヘッダー;

--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -301,10 +301,7 @@ namespace TJAPlayer3
                 #region ネームプレート
                 for (int i = 0; i < TJAPlayer3.ConfigIni.nPlayerCount; i++)
                 {
-                    if (TJAPlayer3.Tx.NamePlate[i] != null)
-                    {
-                        TJAPlayer3.Tx.NamePlate[i].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongSelect_NamePlate_X[i], TJAPlayer3.Skin.SongSelect_NamePlate_Y[i]);
-                    }
+                    TJAPlayer3.Tx.NamePlate[i]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongSelect_NamePlate_X[i], TJAPlayer3.Skin.SongSelect_NamePlate_Y[i]);
                 }
                 #endregion
 

--- a/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
+++ b/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
@@ -166,10 +166,10 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-				TJAPlayer3.tテクスチャの解放( ref this.tx背景 );
-				TJAPlayer3.tテクスチャの解放( ref this.txタイトル );
+				TJAPlayer3.t安全にDisposeする(ref this.tx背景);
+				TJAPlayer3.t安全にDisposeする(ref this.txタイトル);
 				//CDTXMania.tテクスチャの解放( ref this.txSongnamePlate );
-                TJAPlayer3.tテクスチャの解放( ref this.txサブタイトル );
+                TJAPlayer3.t安全にDisposeする(ref this.txサブタイトル);
 				base.OnManagedリソースの解放();
 			}
 		}

--- a/TJAPlayer3/Stages/06.SongLoading/FastRender.cs
+++ b/TJAPlayer3/Stages/06.SongLoading/FastRender.cs
@@ -60,7 +60,7 @@ namespace TJAPlayer3
                 NullCheckAndRender(ref TJAPlayer3.Tx.Chara_Balloon_Miss[i]);
             }
 
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < TJAPlayer3.Tx.Dancer.Length; i++)
             {
                 for (int k = 0; k < TJAPlayer3.Skin.Game_Dancer_Ptn; k++)
                 {

--- a/TJAPlayer3/Stages/07.Game/CAct演奏Combo共通.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏Combo共通.cs
@@ -410,118 +410,132 @@ namespace TJAPlayer3
 
             for ( int i = 0; i < n桁数; i++ )
             {
+                var txTaiko_Combo0 = TJAPlayer3.Tx.Taiko_Combo[0];
+                var txTaiko_Combo1 = TJAPlayer3.Tx.Taiko_Combo[1];
 
-                TJAPlayer3.Tx.Taiko_Combo[0].Opacity = 255;
-                TJAPlayer3.Tx.Taiko_Combo[1].Opacity = 255;
+                if (txTaiko_Combo0 != null)
+                {
+                    txTaiko_Combo0.Opacity = 255;
+                }
+
+                if (txTaiko_Combo1 != null)
+                {
+                    txTaiko_Combo1.Opacity = 255;
+                }
 
                 if ( n桁数 <= 1 )
                 {
-				    if(TJAPlayer3.Tx.Taiko_Combo[0] != null )
+				    if (txTaiko_Combo0 != null)
 				    {
                         var yScalling = ComboScale[this.ctコンボ加算[nPlayer].n現在の値];
-                        TJAPlayer3.Tx.Taiko_Combo[0].vc拡大縮小倍率.Y = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[0] + yScalling;
-                        TJAPlayer3.Tx.Taiko_Combo[0].vc拡大縮小倍率.X = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[0];
-                        TJAPlayer3.Tx.Taiko_Combo[0].t2D拡大率考慮下中心基準描画( TJAPlayer3.app.Device, rightX, TJAPlayer3.Skin.Game_Taiko_Combo_Y[nPlayer] , new Rectangle( n位の数[ i ] * TJAPlayer3.Skin.Game_Taiko_Combo_Size[0], 0, TJAPlayer3.Skin.Game_Taiko_Combo_Size[0], TJAPlayer3.Skin.Game_Taiko_Combo_Size[1]) );
+                        txTaiko_Combo0.vc拡大縮小倍率.Y = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[0] + yScalling;
+                        txTaiko_Combo0.vc拡大縮小倍率.X = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[0];
+                        txTaiko_Combo0.t2D拡大率考慮下中心基準描画( TJAPlayer3.app.Device, rightX, TJAPlayer3.Skin.Game_Taiko_Combo_Y[nPlayer] , new Rectangle( n位の数[ i ] * TJAPlayer3.Skin.Game_Taiko_Combo_Size[0], 0, TJAPlayer3.Skin.Game_Taiko_Combo_Size[0], TJAPlayer3.Skin.Game_Taiko_Combo_Size[1]) );
 				    }
                 }
                 else if( n桁数 <= 2 )
                 {
                     //int[] arComboX = { CDTXMania.Skin.Game_Taiko_Combo_X[nPlayer] + CDTXMania.Skin.Game_Taiko_Combo_Padding[0], CDTXMania.Skin.Game_Taiko_Combo_X[nPlayer] - CDTXMania.Skin.Game_Taiko_Combo_Padding[0] };
-                    if (TJAPlayer3.Tx.Taiko_Combo[0] != null )
+                    if (txTaiko_Combo0 != null)
 				    {
                         var yScalling = ComboScale[this.ctコンボ加算[nPlayer].n現在の値];
-                        TJAPlayer3.Tx.Taiko_Combo[0].vc拡大縮小倍率.Y = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[0] + yScalling;
-                        TJAPlayer3.Tx.Taiko_Combo[0].vc拡大縮小倍率.X = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[0];
-                        TJAPlayer3.Tx.Taiko_Combo[0].t2D拡大率考慮下中心基準描画( TJAPlayer3.app.Device, rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[0] * i, TJAPlayer3.Skin.Game_Taiko_Combo_Y[nPlayer], new Rectangle( n位の数[ i ] * TJAPlayer3.Skin.Game_Taiko_Combo_Size[0], 0, TJAPlayer3.Skin.Game_Taiko_Combo_Size[0], TJAPlayer3.Skin.Game_Taiko_Combo_Size[1]) );
+                        txTaiko_Combo0.vc拡大縮小倍率.Y = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[0] + yScalling;
+                        txTaiko_Combo0.vc拡大縮小倍率.X = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[0];
+                        txTaiko_Combo0.t2D拡大率考慮下中心基準描画( TJAPlayer3.app.Device, rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[0] * i, TJAPlayer3.Skin.Game_Taiko_Combo_Y[nPlayer], new Rectangle( n位の数[ i ] * TJAPlayer3.Skin.Game_Taiko_Combo_Size[0], 0, TJAPlayer3.Skin.Game_Taiko_Combo_Size[0], TJAPlayer3.Skin.Game_Taiko_Combo_Size[1]) );
 				    }
-                }
-                else if( n桁数 == 3 )
-                {
-                    if (TJAPlayer3.Tx.Taiko_Combo[1] != null )
-				    {
-                        var yScalling = ComboScale_Ex[this.ctコンボ加算[nPlayer].n現在の値, 0];
-                        TJAPlayer3.Tx.Taiko_Combo[1].vc拡大縮小倍率.Y = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1] + yScalling;
-                        TJAPlayer3.Tx.Taiko_Combo[1].vc拡大縮小倍率.X = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1];
-                        var yJumping = TJAPlayer3.Skin.Game_Taiko_Combo_Ex_IsJumping ? (int)ComboScale_Ex[this.ctコンボ加算[nPlayer].n現在の値, 1] : 0;
-                        TJAPlayer3.Tx.Taiko_Combo[1].t2D拡大率考慮下中心基準描画( TJAPlayer3.app.Device, rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i, TJAPlayer3.Skin.Game_Taiko_Combo_Ex_Y[nPlayer] + yJumping, new Rectangle( n位の数[ i ] * TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0], 0, TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0], TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1]) );
-                    }
-                    if(TJAPlayer3.Tx.Taiko_Combo_Effect != null )
-                    {
-                        TJAPlayer3.Tx.Taiko_Combo_Effect.b加算合成 = true;
-                        if( this.ctコンボラメ.n現在の値 < 14)
-                        {
-                            // ひだり
-                            #region[透明度制御]
-                            if (this.ctコンボラメ.n現在の値 < 7) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = 255;
-                            else if (this.ctコンボラメ.n現在の値 >= 7 && this.ctコンボラメ.n現在の値 < 14) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = (int)(204 - (24 * this.ctコンボラメ.n現在の値));
-                            #endregion
-                            TJAPlayer3.Tx.Taiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i) - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1]), TJAPlayer3.Skin.Game_Taiko_Combo_Ex_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
-                        }
-                        if(ctコンボラメ.n現在の値 > 4 && ctコンボラメ.n現在の値 < 24)
-                        {
-                            // みぎ
-                            #region[透明度制御]
-                            if (this.ctコンボラメ.n現在の値 < 11) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = 255;
-                            else if (this.ctコンボラメ.n現在の値 >= 11 && this.ctコンボラメ.n現在の値 < 24) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = (int)(204 - (12 * this.ctコンボラメ.n現在の値));
-                            #endregion
-                            TJAPlayer3.Tx.Taiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i) + ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1]), TJAPlayer3.Skin.Game_Taiko_Combo_Ex_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
-
-                        }
-                        if (ctコンボラメ.n現在の値 > 14)
-                        {
-                            // まんなか
-                            #region[透明度制御]
-                            if (this.ctコンボラメ.n現在の値 < 252) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = 255;
-                            else if (this.ctコンボラメ.n現在の値 >= 22 && this.ctコンボラメ.n現在の値 < 30) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = (int)(204 - (6 * this.ctコンボラメ.n現在の値));
-                            #endregion
-                            TJAPlayer3.Tx.Taiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i), TJAPlayer3.Skin.Game_Taiko_Combo_Ex_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
-                        }
-                    }
                 }
                 else
                 {
-                    if (TJAPlayer3.Tx.Taiko_Combo[1] != null)
+                    var txTaiko_Combo_Effect = TJAPlayer3.Tx.Taiko_Combo_Effect;
+
+                    if( n桁数 == 3 )
                     {
-                        var yScalling = ComboScale_Ex[this.ctコンボ加算[nPlayer].n現在の値, 0];
-                        TJAPlayer3.Tx.Taiko_Combo[1].vc拡大縮小倍率.Y = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2] + yScalling;
-                        TJAPlayer3.Tx.Taiko_Combo[1].vc拡大縮小倍率.X = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2];
-                        var yJumping = TJAPlayer3.Skin.Game_Taiko_Combo_Ex_IsJumping ? (int)ComboScale_Ex[this.ctコンボ加算[nPlayer].n現在の値, 1] : 0;
-                        TJAPlayer3.Tx.Taiko_Combo[1].t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[2] * i, TJAPlayer3.Skin.Game_Taiko_Combo_Ex4_Y[nPlayer] + yJumping, new Rectangle(n位の数[i] * TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0], 0, TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0], TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1]));
+                        if (txTaiko_Combo1 != null)
+                        {
+                            var yScalling = ComboScale_Ex[this.ctコンボ加算[nPlayer].n現在の値, 0];
+                            txTaiko_Combo1.vc拡大縮小倍率.Y = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1] + yScalling;
+                            txTaiko_Combo1.vc拡大縮小倍率.X = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1];
+                            var yJumping = TJAPlayer3.Skin.Game_Taiko_Combo_Ex_IsJumping ? (int)ComboScale_Ex[this.ctコンボ加算[nPlayer].n現在の値, 1] : 0;
+                            txTaiko_Combo1.t2D拡大率考慮下中心基準描画( TJAPlayer3.app.Device, rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i, TJAPlayer3.Skin.Game_Taiko_Combo_Ex_Y[nPlayer] + yJumping, new Rectangle( n位の数[ i ] * TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0], 0, TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0], TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1]) );
+                        }
+                        if (txTaiko_Combo_Effect != null)
+                        {
+                            txTaiko_Combo_Effect.b加算合成 = true;
+                            if( this.ctコンボラメ.n現在の値 < 14)
+                            {
+                                // ひだり
+                                #region[透明度制御]
+                                if (this.ctコンボラメ.n現在の値 < 7) txTaiko_Combo_Effect.Opacity = 255;
+                                else if (this.ctコンボラメ.n現在の値 >= 7 && this.ctコンボラメ.n現在の値 < 14) txTaiko_Combo_Effect.Opacity = (int)(204 - (24 * this.ctコンボラメ.n現在の値));
+                                #endregion
+                                txTaiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i) - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1]), TJAPlayer3.Skin.Game_Taiko_Combo_Ex_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
+                            }
+                            if(ctコンボラメ.n現在の値 > 4 && ctコンボラメ.n現在の値 < 24)
+                            {
+                                // みぎ
+                                #region[透明度制御]
+                                if (this.ctコンボラメ.n現在の値 < 11) txTaiko_Combo_Effect.Opacity = 255;
+                                else if (this.ctコンボラメ.n現在の値 >= 11 && this.ctコンボラメ.n現在の値 < 24) txTaiko_Combo_Effect.Opacity = (int)(204 - (12 * this.ctコンボラメ.n現在の値));
+                                #endregion
+                                txTaiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i) + ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1]), TJAPlayer3.Skin.Game_Taiko_Combo_Ex_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
+
+                            }
+                            if (ctコンボラメ.n現在の値 > 14)
+                            {
+                                // まんなか
+                                #region[透明度制御]
+                                if (this.ctコンボラメ.n現在の値 < 252) txTaiko_Combo_Effect.Opacity = 255;
+                                else if (this.ctコンボラメ.n現在の値 >= 22 && this.ctコンボラメ.n現在の値 < 30) txTaiko_Combo_Effect.Opacity = (int)(204 - (6 * this.ctコンボラメ.n現在の値));
+                                #endregion
+                                txTaiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i), TJAPlayer3.Skin.Game_Taiko_Combo_Ex_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[1]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
+                            }
+                        }
                     }
-                    if (TJAPlayer3.Tx.Taiko_Combo_Effect != null)
+                    else
                     {
-                        TJAPlayer3.Tx.Taiko_Combo_Effect.b加算合成 = true;
-                        if (this.ctコンボラメ.n現在の値 < 14)
+                        if (txTaiko_Combo1 != null)
                         {
-                            // ひだり
-                            #region[透明度制御]
-                            if (this.ctコンボラメ.n現在の値 < 7) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = 255;
-                            else if (this.ctコンボラメ.n現在の値 >= 7 && this.ctコンボラメ.n現在の値 < 14) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = (int)(204 - (24 * this.ctコンボラメ.n現在の値));
-                            #endregion
-                            TJAPlayer3.Tx.Taiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i) - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2]), TJAPlayer3.Skin.Game_Taiko_Combo_Ex4_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
+                            var yScalling = ComboScale_Ex[this.ctコンボ加算[nPlayer].n現在の値, 0];
+                            txTaiko_Combo1.vc拡大縮小倍率.Y = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2] + yScalling;
+                            txTaiko_Combo1.vc拡大縮小倍率.X = TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2];
+                            var yJumping = TJAPlayer3.Skin.Game_Taiko_Combo_Ex_IsJumping ? (int)ComboScale_Ex[this.ctコンボ加算[nPlayer].n現在の値, 1] : 0;
+                            txTaiko_Combo1.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[2] * i, TJAPlayer3.Skin.Game_Taiko_Combo_Ex4_Y[nPlayer] + yJumping, new Rectangle(n位の数[i] * TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0], 0, TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0], TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1]));
                         }
-                        if (ctコンボラメ.n現在の値 > 4 && ctコンボラメ.n現在の値 < 24)
+                        if (txTaiko_Combo_Effect != null)
                         {
-                            // みぎ
-                            #region[透明度制御]
-                            if (this.ctコンボラメ.n現在の値 < 11) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = 255;
-                            else if (this.ctコンボラメ.n現在の値 >= 11 && this.ctコンボラメ.n現在の値 < 24) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = (int)(204 - (12 * this.ctコンボラメ.n現在の値));
-                            #endregion
-                            TJAPlayer3.Tx.Taiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i) + ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2]), TJAPlayer3.Skin.Game_Taiko_Combo_Ex4_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
+                            txTaiko_Combo_Effect.b加算合成 = true;
+                            if (this.ctコンボラメ.n現在の値 < 14)
+                            {
+                                // ひだり
+                                #region[透明度制御]
+                                if (this.ctコンボラメ.n現在の値 < 7) txTaiko_Combo_Effect.Opacity = 255;
+                                else if (this.ctコンボラメ.n現在の値 >= 7 && this.ctコンボラメ.n現在の値 < 14) txTaiko_Combo_Effect.Opacity = (int)(204 - (24 * this.ctコンボラメ.n現在の値));
+                                #endregion
+                                txTaiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i) - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2]), TJAPlayer3.Skin.Game_Taiko_Combo_Ex4_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
+                            }
+                            if (ctコンボラメ.n現在の値 > 4 && ctコンボラメ.n現在の値 < 24)
+                            {
+                                // みぎ
+                                #region[透明度制御]
+                                if (this.ctコンボラメ.n現在の値 < 11) txTaiko_Combo_Effect.Opacity = 255;
+                                else if (this.ctコンボラメ.n現在の値 >= 11 && this.ctコンボラメ.n現在の値 < 24) txTaiko_Combo_Effect.Opacity = (int)(204 - (12 * this.ctコンボラメ.n現在の値));
+                                #endregion
+                                txTaiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i) + ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[0] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2]), TJAPlayer3.Skin.Game_Taiko_Combo_Ex4_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
 
-                        }
-                        if (ctコンボラメ.n現在の値 > 14)
-                        {
-                            // まんなか
-                            #region[透明度制御]
-                            if (this.ctコンボラメ.n現在の値 < 22) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = 255;
-                            else if (this.ctコンボラメ.n現在の値 >= 22 && this.ctコンボラメ.n現在の値 < 30) TJAPlayer3.Tx.Taiko_Combo_Effect.Opacity = (int)(204 - (6 * this.ctコンボラメ.n現在の値));
-                            #endregion
-                            TJAPlayer3.Tx.Taiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i), TJAPlayer3.Skin.Game_Taiko_Combo_Ex4_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
+                            }
+                            if (ctコンボラメ.n現在の値 > 14)
+                            {
+                                // まんなか
+                                #region[透明度制御]
+                                if (this.ctコンボラメ.n現在の値 < 22) txTaiko_Combo_Effect.Opacity = 255;
+                                else if (this.ctコンボラメ.n現在の値 >= 22 && this.ctコンボラメ.n現在の値 < 30) txTaiko_Combo_Effect.Opacity = (int)(204 - (6 * this.ctコンボラメ.n現在の値));
+                                #endregion
+                                txTaiko_Combo_Effect.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, (rightX - TJAPlayer3.Skin.Game_Taiko_Combo_Padding[1] * i), TJAPlayer3.Skin.Game_Taiko_Combo_Ex4_Y[nPlayer] - ((TJAPlayer3.Skin.Game_Taiko_Combo_Size_Ex[1] / 4) * TJAPlayer3.Skin.Game_Taiko_Combo_Scale[2]) - (int)(1.05 * this.ctコンボラメ.n現在の値));
 
+                            }
                         }
+
                     }
-
                 }
             }
 

--- a/TJAPlayer3/Stages/07.Game/CAct演奏PauseMenu.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏PauseMenu.cs
@@ -140,8 +140,8 @@ namespace TJAPlayer3
 		{
 			if ( !base.b活性化してない )
 			{
-				TJAPlayer3.tテクスチャの解放( ref this.txパネル本体 );
-				TJAPlayer3.tテクスチャの解放( ref this.tx文字列パネル );
+				TJAPlayer3.t安全にDisposeする(ref this.txパネル本体);
+				TJAPlayer3.t安全にDisposeする(ref this.tx文字列パネル);
 				base.OnManagedリソースの解放();
 			}
 		}

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -159,20 +159,22 @@ namespace TJAPlayer3
 				base.OnManagedリソースの作成();
 			}
 		}
-		public override void OnManagedリソースの解放()
-		{
-			if( !base.b活性化してない )
-			{
-				TJAPlayer3.t安全にDisposeする(ref this.txPanel);
-				TJAPlayer3.t安全にDisposeする(ref this.txMusicName);
-                TJAPlayer3.t安全にDisposeする(ref this.txGENRE);
-                TJAPlayer3.t安全にDisposeする(ref this.txPanel);
-                TJAPlayer3.t安全にDisposeする(ref this.tx歌詞テクスチャ);
-                TJAPlayer3.t安全にDisposeする(ref this.pfMusicName);
-                TJAPlayer3.t安全にDisposeする(ref this.pf歌詞フォント);
+
+        public override void OnManagedリソースの解放()
+        {
+            if (!b活性化してない)
+            {
+                TJAPlayer3.t安全にDisposeする(ref txPanel);
+                TJAPlayer3.t安全にDisposeする(ref txMusicName);
+                TJAPlayer3.t安全にDisposeする(ref txGENRE);
+                TJAPlayer3.t安全にDisposeする(ref txPanel);
+                TJAPlayer3.t安全にDisposeする(ref tx歌詞テクスチャ);
+                TJAPlayer3.t安全にDisposeする(ref pfMusicName);
+                TJAPlayer3.t安全にDisposeする(ref pf歌詞フォント);
                 base.OnManagedリソースの解放();
-			}
-		}
+            }
+        }
+
 		public override int On進行描画()
 		{
 			throw new InvalidOperationException( "t進行描画(x,y)のほうを使用してください。" );

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -30,7 +30,7 @@ namespace TJAPlayer3
 		{
 			if( base.b活性化してる )
 			{
-				TJAPlayer3.tテクスチャの解放( ref this.txPanel );
+				TJAPlayer3.t安全にDisposeする(ref this.txPanel);
 				if( (songName != null ) && (songName.Length > 0 ) )
 				{
 					try
@@ -163,11 +163,11 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-				TJAPlayer3.tテクスチャの解放( ref this.txPanel );
-				TJAPlayer3.tテクスチャの解放( ref this.txMusicName );
-                TJAPlayer3.tテクスチャの解放( ref this.txGENRE );
-                TJAPlayer3.tテクスチャの解放(ref this.txPanel);
-                TJAPlayer3.tテクスチャの解放(ref this.tx歌詞テクスチャ);
+				TJAPlayer3.t安全にDisposeする(ref this.txPanel);
+				TJAPlayer3.t安全にDisposeする(ref this.txMusicName);
+                TJAPlayer3.t安全にDisposeする(ref this.txGENRE);
+                TJAPlayer3.t安全にDisposeする(ref this.txPanel);
+                TJAPlayer3.t安全にDisposeする(ref this.tx歌詞テクスチャ);
                 TJAPlayer3.t安全にDisposeする(ref this.pfMusicName);
                 TJAPlayer3.t安全にDisposeする(ref this.pf歌詞フォント);
                 base.OnManagedリソースの解放();

--- a/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
+++ b/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
@@ -315,7 +315,7 @@ namespace TJAPlayer3
 		{
 			if ( !base.b活性化してない )
 			{
-				TJAPlayer3.tテクスチャの解放( ref this.tx背景 );
+				TJAPlayer3.t安全にDisposeする(ref this.tx背景);
                 Trace.TraceInformation("CStage演奏画面共通 リソースの開放");
                 base.OnManagedリソースの解放();
 			}

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsDancer.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsDancer.cs
@@ -53,7 +53,7 @@ namespace TJAPlayer3
 
             if (TJAPlayer3.ConfigIni.ShowDancer && this.ct踊り子モーション != null && TJAPlayer3.Skin.Game_Dancer_Ptn != 0)
             {
-                for (int i = 0; i < 5; i++)
+                for (int i = 0; i < TJAPlayer3.Tx.Dancer.Length; i++)
                 {
                     if (TJAPlayer3.Tx.Dancer[i][this.ar踊り子モーション番号[(int)this.ct踊り子モーション.db現在の値]] != null)
                     {

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMob.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMob.cs
@@ -55,10 +55,7 @@ namespace TJAPlayer3
                 {
                     if (TJAPlayer3.stage演奏ドラム画面.actGauge.db現在のゲージ値[0] >= 100)
                     {
-                        if (TJAPlayer3.Tx.Mob[(int)ctMobPtn.db現在の値] != null)
-                        {
-                            TJAPlayer3.Tx.Mob[(int)ctMobPtn.db現在の値].t2D描画(TJAPlayer3.app.Device, 0, (720 - (TJAPlayer3.Tx.Mob[0].szテクスチャサイズ.Height - 70)) + -((float)Math.Sin((float)this.ctMob.db現在の値 * (Math.PI / 180)) * 70));
-                        }
+                        TJAPlayer3.Tx.Mob[(int)ctMobPtn.db現在の値]?.t2D描画(TJAPlayer3.app.Device, 0, (720 - (TJAPlayer3.Tx.Mob[0].szテクスチャサイズ.Height - 70)) + -((float)Math.Sin((float)this.ctMob.db現在の値 * (Math.PI / 180)) * 70));
                     }
 
                 }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
@@ -147,15 +147,13 @@ namespace TJAPlayer3
 
             //if(CDTXMania.Tx.Taiko_Frame[ 0 ] != null )
                // CDTXMania.Tx.Taiko_Frame[ 0 ].t2D描画( CDTXMania.app.Device, 0, 184 );
-            if(TJAPlayer3.Tx.Taiko_Background[0] != null ) 
-                TJAPlayer3.Tx.Taiko_Background[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Background_X[0], TJAPlayer3.Skin.Game_Taiko_Background_Y[0] );
+            TJAPlayer3.Tx.Taiko_Background[0]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Background_X[0], TJAPlayer3.Skin.Game_Taiko_Background_Y[0] );
 
             if ( TJAPlayer3.stage演奏ドラム画面.bDoublePlay )
             {
                 //if(CDTXMania.Tx.Taiko_Frame[ 1 ] != null )
                     //CDTXMania.Tx.Taiko_Frame[ 1 ].t2D描画( CDTXMania.app.Device, 0, 360 );
-                if(TJAPlayer3.Tx.Taiko_Background[1] != null )
-                    TJAPlayer3.Tx.Taiko_Background[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Background_X[1], TJAPlayer3.Skin.Game_Taiko_Background_Y[1]);
+                TJAPlayer3.Tx.Taiko_Background[1]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Background_X[1], TJAPlayer3.Skin.Game_Taiko_Background_Y[1]);
             }
             
             if(TJAPlayer3.Tx.Taiko_Base != null )
@@ -293,44 +291,30 @@ namespace TJAPlayer3
                 //    else if( CDTXMania.ConfigIni.eSTEALTH == Eステルスモード.DORON )
                 //        this.txオプションパネル_特殊.t2D描画( CDTXMania.app.Device, 0, 300, new Rectangle( 0, 44, 162, 44 ) );
                 //}
-                if (TJAPlayer3.Tx.Course_Symbol[TJAPlayer3.stage選曲.n確定された曲の難易度] != null)
+                TJAPlayer3.Tx.Course_Symbol[TJAPlayer3.stage選曲.n確定された曲の難易度]?.t2D描画(TJAPlayer3.app.Device,
+                    TJAPlayer3.Skin.Game_CourseSymbol_X[i],
+                    TJAPlayer3.Skin.Game_CourseSymbol_Y[i]
+                    );
+
+                if (TJAPlayer3.ConfigIni.ShinuchiMode)
                 {
-                    TJAPlayer3.Tx.Course_Symbol[TJAPlayer3.stage選曲.n確定された曲の難易度].t2D描画(TJAPlayer3.app.Device,
+                    TJAPlayer3.Tx.Course_Symbol[(int)Difficulty.Total]?.t2D描画(TJAPlayer3.app.Device,
                         TJAPlayer3.Skin.Game_CourseSymbol_X[i],
                         TJAPlayer3.Skin.Game_CourseSymbol_Y[i]
                         );
                 }
-
-                if (TJAPlayer3.ConfigIni.ShinuchiMode)
-                {
-                    if (TJAPlayer3.Tx.Course_Symbol[(int)Difficulty.Total] != null)
-                    {
-                        TJAPlayer3.Tx.Course_Symbol[(int)Difficulty.Total].t2D描画(TJAPlayer3.app.Device,
-                            TJAPlayer3.Skin.Game_CourseSymbol_X[i],
-                            TJAPlayer3.Skin.Game_CourseSymbol_Y[i]
-                            );
-                    }
-
-                }
-
-
-            }
-            if (TJAPlayer3.Tx.Taiko_NamePlate[0] != null)
-            {
-                TJAPlayer3.Tx.Taiko_NamePlate[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_NamePlate_X[0], TJAPlayer3.Skin.Game_Taiko_NamePlate_Y[0]);
-            }
-            if(TJAPlayer3.stage演奏ドラム画面.bDoublePlay && TJAPlayer3.Tx.Taiko_NamePlate[1] != null)
-            {
-                TJAPlayer3.Tx.Taiko_NamePlate[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_NamePlate_X[1], TJAPlayer3.Skin.Game_Taiko_NamePlate_Y[1]);
             }
 
-            if (TJAPlayer3.Tx.Taiko_PlayerNumber[0] != null)
+            TJAPlayer3.Tx.Taiko_NamePlate[0]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_NamePlate_X[0], TJAPlayer3.Skin.Game_Taiko_NamePlate_Y[0]);
+            if(TJAPlayer3.stage演奏ドラム画面.bDoublePlay)
             {
-                TJAPlayer3.Tx.Taiko_PlayerNumber[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_PlayerNumber_X[0], TJAPlayer3.Skin.Game_Taiko_PlayerNumber_Y[0]);
+                TJAPlayer3.Tx.Taiko_NamePlate[1]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_NamePlate_X[1], TJAPlayer3.Skin.Game_Taiko_NamePlate_Y[1]);
             }
-            if (TJAPlayer3.stage演奏ドラム画面.bDoublePlay && TJAPlayer3.Tx.Taiko_PlayerNumber[1] != null)
+
+            TJAPlayer3.Tx.Taiko_PlayerNumber[0]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_PlayerNumber_X[0], TJAPlayer3.Skin.Game_Taiko_PlayerNumber_Y[0]);
+            if (TJAPlayer3.stage演奏ドラム画面.bDoublePlay)
             {
-                TJAPlayer3.Tx.Taiko_PlayerNumber[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_PlayerNumber_X[1], TJAPlayer3.Skin.Game_Taiko_PlayerNumber_Y[1]);
+                TJAPlayer3.Tx.Taiko_PlayerNumber[1]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_PlayerNumber_X[1], TJAPlayer3.Skin.Game_Taiko_PlayerNumber_Y[1]);
             }
 
             //if (CDTXMania.Input管理.Keyboard.bキーが押された((int)SlimDX.DirectInput.Key.V))

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
@@ -293,9 +293,9 @@ namespace TJAPlayer3
                 //    else if( CDTXMania.ConfigIni.eSTEALTH == Eステルスモード.DORON )
                 //        this.txオプションパネル_特殊.t2D描画( CDTXMania.app.Device, 0, 300, new Rectangle( 0, 44, 162, 44 ) );
                 //}
-                if (TJAPlayer3.Tx.Couse_Symbol[TJAPlayer3.stage選曲.n確定された曲の難易度] != null)
+                if (TJAPlayer3.Tx.Course_Symbol[TJAPlayer3.stage選曲.n確定された曲の難易度] != null)
                 {
-                    TJAPlayer3.Tx.Couse_Symbol[TJAPlayer3.stage選曲.n確定された曲の難易度].t2D描画(TJAPlayer3.app.Device,
+                    TJAPlayer3.Tx.Course_Symbol[TJAPlayer3.stage選曲.n確定された曲の難易度].t2D描画(TJAPlayer3.app.Device,
                         TJAPlayer3.Skin.Game_CourseSymbol_X[i],
                         TJAPlayer3.Skin.Game_CourseSymbol_Y[i]
                         );
@@ -303,9 +303,9 @@ namespace TJAPlayer3
 
                 if (TJAPlayer3.ConfigIni.ShinuchiMode)
                 {
-                    if (TJAPlayer3.Tx.Couse_Symbol[(int)Difficulty.Total] != null)
+                    if (TJAPlayer3.Tx.Course_Symbol[(int)Difficulty.Total] != null)
                     {
-                        TJAPlayer3.Tx.Couse_Symbol[(int)Difficulty.Total].t2D描画(TJAPlayer3.app.Device,
+                        TJAPlayer3.Tx.Course_Symbol[(int)Difficulty.Total].t2D描画(TJAPlayer3.app.Device,
                             TJAPlayer3.Skin.Game_CourseSymbol_X[i],
                             TJAPlayer3.Skin.Game_CourseSymbol_Y[i]
                             );

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
@@ -465,34 +465,31 @@ namespace TJAPlayer3
                 //CDTXMania.act文字コンソール.tPrint( 100, 16 * 7, C文字コンソール.Eフォント種別.白, this.st叩ききりまショー.ct加算審査中.n現在の値.ToString() );
 
                 #region[ 残り時間描画 ]
-                if(TJAPlayer3.Tx.Taiko_Combo != null )
+                if (TJAPlayer3.Tx.GameMode_Timer_Frame != null)
+                    TJAPlayer3.Tx.GameMode_Timer_Frame.t2D描画( TJAPlayer3.app.Device, 230, 84 );
+                this.st叩ききりまショー.ct針アニメ.t進行Loop();
+
+                int nCenterX = 230;
+                int nCerterY = 84;
+                float fRotate = -C変換.DegreeToRadian( 360.0f * ( this.st叩ききりまショー.ct針アニメ.n現在の値 / 1000.0f ) );
+                if( this.st叩ききりまショー.b加算アニメ中 == true )
+                    fRotate = C変換.DegreeToRadian( 360.0f * ( this.st叩ききりまショー.ct針アニメ.n現在の値 / (float)this.st叩ききりまショー.n延長アニメ速度 ) );
+
+                SlimDX.Matrix mat = SlimDX.Matrix.Identity;
+                if( this.st叩ききりまショー.b最初のチップが叩かれた )
                 {
-                    if (TJAPlayer3.Tx.GameMode_Timer_Frame != null)
-                        TJAPlayer3.Tx.GameMode_Timer_Frame.t2D描画( TJAPlayer3.app.Device, 230, 84 );
-                    this.st叩ききりまショー.ct針アニメ.t進行Loop();
-
-                    int nCenterX = 230;
-                    int nCerterY = 84;
-                    float fRotate = -C変換.DegreeToRadian( 360.0f * ( this.st叩ききりまショー.ct針アニメ.n現在の値 / 1000.0f ) );
-                    if( this.st叩ききりまショー.b加算アニメ中 == true )
-                        fRotate = C変換.DegreeToRadian( 360.0f * ( this.st叩ききりまショー.ct針アニメ.n現在の値 / (float)this.st叩ききりまショー.n延長アニメ速度 ) );
-
-                    SlimDX.Matrix mat = SlimDX.Matrix.Identity;
-                    if( this.st叩ききりまショー.b最初のチップが叩かれた )
-                    {
-                        mat *= SlimDX.Matrix.RotationZ( fRotate );
-                        mat *= SlimDX.Matrix.Translation( 280 - 640, -( 134 - 360 ), 0 );
-                    }
-                    else
-                    {
-                        mat *= SlimDX.Matrix.Translation( 280 - 640, -( 134 - 360 ), 0 );
-                    }
-
-                    TJAPlayer3.Tx.GameMode_Timer_Tick.t3D描画( TJAPlayer3.app.Device, mat );
-
-                    string str表示する残り時間 = ( this.st叩ききりまショー.ct残り時間.n現在の値 < 1000 ) ? "25" : ( ( 26000 - this.st叩ききりまショー.ct残り時間.n現在の値 ) / 1000 ).ToString();
-                    this.t小文字表示( 230 + (str表示する残り時間.Length * TJAPlayer3.Skin.Game_Taiko_Combo_Size[0] / 4 ), 84 + TJAPlayer3.Tx.GameMode_Timer_Frame.szテクスチャサイズ.Height / 2 , string.Format("{0,2:#0}", str表示する残り時間 ));
+                    mat *= SlimDX.Matrix.RotationZ( fRotate );
+                    mat *= SlimDX.Matrix.Translation( 280 - 640, -( 134 - 360 ), 0 );
                 }
+                else
+                {
+                    mat *= SlimDX.Matrix.Translation( 280 - 640, -( 134 - 360 ), 0 );
+                }
+
+                TJAPlayer3.Tx.GameMode_Timer_Tick.t3D描画( TJAPlayer3.app.Device, mat );
+
+                string str表示する残り時間 = ( this.st叩ききりまショー.ct残り時間.n現在の値 < 1000 ) ? "25" : ( ( 26000 - this.st叩ききりまショー.ct残り時間.n現在の値 ) / 1000 ).ToString();
+                this.t小文字表示( 230 + (str表示する残り時間.Length * TJAPlayer3.Skin.Game_Taiko_Combo_Size[0] / 4 ), 84 + TJAPlayer3.Tx.GameMode_Timer_Frame.szテクスチャサイズ.Height / 2 , string.Format("{0,2:#0}", str表示する残り時間 ));
 
                 if( !this.st叩ききりまショー.ct加算審査中.b停止中 )
                 {

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsチップエフェクト.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsチップエフェクト.cs
@@ -75,13 +75,11 @@ namespace TJAPlayer3
                     switch (st[i].nプレイヤー)
                     {
                         case 0:
-                            if(TJAPlayer3.Tx.Gauge_Soul_Explosion[0] != null)
-                                TJAPlayer3.Tx.Gauge_Soul_Explosion[0].t2D中心基準描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_X[0], TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_Y[0], new Rectangle(st[i].ct進行.n現在の値 * TJAPlayer3.Skin.Game_Effect_NotesFlash[0], 0, TJAPlayer3.Skin.Game_Effect_NotesFlash[0], TJAPlayer3.Skin.Game_Effect_NotesFlash[1]));
+                            TJAPlayer3.Tx.Gauge_Soul_Explosion[0]?.t2D中心基準描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_X[0], TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_Y[0], new Rectangle(st[i].ct進行.n現在の値 * TJAPlayer3.Skin.Game_Effect_NotesFlash[0], 0, TJAPlayer3.Skin.Game_Effect_NotesFlash[0], TJAPlayer3.Skin.Game_Effect_NotesFlash[1]));
                             TJAPlayer3.Tx.Notes.t2D中心基準描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_X[0], TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_Y[0], new Rectangle(st[i].Lane * 130, 0, 130, 130));
                             break;
                         case 1:
-                            if (TJAPlayer3.Tx.Gauge_Soul_Explosion[1] != null)
-                                TJAPlayer3.Tx.Gauge_Soul_Explosion[1].t2D中心基準描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_X[1], TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_Y[1], new Rectangle(st[i].ct進行.n現在の値 * TJAPlayer3.Skin.Game_Effect_NotesFlash[0], 0, TJAPlayer3.Skin.Game_Effect_NotesFlash[0], TJAPlayer3.Skin.Game_Effect_NotesFlash[1]));
+                            TJAPlayer3.Tx.Gauge_Soul_Explosion[1]?.t2D中心基準描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_X[1], TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_Y[1], new Rectangle(st[i].ct進行.n現在の値 * TJAPlayer3.Skin.Game_Effect_NotesFlash[0], 0, TJAPlayer3.Skin.Game_Effect_NotesFlash[0], TJAPlayer3.Skin.Game_Effect_NotesFlash[1]));
                             TJAPlayer3.Tx.Notes.t2D中心基準描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_X[1], TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_Y[1], new Rectangle(st[i].Lane * 130, 0, 130, 130));
                             break;
                     }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン.cs
@@ -11,7 +11,8 @@ namespace TJAPlayer3
 
         public override void On非活性化()
         {
-            TJAPlayer3.t安全にDisposeする( ref this.ct分岐アニメ進行 );
+            ct分岐アニメ進行 = null;
+
             base.On非活性化();
         }
 

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
@@ -551,17 +551,11 @@ namespace TJAPlayer3
 
 
 
-            if (TJAPlayer3.Tx.Taiko_Frame[0] != null)
-            {
-                TJAPlayer3.Tx.Taiko_Frame[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Frame_X[0], TJAPlayer3.Skin.Game_Taiko_Frame_Y[0]);
+            TJAPlayer3.Tx.Taiko_Frame[0]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Frame_X[0], TJAPlayer3.Skin.Game_Taiko_Frame_Y[0]);
 
-                if (TJAPlayer3.stage演奏ドラム画面.bDoublePlay)
-                {
-                    if(TJAPlayer3.Tx.Taiko_Frame[1] != null)
-                    {
-                        TJAPlayer3.Tx.Taiko_Frame[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Frame_X[1], TJAPlayer3.Skin.Game_Taiko_Frame_Y[1]);
-                    }
-                }
+            if (TJAPlayer3.stage演奏ドラム画面.bDoublePlay)
+            {
+                TJAPlayer3.Tx.Taiko_Frame[1]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Frame_X[1], TJAPlayer3.Skin.Game_Taiko_Frame_Y[1]);
             }
 
 

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums演奏終了演出.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums演奏終了演出.cs
@@ -240,10 +240,8 @@ namespace TJAPlayer3
                                 }
                                 else if (this.ct進行メイン.n現在の値 <= 35)
                                 {
-                                    if (TJAPlayer3.Tx.End_Clear_L[0] != null)
-                                        TJAPlayer3.Tx.End_Clear_L[0].t2D描画(TJAPlayer3.app.Device, 697 - (int)((this.ct進行メイン.n現在の値 - 12) * 10), y[i] - 30);
-                                    if (TJAPlayer3.Tx.End_Clear_R[0] != null)
-                                        TJAPlayer3.Tx.End_Clear_R[0].t2D描画(TJAPlayer3.app.Device, 738 + (int)((this.ct進行メイン.n現在の値 - 12) * 10), y[i] - 30);
+                                    TJAPlayer3.Tx.End_Clear_L[0]?.t2D描画(TJAPlayer3.app.Device, 697 - (int)((this.ct進行メイン.n現在の値 - 12) * 10), y[i] - 30);
+                                    TJAPlayer3.Tx.End_Clear_R[0]?.t2D描画(TJAPlayer3.app.Device, 738 + (int)((this.ct進行メイン.n現在の値 - 12) * 10), y[i] - 30);
                                 }
                                 else if (this.ct進行メイン.n現在の値 <= 46)
                                 {
@@ -253,38 +251,29 @@ namespace TJAPlayer3
                                         float[] fRet = new float[] { 1.0f, 0.99f, 0.98f, 0.97f, 0.96f, 0.95f, 0.96f, 0.97f, 0.98f, 0.99f, 1.0f };
                                         TJAPlayer3.Tx.End_Clear_L[0].t2D描画(TJAPlayer3.app.Device, 466, y[i] - 30);
                                         TJAPlayer3.Tx.End_Clear_L[0].vc拡大縮小倍率 = new SlimDX.Vector3(fRet[this.ct進行メイン.n現在の値 - 36], 1.0f, 1.0f);
-                                        //CDTXMania.Tx.End_Clear_R[ 0 ].t2D描画( CDTXMania.app.Device, 956 + (( this.ct進行メイン.n現在の値 - 36 ) / 2), 180 );
                                         TJAPlayer3.Tx.End_Clear_R[0].t2D描画(TJAPlayer3.app.Device, 1136 - 180 * fRet[this.ct進行メイン.n現在の値 - 36], y[i] - 30);
                                         TJAPlayer3.Tx.End_Clear_R[0].vc拡大縮小倍率 = new SlimDX.Vector3(fRet[this.ct進行メイン.n現在の値 - 36], 1.0f, 1.0f);
                                     }
                                 }
                                 else if (this.ct進行メイン.n現在の値 <= 49)
                                 {
-                                    if (TJAPlayer3.Tx.End_Clear_L[1] != null)
-                                        TJAPlayer3.Tx.End_Clear_L[1].t2D描画(TJAPlayer3.app.Device, 466, y[i] - 30);
-                                    if (TJAPlayer3.Tx.End_Clear_R[1] != null)
-                                        TJAPlayer3.Tx.End_Clear_R[1].t2D描画(TJAPlayer3.app.Device, 956, y[i] - 30);
+                                    TJAPlayer3.Tx.End_Clear_L[1]?.t2D描画(TJAPlayer3.app.Device, 466, y[i] - 30);
+                                    TJAPlayer3.Tx.End_Clear_R[1]?.t2D描画(TJAPlayer3.app.Device, 956, y[i] - 30);
                                 }
                                 else if (this.ct進行メイン.n現在の値 <= 54)
                                 {
-                                    if (TJAPlayer3.Tx.End_Clear_L[2] != null)
-                                        TJAPlayer3.Tx.End_Clear_L[2].t2D描画(TJAPlayer3.app.Device, 466, y[i] - 30);
-                                    if (TJAPlayer3.Tx.End_Clear_R[2] != null)
-                                        TJAPlayer3.Tx.End_Clear_R[2].t2D描画(TJAPlayer3.app.Device, 956, y[i] - 30);
+                                    TJAPlayer3.Tx.End_Clear_L[2]?.t2D描画(TJAPlayer3.app.Device, 466, y[i] - 30);
+                                    TJAPlayer3.Tx.End_Clear_R[2]?.t2D描画(TJAPlayer3.app.Device, 956, y[i] - 30);
                                 }
                                 else if (this.ct進行メイン.n現在の値 <= 58)
                                 {
-                                    if (TJAPlayer3.Tx.End_Clear_L[3] != null)
-                                        TJAPlayer3.Tx.End_Clear_L[3].t2D描画(TJAPlayer3.app.Device, 466, y[i] - 30);
-                                    if (TJAPlayer3.Tx.End_Clear_R[3] != null)
-                                        TJAPlayer3.Tx.End_Clear_R[3].t2D描画(TJAPlayer3.app.Device, 956, y[i] - 30);
+                                    TJAPlayer3.Tx.End_Clear_L[3]?.t2D描画(TJAPlayer3.app.Device, 466, y[i] - 30);
+                                    TJAPlayer3.Tx.End_Clear_R[3]?.t2D描画(TJAPlayer3.app.Device, 956, y[i] - 30);
                                 }
                                 else
                                 {
-                                    if (TJAPlayer3.Tx.End_Clear_L[4] != null)
-                                        TJAPlayer3.Tx.End_Clear_L[4].t2D描画(TJAPlayer3.app.Device, 466, y[i] - 30);
-                                    if (TJAPlayer3.Tx.End_Clear_R[4] != null)
-                                        TJAPlayer3.Tx.End_Clear_R[4].t2D描画(TJAPlayer3.app.Device, 956, y[i] - 30);
+                                    TJAPlayer3.Tx.End_Clear_L[4]?.t2D描画(TJAPlayer3.app.Device, 466, y[i] - 30);
+                                    TJAPlayer3.Tx.End_Clear_R[4]?.t2D描画(TJAPlayer3.app.Device, 956, y[i] - 30);
                                 }
                                 #endregion
                             }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums背景.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums背景.cs
@@ -24,12 +24,15 @@ namespace TJAPlayer3
 
         public override void On非活性化()
         {
-            TJAPlayer3.t安全にDisposeする( ref this.ct上背景FIFOタイマー );
+            ct上背景FIFOタイマー = null;
+
             for (int i = 0; i < 2; i++)
             {
                 ct上背景スクロール用タイマー[i] = null;
             }
-            TJAPlayer3.t安全にDisposeする( ref this.ct下背景スクロール用タイマー1 );
+
+            ct下背景スクロール用タイマー1 = null;
+
             base.On非活性化();
         }
 

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums風船.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums風船.cs
@@ -128,8 +128,7 @@ namespace TJAPlayer3
                 {
                     if (n残り打数[j] < n連打数)
                     {
-                        if (TJAPlayer3.Tx.Balloon_Breaking[j] != null)
-                            TJAPlayer3.Tx.Balloon_Breaking[j].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Balloon_Balloon_X[player] + (this.ct風船ふきだしアニメ.n現在の値 == 1 ? 3 : 0), TJAPlayer3.Skin.Game_Balloon_Balloon_Y[player]);
+                        TJAPlayer3.Tx.Balloon_Breaking[j]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Balloon_Balloon_X[player] + (this.ct風船ふきだしアニメ.n現在の値 == 1 ? 3 : 0), TJAPlayer3.Skin.Game_Balloon_Balloon_Y[player]);
                         break;
                     }
                 }

--- a/TJAPlayer3/Stages/07.Game/Taiko/Dan_Cert.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/Dan_Cert.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using FDK;
 using System.IO;
-using TJAPlayer3;
 
 namespace TJAPlayer3
 {
@@ -27,7 +24,7 @@ namespace TJAPlayer3
         {
             NowShowingNumber = number;
             Counter_In = new CCounter(0, 999, 1, TJAPlayer3.Timer);
-            ScreenPoint = new double[] { TJAPlayer3.Skin.Game_Lane_Background_X[0] - TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, 1280 };
+            ScreenPoint = new double[] { TJAPlayer3.Skin.Game_Lane_Background_X[0] - (TJAPlayer3.Tx.DanC_Screen?.szテクスチャサイズ.Width ?? 1280) / 2, 1280 };
             TJAPlayer3.stage演奏ドラム画面.ReSetScore(TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].ScoreInit, TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].ScoreDiff);
             IsAnimating = true;
             TJAPlayer3.stage演奏ドラム画面.actPanel.SetPanelString(TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].Title, TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].Genre, 1 + NowShowingNumber + "曲目");
@@ -484,7 +481,7 @@ namespace TJAPlayer3
                 #region 条件達成失敗の画像を描画する。
                 if (dan_C[i].GetReached())
                 {
-                    TJAPlayer3.Tx.DanC_Failed.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_DanC_X[count - 1], TJAPlayer3.Skin.Game_DanC_Y[count - 1] + TJAPlayer3.Skin.Game_DanC_Size[1] * i + (i * TJAPlayer3.Skin.Game_DanC_Padding));
+                    TJAPlayer3.Tx.DanC_Failed?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_DanC_X[count - 1], TJAPlayer3.Skin.Game_DanC_Y[count - 1] + TJAPlayer3.Skin.Game_DanC_Size[1] * i + (i * TJAPlayer3.Skin.Game_DanC_Padding));
                 }
                 #endregion
             }
@@ -500,19 +497,20 @@ namespace TJAPlayer3
         /// <param name="scaleX">拡大率X</param>
         /// <param name="scaleY">拡大率Y</param>
         /// <param name="scaleJump">アニメーション用拡大率(Yに加算される)。</param>
-        private void DrawNumber(int value, int x, int y, int padding, float scaleX = 1.0f, float scaleY = 1.0f, float scaleJump = 0.0f)
+        private static void DrawNumber(int value, int x, int y, int padding, float scaleX = 1.0f, float scaleY = 1.0f, float scaleJump = 0.0f)
         {
             var notesRemainDigit = 0;
             for (int i = value.ToString().Length; i > 0; i--)
             {
-                var number = Convert.ToInt32(value.ToString()[i - 1].ToString());
-                Rectangle rectangle = new Rectangle(TJAPlayer3.Skin.Game_DanC_Number_Size[0] * number - 1, 0, TJAPlayer3.Skin.Game_DanC_Number_Size[0], TJAPlayer3.Skin.Game_DanC_Number_Size[1]);
                 if(TJAPlayer3.Tx.DanC_Number != null)
                 {
                     TJAPlayer3.Tx.DanC_Number.vc拡大縮小倍率.X = scaleX;
                     TJAPlayer3.Tx.DanC_Number.vc拡大縮小倍率.Y = scaleY + scaleJump;
+
+                    var number = Convert.ToInt32(value.ToString()[i - 1].ToString());
+                    Rectangle rectangle = new Rectangle(TJAPlayer3.Skin.Game_DanC_Number_Size[0] * number - 1, 0, TJAPlayer3.Skin.Game_DanC_Number_Size[0], TJAPlayer3.Skin.Game_DanC_Number_Size[1]);
+                    TJAPlayer3.Tx.DanC_Number.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, x - (notesRemainDigit * padding), y, rectangle);
                 }
-                TJAPlayer3.Tx.DanC_Number?.t2D拡大率考慮下中心基準描画(TJAPlayer3.app.Device, x - (notesRemainDigit * padding), y, rectangle);
                 notesRemainDigit++;
             }
         }

--- a/TJAPlayer3/Stages/08.Result/CActResultSongBar.cs
+++ b/TJAPlayer3/Stages/08.Result/CActResultSongBar.cs
@@ -70,8 +70,8 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-                TJAPlayer3.tテクスチャの解放( ref this.txMusicName );
-                TJAPlayer3.tテクスチャの解放(ref this.txStageText);
+                TJAPlayer3.t安全にDisposeする(ref this.txMusicName);
+                TJAPlayer3.t安全にDisposeする(ref this.txStageText);
                 base.OnManagedリソースの解放();
 			}
 		}

--- a/TJAPlayer3/Stages/08.Result/CStage結果.cs
+++ b/TJAPlayer3/Stages/08.Result/CStage結果.cs
@@ -337,10 +337,7 @@ namespace TJAPlayer3
                 #region ネームプレート
                 for (int i = 0; i < TJAPlayer3.ConfigIni.nPlayerCount; i++)
                 {
-                    if (TJAPlayer3.Tx.NamePlate[i] != null)
-                    {
-                        TJAPlayer3.Tx.NamePlate[i].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_NamePlate_X[i], TJAPlayer3.Skin.Result_NamePlate_Y[i]);
-                    }
+                    TJAPlayer3.Tx.NamePlate[i]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_NamePlate_X[i], TJAPlayer3.Skin.Result_NamePlate_Y[i]);
                 }
                 #endregion
 

--- a/TJAPlayer3/Stages/CActオプションパネル.cs
+++ b/TJAPlayer3/Stages/CActオプションパネル.cs
@@ -17,7 +17,7 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-				TJAPlayer3.tテクスチャの解放( ref this.txオプションパネル );
+				TJAPlayer3.t安全にDisposeする(ref this.txオプションパネル);
 				base.On非活性化();
 			}
 		}


### PR DESCRIPTION
Many textures were being mismanaged, particularly when used but also sometimes when freed. This resulted in various crashes during general usage (but especially after switching skins) if texture files were not present as required by the code and/or the skin configuration.

From automatic error reports I suspect this happened most often during name plate customization and Dan-C play.

Null reference exceptions were a common result, but these issues are also a possible source of various uglier exception types like memory access violation (and similar) exceptions that would be thrown from deep in render code nowhere near the point of mismanagement.

Some texture management issues remain (see #42 for but one example) but this pull request should address a good number of them.