### PR TITLE
Fix performance panel missing texture crash and memory leak

### DIFF
--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -75,10 +75,11 @@ namespace TJAPlayer3
                             bmpDiff = pfMusicName.DrawPrivateFont(stageText, TJAPlayer3.Skin.Game_StageText_ForeColor, TJAPlayer3.Skin.Game_StageText_BackColor );
                         }
 
-					    using (bmpDiff)
-					    {
-					        this.tx難易度とステージ数 = TJAPlayer3.tテクスチャの生成( bmpDiff, false );
-					    }
+                        using (bmpDiff)
+                        {
+                            TJAPlayer3.t安全にDisposeする(ref tx難易度とステージ数);
+                            tx難易度とステージ数 = TJAPlayer3.tテクスチャの生成(bmpDiff, false);
+                        }
 					}
 					catch( CTextureCreateFailedException e )
 					{
@@ -162,6 +163,7 @@ namespace TJAPlayer3
                 TJAPlayer3.t安全にDisposeする(ref tx歌詞テクスチャ);
                 TJAPlayer3.t安全にDisposeする(ref pfMusicName);
                 TJAPlayer3.t安全にDisposeする(ref pf歌詞フォント);
+                TJAPlayer3.t安全にDisposeする(ref tx難易度とステージ数);
                 base.OnManagedリソースの解放();
             }
         }

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -277,11 +277,7 @@ namespace TJAPlayer3
                             this.tx難易度とステージ数.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - this.tx難易度とステージ数.szテクスチャサイズ.Width, TJAPlayer3.Skin.Game_MusicName_XY[1]);
                         }
                 }
-
-                //CDTXMania.act文字コンソール.tPrint( 0, 0, C文字コンソール.Eフォント種別.白, this.ct進行用.n現在の値.ToString() );
-
-				//this.txMusicName.t2D描画( CDTXMania.app.Device, 1250 - this.txMusicName.szテクスチャサイズ.Width, 14 );
-			}
+            }
 		}
 
 

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -14,7 +14,6 @@ namespace TJAPlayer3
 		public CAct演奏パネル文字列()
 		{
 			base.b活性化してない = true;
-			this.Start();
 		}
 
 
@@ -94,7 +93,6 @@ namespace TJAPlayer3
 			    this.txGENRE = genreTextureFileName == null ? null : TJAPlayer3.Tx.TxCGen(genreTextureFileName);
 
 			    this.ct進行用 = new CCounter( 0, 2000, 2, TJAPlayer3.Timer );
-				this.Start();
 			}
 		}
 
@@ -128,12 +126,6 @@ namespace TJAPlayer3
             }
         }
 
-		public void Start()
-		{
-			this.bMute = false;
-		}
-
-
 		// CActivity 実装
 
 		public override void On活性化()
@@ -143,7 +135,6 @@ namespace TJAPlayer3
 
 			this.txPanel = null;
 			this.ct進行用 = new CCounter();
-			this.Start();
             this.bFirst = true;
 			base.On活性化();
 		}
@@ -186,9 +177,14 @@ namespace TJAPlayer3
                 return;
             }
 
-			if( !base.b活性化してない && !this.bMute )
-			{
-				this.ct進行用.t進行Loop();
+            if (!base.b活性化してない)
+            {
+                if(this.b初めての進行描画)
+                {
+                    b初めての進行描画 = false;
+                }
+
+                this.ct進行用.t進行Loop();
                 if( this.bFirst )
                 {
                     this.ct進行用.n現在の値 = 300;
@@ -206,7 +202,7 @@ namespace TJAPlayer3
                         this.txMusicName.vc拡大縮小倍率.X = fRate;
                         if (TJAPlayer3.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Center)
                         {
-                            this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * fRate) / 2), TJAPlayer3.Skin.Game_MusicName_XY[1]);
+                            this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), TJAPlayer3.Skin.Game_MusicName_XY[1]);
                         }
                         else if (TJAPlayer3.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Left)
                         {
@@ -214,7 +210,7 @@ namespace TJAPlayer3
                         }
                         else
                         {
-                            this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - (this.txMusicName.szテクスチャサイズ.Width * fRate), TJAPlayer3.Skin.Game_MusicName_XY[1]);
+                            this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - (this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X), TJAPlayer3.Skin.Game_MusicName_XY[1]);
                         }
                     }
                 }
@@ -254,10 +250,6 @@ namespace TJAPlayer3
                     #endregion
                     if( this.txMusicName != null )
                     {
-                        if(this.b初めての進行描画)
-                        {
-                            b初めての進行描画 = false;
-                        }
                         if (TJAPlayer3.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Center)
                         {
                             this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), TJAPlayer3.Skin.Game_MusicName_XY[1]);
@@ -300,7 +292,6 @@ namespace TJAPlayer3
 		private CCounter ct進行用;
 
 		private CTexture txPanel;
