### PR TITLE
Consume more exception types when attempting to load private fonts (e.g. box.def fonts)

### DIFF
--- a/TJAPlayer3/Common/CPrivateFont.cs
+++ b/TJAPlayer3/Common/CPrivateFont.cs
@@ -44,11 +44,9 @@ namespace TJAPlayer3
 					this._pfc.AddFontFile(fontpath);								//PrivateFontCollectionにフォントを追加する
 					_fontfamily = _pfc.Families[0];
 				}
-				catch (System.IO.FileNotFoundException)
+				catch
 				{
 					Trace.TraceWarning($"プライベートフォントの追加に失敗しました({fontpath})。代わりに{FontUtilities.FallbackFontName}の使用を試みます。");
-					//throw new FileNotFoundException( "プライベートフォントの追加に失敗しました。({0})", Path.GetFileName( fontpath ) );
-					//return;
 					_fontfamily = null;
 				}
 			}


### PR DESCRIPTION
The pre-existing exception block in CPrivateFont.Initialize, surrounding its attempt to add a font path to a private font collection, was not catching a wide enough range of errors. This PR changes it into a catch-all so that it will continue executing in the same manner as other failures to load a specified font (e.g. a box.def-specified font)

Fixes TJAPLAYER3-1P