### PR TITLE
Add Japanese Language Pack (MS UI Gothic) requirement to README.md and wrapped font exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ If the information above still leaves you feeling uncomfortable, your computer o
 - .NET Framework 4.8 is required.
   - No, Mono is not supported. Mono crash reports distract from more important work like, for example, entirely removing the .NET Framework requirement by porting to .NET Core. Please stop.
 - DirectX 9c is required.
+- Japanese Language Pack installation is required.
+- Japanese System Locale is required.
 
 ### Installation
 

--- a/TJAPlayer3/Common/FontUtilities.cs
+++ b/TJAPlayer3/Common/FontUtilities.cs
@@ -23,7 +23,16 @@ namespace TJAPlayer3.Common
             {
                 Trace.TraceError(e.Message);
 
-                return new FontFamily(FallbackFontName);
+                try
+                {
+                    return new FontFamily(FallbackFontName);
+                }
+                catch (ArgumentException fallbackException)
+                {
+                    throw new ArgumentException(
+                        $"Japanese Language Pack, or manual {FallbackFontName} font family, installation is required.",
+                        fallbackException);
+                }
             }
         }
     }


### PR DESCRIPTION
With the old setup documentation lost to the sands of time, too many automatic error reports describe users encountering missing fonts. And not just missing main fonts but even missing fallback fonts.

This PR:
- Updates the README.md System Requirements to call out the need for the Japanese Language Pack
- Also adds a similar stated requirement of running in the Japanese System Culture, because why not add that while there.
- Wraps exceptions loading the MS UI Gothic fallback font with a same-typed exception whose Message specifically instructs the user of the need for the Japanese Language Pack (or manual installation of the MS UI Gothic font.)

Fixes TJAPLAYER3-2J