-		private bool bMute;
         private bool bFirst;
 
         private CTexture txMusicName;

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -220,36 +220,46 @@ namespace TJAPlayer3
                 {
                     #region[ 透明度制御 ]
 
-                    if( this.ct進行用.n現在の値 < 745 )
+                    if (ct進行用.n現在の値 < 745)
                     {
-                        this.bFirst = false;
-                        this.txMusicName.Opacity = 255;
-                        if( this.txGENRE != null )
-                            this.txGENRE.Opacity = 255;
-                        this.tx難易度とステージ数.Opacity = 0;
+                        bFirst = false;
                     }
-                    else if( this.ct進行用.n現在の値 >= 745 && this.ct進行用.n現在の値 < 1000 )
+
+                    var opacity = 255;
+                    if (ct進行用.n現在の値 < 745)
                     {
-                        this.txMusicName.Opacity = 255 - ( this.ct進行用.n現在の値 - 745 );
-                        if( this.txGENRE != null )
-                            this.txGENRE.Opacity = 255 - ( this.ct進行用.n現在の値 - 745 );
-                        this.tx難易度とステージ数.Opacity = this.ct進行用.n現在の値 - 745;
+                        opacity = 255;
                     }
-                    else if( this.ct進行用.n現在の値 >= 1000 && this.ct進行用.n現在の値 <= 1745 )
+                    else if (ct進行用.n現在の値 >= 745 && ct進行用.n現在の値 < 1000)
                     {
-                        this.txMusicName.Opacity = 0;
-                        if( this.txGENRE != null )
-                            this.txGENRE.Opacity = 0;
-                        this.tx難易度とステージ数.Opacity = 255;
+                        opacity = 255 - (ct進行用.n現在の値 - 745);
                     }
-                    else if( this.ct進行用.n現在の値 >= 1745 )
+                    else if (ct進行用.n現在の値 >= 1000 && ct進行用.n現在の値 <= 1745)
                     {
-                        this.txMusicName.Opacity = this.ct進行用.n現在の値 - 1745;
-                        if( this.txGENRE != null )
-                            this.txGENRE.Opacity = this.ct進行用.n現在の値 - 1745;
-                        this.tx難易度とステージ数.Opacity = 255 - ( this.ct進行用.n現在の値 - 1745 );
+                        opacity = 0;
                     }
+                    else if (ct進行用.n現在の値 >= 1745)
+                    {
+                        opacity = ct進行用.n現在の値 - 1745;
+                    }
+
+                    if (txMusicName != null)
+                    {
+                        txMusicName.Opacity = opacity;
+                    }
+
+                    if (txGENRE != null)
+                    {
+                        txGENRE.Opacity = opacity;
+                    }
+
+                    if (tx難易度とステージ数 != null)
+                    {
+                        tx難易度とステージ数.Opacity = 255 - opacity;
+                    }
+
                     #endregion
+
                     if( this.txMusicName != null )
                     {
                         if (TJAPlayer3.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Center)

--- a/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
+++ b/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
@@ -3935,7 +3935,6 @@ namespace TJAPlayer3
 			CSound管理.rc演奏用タイマ.t再開();
 			//CDTXMania.Timer.t再開();
 			this.bPAUSE = false;								// システムがPAUSE状態だったら、強制解除
-			this.actPanel.Start();
 #endregion
 #endregion
 		}

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsDancer.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsDancer.cs
@@ -46,7 +46,7 @@ namespace TJAPlayer3
         {
             if( this.b初めての進行描画 )
             {
-                this.b初めての進行描画 = true;
+                this.b初めての進行描画 = false;
             }
 
             if (this.ct踊り子モーション != null || TJAPlayer3.Skin.Game_Dancer_Ptn != 0) this.ct踊り子モーション.t進行LoopDb();

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsDancer.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsDancer.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Drawing;
-using System.Runtime.InteropServices;
-using FDK;
+﻿using FDK;
 
 namespace TJAPlayer3
 {
@@ -35,11 +30,6 @@ namespace TJAPlayer3
             if(this.ar踊り子モーション番号 == null) ar踊り子モーション番号 = C変換.ar配列形式のstringをint配列に変換して返す("0,0");
             this.ct踊り子モーション = new CCounter(0, this.ar踊り子モーション番号.Length - 1, 0.01, CSound管理.rc演奏用タイマ);
             base.OnManagedリソースの作成();
-        }
-
-        public override void OnManagedリソースの解放()
-        {
-            base.OnManagedリソースの解放();
         }
 
         public override int On進行描画()


### PR DESCRIPTION
While investigating TJAPlayer3-11 it became apparent that CAct演奏パネル文字列 was unable to handle missing txMusicName and tx難易度とステージ数 texture files, resulting in NullReferenceException and a crash. It was also failing to properly dispose of tx難易度とステージ数 textures, resulting in an unmanaged memory leak. These issues have been fixed.

Along the way, nearby code duplication was noted and a duplication-caused bug quickly noticed, resulting in the creation of #47.