### PR TITLE
Fix song loading subtitle positioning bug (by de-duplicating left/center/right-aligned drawing code that was using "reference points")

### DIFF
--- a/FDK19/FDK19.csproj
+++ b/FDK19/FDK19.csproj
@@ -129,6 +129,8 @@
     <Compile Include="コード\04.グラフィック\CTextureAutofold.cs" />
     <Compile Include="コード\04.グラフィック\CTexture.cs" />
     <Compile Include="コード\04.グラフィック\CTextureCreateFailedException.cs" />
+    <Compile Include="コード\04.グラフィック\HorizontalReferencePoint.cs" />
+    <Compile Include="コード\04.グラフィック\VerticalReferencePoint.cs" />
     <Compile Include="コード\04.グラフィック\頂点フォーマット%28Vertex%29\PositionColoredTexturedVertex.cs" />
     <Compile Include="コード\04.グラフィック\頂点フォーマット%28Vertex%29\TransformedColoredTexturedVertex.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/FDK19/コード/01.フレームワーク/Rendering/GraphicsDeviceManager.cs
+++ b/FDK19/コード/01.フレームワーク/Rendering/GraphicsDeviceManager.cs
@@ -49,11 +49,7 @@ namespace SampleFramework
         long windowedStyle;
         bool savedTopmost;
 
-#if TEST_Direct3D9Ex
-		internal static Direct3DEx Direct3D9Object			// yyagi
-#else
 		internal static Direct3D Direct3D9Object
-#endif
 		{
             get;
             private set;
@@ -457,47 +453,14 @@ namespace SampleFramework
 			{
 				EnsureD3D9();
 
-#if TEST_Direct3D9Ex
-				// 2011.4.26 yyagi
-				// Direct3D9.DeviceExを呼ぶ際(IDirect3D9Ex::CreateDeviceExを呼ぶ際)、
-				// フルスクリーンモードで初期化する場合はDisplayModeEx(D3DDISPLAYMODEEX *pFullscreenDisplayMode)に
-				// 適切な値を設定する必要あり。
-				// 一方、ウインドウモードで初期化する場合は、D3DDISPLAYMODEEXをNULLにする必要があるが、
-				// DisplayModeExがNULL不可と定義されているため、DeviceExのoverloadの中でDisplayModeExを引数に取らないものを
-				// 使う。(DeviceEx側でD3DDISPLAYMODEEXをNULLにしてくれる)
-				// 結局、DeviceExの呼び出しの際に、フルスクリーンかどうかで場合分けが必要となる。
-				if ( CurrentSettings.Direct3D9.PresentParameters.Windowed == false )
-				{
-					DisplayModeEx fullScreenDisplayMode = new DisplayModeEx();
-					fullScreenDisplayMode.Width = CurrentSettings.Direct3D9.PresentParameters.BackBufferWidth;
-					fullScreenDisplayMode.Height = CurrentSettings.Direct3D9.PresentParameters.BackBufferHeight;
-					fullScreenDisplayMode.RefreshRate = CurrentSettings.Direct3D9.PresentParameters.FullScreenRefreshRateInHertz;
-					fullScreenDisplayMode.Format = CurrentSettings.Direct3D9.PresentParameters.BackBufferFormat;
-
-					Device = new SlimDX.Direct3D9.DeviceEx( Direct3D9Object, CurrentSettings.Direct3D9.AdapterOrdinal,
-						CurrentSettings.Direct3D9.DeviceType, game.Window.Handle,
-						CurrentSettings.Direct3D9.CreationFlags, CurrentSettings.Direct3D9.PresentParameters, fullScreenDisplayMode );
-				}
-				else
-				{
-					Device = new SlimDX.Direct3D9.DeviceEx( Direct3D9Object, CurrentSettings.Direct3D9.AdapterOrdinal,
-						CurrentSettings.Direct3D9.DeviceType, game.Window.Handle,
-						CurrentSettings.Direct3D9.CreationFlags, CurrentSettings.Direct3D9.PresentParameters );
-				}
-				Device.MaximumFrameLatency = 1;
-#else
 				Device = new DeviceCache( new SlimDX.Direct3D9.Device( Direct3D9Object, CurrentSettings.Direct3D9.AdapterOrdinal,
 					CurrentSettings.Direct3D9.DeviceType, game.Window.Handle,
 					CurrentSettings.Direct3D9.CreationFlags, CurrentSettings.Direct3D9.PresentParameters ) );
-#endif
 				if ( Result.Last == SlimDX.Direct3D9.ResultCode.DeviceLost )
 				{
 					deviceLost = true;
 					return;
 				}
-#if TEST_Direct3D9Ex
-				Device.MaximumFrameLatency = 1;			// yyagi
-#endif
 			}
 			catch( Exception e )
 			{
@@ -662,11 +625,7 @@ namespace SampleFramework
         internal static void EnsureD3D9()
         {
 			if ( Direct3D9Object == null )
-#if TEST_Direct3D9Ex
-				Direct3D9Object = new Direct3DEx();		// yyagi
-#else
 				Direct3D9Object = new Direct3D();
-#endif
         }
     }
 }

--- a/FDK19/コード/04.グラフィック/CTexture.cs
+++ b/FDK19/コード/04.グラフィック/CTexture.cs
@@ -222,9 +222,6 @@ namespace FDK
                     {
                         bitmap.Save(stream, ImageFormat.Bmp);
                         stream.Seek(0L, SeekOrigin.Begin);
-#if TEST_Direct3D9Ex
-						pool = poolvar;
-#endif
                         // 中で更にメモリ読み込みし直していて無駄なので、Streamを使うのは止めたいところ
                         this.texture = Texture.FromStream(device.UnderlyingDevice, stream, n幅, n高さ, 1, usage, format, pool, Filter.Point, Filter.None, 0);
                     }
@@ -279,9 +276,6 @@ namespace FDK
                 this.rc全画像 = new Rectangle(0, 0, this.sz画像サイズ.Width, this.sz画像サイズ.Height);
                 int colorKey = (b黒を透過する) ? unchecked((int)0xFF000000) : 0;
                 this.szテクスチャサイズ = this.t指定されたサイズを超えない最適なテクスチャサイズを返す(device, this.sz画像サイズ);
-#if TEST_Direct3D9Ex
-				pool = poolvar;
-#endif
                 //				lock ( lockobj )
                 //				{
                 //Trace.TraceInformation( "CTexture() start: " );
@@ -311,44 +305,14 @@ namespace FDK
                 this.rc全画像 = new Rectangle(0, 0, this.sz画像サイズ.Width, this.sz画像サイズ.Height);
                 int colorKey = (b黒を透過する) ? unchecked((int)0xFF000000) : 0;
                 this.szテクスチャサイズ = this.t指定されたサイズを超えない最適なテクスチャサイズを返す(device, this.sz画像サイズ);
-#if TEST_Direct3D9Ex
-				pool = poolvar;
-#endif
                 //Trace.TraceInformation( "CTExture() start: " );
                 unsafe  // Bitmapの内部データ(a8r8g8b8)を自前でゴリゴリコピーする
                 {
-                    int tw =
-#if TEST_Direct3D9Ex
-					288;		// 32の倍数にする(グラフによっては2のべき乗にしないとダメかも)
-#else
-                    this.sz画像サイズ.Width;
-#endif
-#if TEST_Direct3D9Ex
-					this.texture = new Texture( device, tw, this.sz画像サイズ.Height, 1, Usage.Dynamic, format, Pool.Default );
-#else
                     this.texture = new Texture(device.UnderlyingDevice, this.sz画像サイズ.Width, this.sz画像サイズ.Height, 1, Usage.None, format, pool);
-#endif
                     BitmapData srcBufData = bitmap.LockBits(new Rectangle(0, 0, this.sz画像サイズ.Width, this.sz画像サイズ.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
                     DataRectangle destDataRectangle = texture.LockRectangle(0, LockFlags.Discard);  // None
-#if TEST_Direct3D9Ex
-					byte[] filldata = null;
-					if ( tw > this.sz画像サイズ.Width )
-					{
-						filldata = new byte[ (tw - this.sz画像サイズ.Width) * 4 ];
-					}
-					for ( int y = 0; y < this.sz画像サイズ.Height; y++ )
-					{
-						IntPtr src_scan0 = (IntPtr) ( (Int64) srcBufData.Scan0 + y * srcBufData.Stride );
-						destDataRectangle.Data.WriteRange( src_scan0, this.sz画像サイズ.Width * 4  );
-						if ( tw > this.sz画像サイズ.Width )
-						{
-							destDataRectangle.Data.WriteRange( filldata );
-						}
-					}
-#else
                     IntPtr src_scan0 = (IntPtr)((Int64)srcBufData.Scan0);
                     destDataRectangle.Data.WriteRange(src_scan0, this.sz画像サイズ.Width * 4 * this.sz画像サイズ.Height);
-#endif
                     texture.UnlockRectangle(0);
                     bitmap.UnlockBits(srcBufData);
                 }
@@ -942,12 +906,7 @@ namespace FDK
             new TransformedColoredTexturedVertex(),
             new TransformedColoredTexturedVertex(),
         };
-        private const Pool poolvar =                                                // 2011.4.25 yyagi
-#if TEST_Direct3D9Ex
-			Pool.Default;
-#else
-            Pool.Managed;
-#endif
+        private const Pool poolvar = Pool.Managed;
         //		byte[] _txData;
 
         /// <summary>

--- a/FDK19/コード/04.グラフィック/CTexture.cs
+++ b/FDK19/コード/04.グラフィック/CTexture.cs
@@ -428,6 +428,46 @@ namespace FDK
             this.t2D拡大率考慮下中心基準描画(device, (int)x, (int)y);
         }
 
+        // TODO Funnel overloads toward this method, inline them, and then push this logic further down toward its callee
+        public void t2D描画(
+            Device device,
+            int x,
+            int y,
+            HorizontalReferencePoint horizontalReferencePoint,
+            VerticalReferencePoint verticalReferencePoint = VerticalReferencePoint.Top)
+        {
+            t2D描画(device, x + GetTruncatedOffset(horizontalReferencePoint), y + GetTruncatedOffset(verticalReferencePoint));
+        }
+
+        private int GetTruncatedOffset(HorizontalReferencePoint horizontalReferencePoint)
+        {
+            switch (horizontalReferencePoint)
+            {
+                case HorizontalReferencePoint.Center:
+                    return -(szテクスチャサイズ.Width / 2);
+                case HorizontalReferencePoint.Left:
+                    return 0;
+                case HorizontalReferencePoint.Right:
+                    return -szテクスチャサイズ.Width;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(horizontalReferencePoint), horizontalReferencePoint, null);
+            }
+        }
+
+        private int GetTruncatedOffset(VerticalReferencePoint verticalReferencePoint)
+        {
+            switch (verticalReferencePoint)
+            {
+                case VerticalReferencePoint.Center:
+                    return -(szテクスチャサイズ.Height / 2);
+                case VerticalReferencePoint.Top:
+                    return 0;
+                case VerticalReferencePoint.Bottom:
+                    return -szテクスチャサイズ.Height;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(verticalReferencePoint), verticalReferencePoint, null);
+            }
+        }
 
         /// <summary>
         /// テクスチャを 2D 画像と見なして描画する。

--- a/FDK19/コード/04.グラフィック/CTexture.cs
+++ b/FDK19/コード/04.グラフィック/CTexture.cs
@@ -386,11 +386,11 @@ namespace FDK
         /// <param name="device">Direct3D9 デバイス。</param>
         /// <param name="x">描画位置（テクスチャの左上位置の X 座標[dot]）。</param>
         /// <param name="y">描画位置（テクスチャの左上位置の Y 座標[dot]）。</param>
-        public void t2D描画(Device device, int x, int y)
+        public void t2D描画(Device device, int x, int y) // Watch out for this overload. It's one that the CTextureAf "new" methods intended to hit but which production code never called because it referenced CTexture types, not CTextureAf.
         {
             this.t2D描画(device, x, y, 1f, this.rc全画像);
         }
-        public void t2D描画(Device device, int x, int y, Rectangle rc画像内の描画領域)
+        public void t2D描画(Device device, int x, int y, Rectangle rc画像内の描画領域) // Watch out for this overload. It's one that the CTextureAf "new" methods intended to hit but which production code never called because it referenced CTexture types, not CTextureAf.
         {
             this.t2D描画(device, x, y, 1f, rc画像内の描画領域);
         }

--- a/FDK19/コード/04.グラフィック/CTexture.cs
+++ b/FDK19/コード/04.グラフィック/CTexture.cs
@@ -223,22 +223,18 @@ namespace FDK
             try
             {
                 var information = ImageInformation.FromMemory(txData);
+
                 this.Format = format;
                 this.sz画像サイズ = new Size(information.Width, information.Height);
                 this.rc全画像 = new Rectangle(0, 0, this.sz画像サイズ.Width, this.sz画像サイズ.Height);
-                int colorKey = (b黒を透過する) ? unchecked((int)0xFF000000) : 0;
                 this.szテクスチャサイズ = this.t指定されたサイズを超えない最適なテクスチャサイズを返す(device, this.sz画像サイズ);
-                //				lock ( lockobj )
-                //				{
-                //Trace.TraceInformation( "CTexture() start: " );
+
+                int colorKey = (b黒を透過する) ? unchecked((int)0xFF000000) : 0;
                 this.texture = Texture.FromMemory(device.UnderlyingDevice, txData, this.sz画像サイズ.Width, this.sz画像サイズ.Height, 1, Usage.None, format, pool, Filter.Point, Filter.None, colorKey);
-                //Trace.TraceInformation( "CTexture() end:   " );
-                //				}
             }
             catch
             {
                 this.Dispose();
-                // throw new CTextureCreateFailedException( string.Format( "テクスチャの生成に失敗しました。\n{0}", strファイル名 ) );
                 throw new CTextureCreateFailedException(string.Format("テクスチャの生成に失敗しました。\n"));
             }
         }

--- a/FDK19/コード/04.グラフィック/CTexture.cs
+++ b/FDK19/コード/04.グラフィック/CTexture.cs
@@ -367,26 +367,19 @@ namespace FDK
         // Rectangleを使う場合、座標調整のためにテクスチャサイズの値をそのまま使うとまずいことになるため、Rectragleから幅を取得して調整をする。
         public void t2D中心基準描画(Device device, int x, int y)
         {
-            this.t2D描画(device, x - (this.szテクスチャサイズ.Width / 2), y - (this.szテクスチャサイズ.Height / 2), 1f, this.rc全画像);
+            this.t2D描画(device, x, y, HorizontalReferencePoint.Center, VerticalReferencePoint.Center);
         }
+
         public void t2D中心基準描画(Device device, int x, int y, Rectangle rc画像内の描画領域)
         {
             this.t2D描画(device, x - (rc画像内の描画領域.Width / 2), y - (rc画像内の描画領域.Height / 2), 1f, rc画像内の描画領域);
         }
-        public void t2D中心基準描画(Device device, float x, float y)
-        {
-            this.t2D描画(device, (int)x - (this.szテクスチャサイズ.Width / 2), (int)y - (this.szテクスチャサイズ.Height / 2), 1f, this.rc全画像);
-        }
+
         public void t2D中心基準描画(Device device, float x, float y, float depth, Rectangle rc画像内の描画領域)
         {
             this.t2D描画(device, (int)x - (rc画像内の描画領域.Width / 2), (int)y - (rc画像内の描画領域.Height / 2), depth, rc画像内の描画領域);
         }
 
-        // 下を基準にして描画する(拡大率考慮)メソッドを追加。 (AioiLight)
-        public void t2D拡大率考慮下基準描画(Device device, int x, int y)
-        {
-            this.t2D描画(device, x, y - (szテクスチャサイズ.Height * this.vc拡大縮小倍率.Y), 1f, this.rc全画像);
-        }
         public void t2D拡大率考慮下基準描画(Device device, int x, int y, Rectangle rc画像内の描画領域)
         {
             this.t2D描画(device, x, y - (rc画像内の描画領域.Height * this.vc拡大縮小倍率.Y), 1f, rc画像内の描画領域);
@@ -404,31 +397,23 @@ namespace FDK
         {
             this.t2D描画(device, x - ((rc画像内の描画領域.Width / 2)), y - (rc画像内の描画領域.Height * this.vc拡大縮小倍率.Y), 1f, rc画像内の描画領域);
         }
-        public void t2D拡大率考慮下中心基準描画(Device device, float x, float y, Rectangle rc画像内の描画領域)
-        {
-            this.t2D拡大率考慮下中心基準描画(device, (int)x, (int)y, rc画像内の描画領域);
-        }
+
         public void t2D下中央基準描画(Device device, int x, int y)
         {
-            this.t2D描画(device, x - (this.szテクスチャサイズ.Width / 2), y - (szテクスチャサイズ.Height), this.rc全画像);
+            this.t2D描画(device, x, y, HorizontalReferencePoint.Center, VerticalReferencePoint.Bottom);
         }
+
         public void t2D下中央基準描画(Device device, int x, int y, Rectangle rc画像内の描画領域)
         {
             this.t2D描画(device, x - (rc画像内の描画領域.Width / 2), y - (rc画像内の描画領域.Height), rc画像内の描画領域);
-            //this.t2D描画(devicek x, y, rc画像内の描画領域;
         }
-
 
         public void t2D拡大率考慮中央基準描画(Device device, int x, int y)
         {
             this.t2D描画(device, x - (this.szテクスチャサイズ.Width / 2 * this.vc拡大縮小倍率.X), y - (szテクスチャサイズ.Height / 2 * this.vc拡大縮小倍率.Y), 1f, this.rc全画像);
         }
-        public void t2D拡大率考慮中央基準描画(Device device, float x, float y)
-        {
-            this.t2D拡大率考慮下中心基準描画(device, (int)x, (int)y);
-        }
 
-        // TODO Funnel overloads toward this method, inline them, and then push this logic further down toward its callee
+        // TODO Funnel overloads toward these two methods, inline the overloads, and then push this logic further down toward its lower-level callee
         public void t2D描画(
             Device device,
             int x,
@@ -436,7 +421,18 @@ namespace FDK
             HorizontalReferencePoint horizontalReferencePoint,
             VerticalReferencePoint verticalReferencePoint = VerticalReferencePoint.Top)
         {
-            t2D描画(device, x + GetTruncatedOffset(horizontalReferencePoint), y + GetTruncatedOffset(verticalReferencePoint));
+            t2D描画(device, x, y, rc全画像, horizontalReferencePoint, verticalReferencePoint);
+        }
+
+        public void t2D描画(
+            Device device,
+            int x,
+            int y,
+            Rectangle rc画像内の描画領域,
+            HorizontalReferencePoint horizontalReferencePoint,
+            VerticalReferencePoint verticalReferencePoint = VerticalReferencePoint.Top)
+        {
+            t2D描画(device, x + GetTruncatedOffset(horizontalReferencePoint), y + GetTruncatedOffset(verticalReferencePoint), 1f, rc画像内の描画領域);
         }
 
         private int GetTruncatedOffset(HorizontalReferencePoint horizontalReferencePoint)

--- a/FDK19/コード/04.グラフィック/CTexture.cs
+++ b/FDK19/コード/04.グラフィック/CTexture.cs
@@ -328,7 +328,6 @@ namespace FDK
             this.t2D描画(device, x - (this.szテクスチャサイズ.Width / 2 * this.vc拡大縮小倍率.X), y - (szテクスチャサイズ.Height / 2 * this.vc拡大縮小倍率.Y), 1f, this.rc全画像);
         }
 
-        // TODO Funnel overloads toward these two methods, inline the overloads, and then push this logic further down toward its lower-level callee
         public void t2D描画(
             Device device,
             int x,
@@ -339,6 +338,7 @@ namespace FDK
             t2D描画(device, x, y, rc全画像, horizontalReferencePoint, verticalReferencePoint);
         }
 
+        // TODO Funnel overloads toward these this method, inline the overloads, and then push this logic further down toward its lower-level callee
         private void t2D描画(
             Device device,
             int x,

--- a/FDK19/コード/04.グラフィック/CTextureAutofold.cs
+++ b/FDK19/コード/04.グラフィック/CTextureAutofold.cs
@@ -44,15 +44,12 @@ namespace FDK
 		/// <param name="b黒を透過する">画像の黒（0xFFFFFFFF）を透過させるなら true。</param>
 		/// <param name="pool">テクスチャの管理方法。</param>
 		/// <exception cref="CTextureCreateFailedException">テクスチャの作成に失敗しました。</exception>
-		public CTextureAf( Device device, string strファイル名, Format format, bool b黒を透過する, Pool pool )
+        private CTextureAf( Device device, string strファイル名, Format format, bool b黒を透過する, Pool pool )
 		{
 			MakeTexture( device, strファイル名, format, b黒を透過する, pool );
 		}
 
-
-
-
-		public new void MakeTexture( Device device, string strファイル名, Format format, bool b黒を透過する, Pool pool )
+        private new void MakeTexture( Device device, string strファイル名, Format format, bool b黒を透過する, Pool pool )
 		{
 			if ( !File.Exists( strファイル名 ) )		// #27122 2012.1.13 from: ImageInformation では FileNotFound 例外は返ってこないので、ここで自分でチェックする。わかりやすいログのために。
 				throw new FileNotFoundException( string.Format( "ファイルが存在しません。\n[{0}]", strファイル名 ) );

--- a/FDK19/コード/04.グラフィック/HorizontalReferencePoint.cs
+++ b/FDK19/コード/04.グラフィック/HorizontalReferencePoint.cs
@@ -1,0 +1,9 @@
+﻿namespace FDK
+{
+    public enum HorizontalReferencePoint
+    {
+        Center,
+        Left,
+        Right
+    }
+}

--- a/FDK19/コード/04.グラフィック/VerticalReferencePoint.cs
+++ b/FDK19/コード/04.グラフィック/VerticalReferencePoint.cs
@@ -1,0 +1,9 @@
+﻿namespace FDK
+{
+    public enum VerticalReferencePoint
+    {
+        Center,
+        Top,
+        Bottom
+    }
+}

--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -1111,17 +1111,17 @@ namespace TJAPlayer3
                                 if (int.Parse(strParam) > 0)
                                     SongLoading_SubTitle_FontSize = int.Parse(strParam);
                             }
-                            else if (strCommand == nameof(SongLoading_Plate_ReferencePoint))
+                            else if (strCommand == nameof(SongLoadingPlateHorizontalReferencePoint))
                             {
-                                SongLoading_Plate_ReferencePoint = (ReferencePoint)int.Parse(strParam);
+                                SongLoadingPlateHorizontalReferencePoint = (HorizontalReferencePoint)int.Parse(strParam);
                             }
-                            else if (strCommand == nameof(SongLoading_Title_ReferencePoint))
+                            else if (strCommand == nameof(SongLoadingTitleHorizontalReferencePoint))
                             {
-                                SongLoading_Title_ReferencePoint = (ReferencePoint)int.Parse(strParam);
+                                SongLoadingTitleHorizontalReferencePoint = (HorizontalReferencePoint)int.Parse(strParam);
                             }
-                            else if (strCommand == nameof(SongLoading_SubTitle_ReferencePoint))
+                            else if (strCommand == nameof(SongLoadingSubTitleHorizontalReferencePoint))
                             {
-                                SongLoading_SubTitle_ReferencePoint = (ReferencePoint)int.Parse(strParam);
+                                SongLoadingSubTitleHorizontalReferencePoint = (HorizontalReferencePoint)int.Parse(strParam);
                             }
 
                             else if (strCommand == nameof(SongLoading_Title_ForeColor))
@@ -1199,9 +1199,9 @@ namespace TJAPlayer3
                                 if (int.Parse(strParam) > 0)
                                     Game_MusicName_FontSize = int.Parse(strParam);
                             }
-                            else if (strCommand == nameof(Game_MusicName_ReferencePoint))
+                            else if (strCommand == nameof(GameMusicNameHorizontalReferencePoint))
                             {
-                                Game_MusicName_ReferencePoint = (ReferencePoint)int.Parse(strParam);
+                                GameMusicNameHorizontalReferencePoint = (HorizontalReferencePoint)int.Parse(strParam);
                             }
                             else if (strCommand == nameof(Game_Genre_XY))
                             {
@@ -1220,9 +1220,9 @@ namespace TJAPlayer3
                                 if (int.Parse(strParam) > 0)
                                     Game_Lyric_FontSize = int.Parse(strParam);
                             }
-                            else if (strCommand == nameof(Game_Lyric_ReferencePoint))
+                            else if (strCommand == nameof(GameLyricHorizontalReferencePoint))
                             {
-                                Game_Lyric_ReferencePoint = (ReferencePoint)int.Parse(strParam);
+                                GameLyricHorizontalReferencePoint = (HorizontalReferencePoint)int.Parse(strParam);
                             }
 
                             else if (strCommand == nameof(Game_MusicName_ForeColor))
@@ -2176,9 +2176,9 @@ namespace TJAPlayer3
                                 if (int.Parse(strParam) > 0)
                                     Result_MusicName_FontSize = int.Parse(strParam);
                             }
-                            else if (strCommand == nameof(Result_MusicName_ReferencePoint))
+                            else if (strCommand == nameof(ResultMusicNameHorizontalReferencePoint))
                             {
-                                Result_MusicName_ReferencePoint = (ReferencePoint)int.Parse(strParam);
+                                ResultMusicNameHorizontalReferencePoint = (HorizontalReferencePoint)int.Parse(strParam);
                             }
                             else if (strCommand == nameof(Result_StageText_XY))
                             {
@@ -2189,9 +2189,9 @@ namespace TJAPlayer3
                                 if (int.Parse(strParam) > 0)
                                     Result_StageText_FontSize = int.Parse(strParam);
                             }
-                            else if (strCommand == nameof(Result_StageText_ReferencePoint))
+                            else if (strCommand == nameof(ResultStageTextHorizontalReferencePoint))
                             {
-                                Result_StageText_ReferencePoint = (ReferencePoint)int.Parse(strParam);
+                                ResultStageTextHorizontalReferencePoint = (HorizontalReferencePoint)int.Parse(strParam);
                             }
 
                             else if (strCommand == nameof(Result_MusicName_ForeColor))
@@ -2382,12 +2382,6 @@ namespace TJAPlayer3
             All, // 旧筐体(旧作含む)
             WithoutStart // 新筐体
         }
-        public enum ReferencePoint //テクスチャ描画の基準点を変更可能にするための値(rhimm)
-        {
-            Center,
-            Left,
-            Right
-        }
 
         #region 新・SkinConfig
         #region General
@@ -2446,9 +2440,9 @@ namespace TJAPlayer3
         public int[] SongLoading_SubTitle_XY = new int[] { 640, 390 };
         public int SongLoading_Title_FontSize = 30;
         public int SongLoading_SubTitle_FontSize = 22;
-        public ReferencePoint SongLoading_Plate_ReferencePoint = ReferencePoint.Center;
-        public ReferencePoint SongLoading_Title_ReferencePoint = ReferencePoint.Center;
-        public ReferencePoint SongLoading_SubTitle_ReferencePoint = ReferencePoint.Center;
+        public HorizontalReferencePoint SongLoadingPlateHorizontalReferencePoint = HorizontalReferencePoint.Center;
+        public HorizontalReferencePoint SongLoadingTitleHorizontalReferencePoint = HorizontalReferencePoint.Center;
+        public HorizontalReferencePoint SongLoadingSubTitleHorizontalReferencePoint = HorizontalReferencePoint.Center;
         public Color SongLoading_Title_ForeColor = ColorTranslator.FromHtml("#FFFFFF");
         public Color SongLoading_Title_BackColor = ColorTranslator.FromHtml("#000000");
         public Color SongLoading_SubTitle_ForeColor = ColorTranslator.FromHtml("#FFFFFF");
@@ -2512,10 +2506,10 @@ namespace TJAPlayer3
         public int[] Game_Genre_XY = new int[] { 1114, 74 };
         public int[] Game_Lyric_XY = new int[] { 640, 630 };
         public int Game_MusicName_FontSize = 30;
-        public ReferencePoint Game_MusicName_ReferencePoint = ReferencePoint.Right;
+        public HorizontalReferencePoint GameMusicNameHorizontalReferencePoint = HorizontalReferencePoint.Right;
         public string Game_Lyric_FontName = FontUtilities.FallbackFontName;
         public int Game_Lyric_FontSize = 38;
-        public ReferencePoint Game_Lyric_ReferencePoint = ReferencePoint.Center;
+        public HorizontalReferencePoint GameLyricHorizontalReferencePoint = HorizontalReferencePoint.Center;
 
         public Color Game_MusicName_ForeColor = ColorTranslator.FromHtml("#FFFFFF");
         public Color Game_StageText_ForeColor = ColorTranslator.FromHtml("#FFFFFF");
@@ -2700,10 +2694,10 @@ namespace TJAPlayer3
         #region Result
         public int[] Result_MusicName_XY = new int[] { 1254, 6 };
         public int Result_MusicName_FontSize = 30;
-        public ReferencePoint Result_MusicName_ReferencePoint = ReferencePoint.Right;
+        public HorizontalReferencePoint ResultMusicNameHorizontalReferencePoint = HorizontalReferencePoint.Right;
         public int[] Result_StageText_XY = new int[] { 230, 6 };
         public int Result_StageText_FontSize = 30;
-        public ReferencePoint Result_StageText_ReferencePoint = ReferencePoint.Left;
+        public HorizontalReferencePoint ResultStageTextHorizontalReferencePoint = HorizontalReferencePoint.Left;
 
         public Color Result_MusicName_ForeColor = ColorTranslator.FromHtml("#FFFFFF");
         public Color Result_StageText_ForeColor = ColorTranslator.FromHtml("#FFFFFF");

--- a/TJAPlayer3/Common/TJAPlayer3.cs
+++ b/TJAPlayer3/Common/TJAPlayer3.cs
@@ -1330,7 +1330,8 @@ for (int i = 0; i < 3; i++) {
 		{
 			return tテクスチャの生成Af( fileName, false );
 		}
-		public static CTextureAf tテクスチャの生成Af( string fileName, bool b黒を透過する )
+
+        private static CTextureAf tテクスチャの生成Af( string fileName, bool b黒を透過する )
 		{
 			if ( app == null )
 			{

--- a/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
+++ b/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
@@ -247,34 +247,12 @@ namespace TJAPlayer3
                 int nサブタイトル補正 = string.IsNullOrEmpty(TJAPlayer3.stage選曲.r確定されたスコア.譜面情報.strサブタイトル) ? 15 : 0;
 
                 this.txタイトル.Opacity = C変換.nParsentTo255( ( this.ct曲名表示.n現在の値 / 30.0 ) );
-                if(TJAPlayer3.Skin.SongLoadingTitleHorizontalReferencePoint == HorizontalReferencePoint.Left)
-                {
-                    this.txタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_Title_XY[0], TJAPlayer3.Skin.SongLoading_Title_XY[1] - (this.txタイトル.sz画像サイズ.Height / 2) + nサブタイトル補正);
-                }
-                else if(TJAPlayer3.Skin.SongLoadingTitleHorizontalReferencePoint == HorizontalReferencePoint.Right)
-                {
-                    this.txタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_Title_XY[0] - (this.txタイトル.sz画像サイズ.Width * txタイトル.vc拡大縮小倍率.X), TJAPlayer3.Skin.SongLoading_Title_XY[1] - (this.txタイトル.sz画像サイズ.Height / 2) + nサブタイトル補正);
-                }
-                else
-                {
-                    this.txタイトル.t2D描画(TJAPlayer3.app.Device, (TJAPlayer3.Skin.SongLoading_Title_XY[0] - ((this.txタイトル.sz画像サイズ.Width * txタイトル.vc拡大縮小倍率.X) / 2)), TJAPlayer3.Skin.SongLoading_Title_XY[1] - (this.txタイトル.sz画像サイズ.Height / 2) + nサブタイトル補正);
-                }
+                this.txタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_Title_XY[0], TJAPlayer3.Skin.SongLoading_Title_XY[1] + nサブタイトル補正, TJAPlayer3.Skin.SongLoadingTitleHorizontalReferencePoint, VerticalReferencePoint.Center);
             }
 			if( this.txサブタイトル != null )
 			{
                 this.txサブタイトル.Opacity = C変換.nParsentTo255( ( this.ct曲名表示.n現在の値 / 30.0 ) );
-                if(TJAPlayer3.Skin.SongLoadingSubTitleHorizontalReferencePoint == HorizontalReferencePoint.Left)
-                {
-                    this.txサブタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_SubTitle_XY[0], TJAPlayer3.Skin.SongLoading_SubTitle_XY[1] - (this.txサブタイトル.sz画像サイズ.Height / 2));
-                }
-                else if(TJAPlayer3.Skin.SongLoadingTitleHorizontalReferencePoint == HorizontalReferencePoint.Right)
-                {
-                    this.txサブタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_SubTitle_XY[0] - (this.txサブタイトル.sz画像サイズ.Width * txサブタイトル.vc拡大縮小倍率.X), TJAPlayer3.Skin.SongLoading_SubTitle_XY[1] - (this.txサブタイトル.sz画像サイズ.Height / 2));
-                }
-                else
-                {
-                    this.txサブタイトル.t2D描画(TJAPlayer3.app.Device, (TJAPlayer3.Skin.SongLoading_SubTitle_XY[0] - ((this.txサブタイトル.sz画像サイズ.Width * txサブタイトル.vc拡大縮小倍率.X) / 2)), TJAPlayer3.Skin.SongLoading_SubTitle_XY[1] - (this.txサブタイトル.sz画像サイズ.Height / 2));
-                }
+                this.txサブタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_SubTitle_XY[0], TJAPlayer3.Skin.SongLoading_SubTitle_XY[1], TJAPlayer3.Skin.SongLoadingSubTitleHorizontalReferencePoint, VerticalReferencePoint.Center);
             }
 			//-----------------------------
 			#endregion

--- a/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
+++ b/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
@@ -238,11 +238,11 @@ namespace TJAPlayer3
             {
                 TJAPlayer3.Tx.SongLoading_Plate.bスクリーン合成 = TJAPlayer3.Skin.SongLoading_Plate_ScreenBlend; //あまりにも出番が無い
                 TJAPlayer3.Tx.SongLoading_Plate.Opacity = C変換.nParsentTo255((this.ct曲名表示.n現在の値 / 30.0));
-                if(TJAPlayer3.Skin.SongLoading_Plate_ReferencePoint == CSkin.ReferencePoint.Left)
+                if(TJAPlayer3.Skin.SongLoadingPlateHorizontalReferencePoint == HorizontalReferencePoint.Left)
                 {
                     TJAPlayer3.Tx.SongLoading_Plate.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_Plate_XY[0], TJAPlayer3.Skin.SongLoading_Plate_XY[1] - (TJAPlayer3.Tx.SongLoading_Plate.sz画像サイズ.Height / 2));
                 }
-                else if(TJAPlayer3.Skin.SongLoading_Plate_ReferencePoint == CSkin.ReferencePoint.Right)
+                else if(TJAPlayer3.Skin.SongLoadingPlateHorizontalReferencePoint == HorizontalReferencePoint.Right)
                 {
                     TJAPlayer3.Tx.SongLoading_Plate.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_Plate_XY[0] - TJAPlayer3.Tx.SongLoading_Plate.sz画像サイズ.Width, TJAPlayer3.Skin.SongLoading_Plate_XY[1] - (TJAPlayer3.Tx.SongLoading_Plate.sz画像サイズ.Height / 2));
                 }
@@ -260,11 +260,11 @@ namespace TJAPlayer3
                 int nサブタイトル補正 = string.IsNullOrEmpty(TJAPlayer3.stage選曲.r確定されたスコア.譜面情報.strサブタイトル) ? 15 : 0;
 
                 this.txタイトル.Opacity = C変換.nParsentTo255( ( this.ct曲名表示.n現在の値 / 30.0 ) );
-                if(TJAPlayer3.Skin.SongLoading_Title_ReferencePoint == CSkin.ReferencePoint.Left)
+                if(TJAPlayer3.Skin.SongLoadingTitleHorizontalReferencePoint == HorizontalReferencePoint.Left)
                 {
                     this.txタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_Title_XY[0], TJAPlayer3.Skin.SongLoading_Title_XY[1] - (this.txタイトル.sz画像サイズ.Height / 2) + nサブタイトル補正);
                 }
-                else if(TJAPlayer3.Skin.SongLoading_Title_ReferencePoint == CSkin.ReferencePoint.Right)
+                else if(TJAPlayer3.Skin.SongLoadingTitleHorizontalReferencePoint == HorizontalReferencePoint.Right)
                 {
                     this.txタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_Title_XY[0] - (this.txタイトル.sz画像サイズ.Width * txタイトル.vc拡大縮小倍率.X), TJAPlayer3.Skin.SongLoading_Title_XY[1] - (this.txタイトル.sz画像サイズ.Height / 2) + nサブタイトル補正);
                 }
@@ -276,11 +276,11 @@ namespace TJAPlayer3
 			if( this.txサブタイトル != null )
 			{
                 this.txサブタイトル.Opacity = C変換.nParsentTo255( ( this.ct曲名表示.n現在の値 / 30.0 ) );
-                if(TJAPlayer3.Skin.SongLoading_SubTitle_ReferencePoint == CSkin.ReferencePoint.Left)
+                if(TJAPlayer3.Skin.SongLoadingSubTitleHorizontalReferencePoint == HorizontalReferencePoint.Left)
                 {
                     this.txサブタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_SubTitle_XY[0], TJAPlayer3.Skin.SongLoading_SubTitle_XY[1] - (this.txサブタイトル.sz画像サイズ.Height / 2));
                 }
-                else if(TJAPlayer3.Skin.SongLoading_Title_ReferencePoint == CSkin.ReferencePoint.Right)
+                else if(TJAPlayer3.Skin.SongLoadingTitleHorizontalReferencePoint == HorizontalReferencePoint.Right)
                 {
                     this.txサブタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_SubTitle_XY[0] - (this.txサブタイトル.sz画像サイズ.Width * txサブタイトル.vc拡大縮小倍率.X), TJAPlayer3.Skin.SongLoading_SubTitle_XY[1] - (this.txサブタイトル.sz画像サイズ.Height / 2));
                 }

--- a/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
+++ b/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
@@ -282,7 +282,7 @@ namespace TJAPlayer3
                 }
                 else if(TJAPlayer3.Skin.SongLoading_Title_ReferencePoint == CSkin.ReferencePoint.Right)
                 {
-                    this.txサブタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_SubTitle_XY[0] - (this.txサブタイトル.sz画像サイズ.Width * txタイトル.vc拡大縮小倍率.X), TJAPlayer3.Skin.SongLoading_SubTitle_XY[1] - (this.txサブタイトル.sz画像サイズ.Height / 2));
+                    this.txサブタイトル.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_SubTitle_XY[0] - (this.txサブタイトル.sz画像サイズ.Width * txサブタイトル.vc拡大縮小倍率.X), TJAPlayer3.Skin.SongLoading_SubTitle_XY[1] - (this.txサブタイトル.sz画像サイズ.Height / 2));
                 }
                 else
                 {

--- a/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
+++ b/TJAPlayer3/Stages/06.SongLoading/CStage曲読み込み.cs
@@ -232,26 +232,13 @@ namespace TJAPlayer3
             this.ct曲名表示.t進行();
 			if( this.tx背景 != null )
 				this.tx背景.t2D描画( TJAPlayer3.app.Device, 0, 0 );
-            //CDTXMania.act文字コンソール.tPrint( 0, 0, C文字コンソール.Eフォント種別.灰, this.ct曲名表示.n現在の値.ToString() );
 
             if (TJAPlayer3.Tx.SongLoading_Plate != null)
             {
                 TJAPlayer3.Tx.SongLoading_Plate.bスクリーン合成 = TJAPlayer3.Skin.SongLoading_Plate_ScreenBlend; //あまりにも出番が無い
                 TJAPlayer3.Tx.SongLoading_Plate.Opacity = C変換.nParsentTo255((this.ct曲名表示.n現在の値 / 30.0));
-                if(TJAPlayer3.Skin.SongLoadingPlateHorizontalReferencePoint == HorizontalReferencePoint.Left)
-                {
-                    TJAPlayer3.Tx.SongLoading_Plate.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_Plate_XY[0], TJAPlayer3.Skin.SongLoading_Plate_XY[1] - (TJAPlayer3.Tx.SongLoading_Plate.sz画像サイズ.Height / 2));
-                }
-                else if(TJAPlayer3.Skin.SongLoadingPlateHorizontalReferencePoint == HorizontalReferencePoint.Right)
-                {
-                    TJAPlayer3.Tx.SongLoading_Plate.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_Plate_XY[0] - TJAPlayer3.Tx.SongLoading_Plate.sz画像サイズ.Width, TJAPlayer3.Skin.SongLoading_Plate_XY[1] - (TJAPlayer3.Tx.SongLoading_Plate.sz画像サイズ.Height / 2));
-                }
-                else
-                {
-                TJAPlayer3.Tx.SongLoading_Plate.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_Plate_XY[0] - (TJAPlayer3.Tx.SongLoading_Plate.sz画像サイズ.Width / 2), TJAPlayer3.Skin.SongLoading_Plate_XY[1] - (TJAPlayer3.Tx.SongLoading_Plate.sz画像サイズ.Height / 2));
-                }
+                TJAPlayer3.Tx.SongLoading_Plate.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongLoading_Plate_XY[0], TJAPlayer3.Skin.SongLoading_Plate_XY[1], TJAPlayer3.Skin.SongLoadingPlateHorizontalReferencePoint, VerticalReferencePoint.Center);
             }
-            //CDTXMania.act文字コンソール.tPrint( 0, 16, C文字コンソール.Eフォント種別.灰, C変換.nParsentTo255( ( this.ct曲名表示.n現在の値 / 30.0 ) ).ToString() );
 
 
 			int y = 720 - 45;

--- a/TJAPlayer3/Stages/07.Game/CAct演奏AVI.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏AVI.cs
@@ -542,12 +542,8 @@ namespace TJAPlayer3
 		{
 			if ( !base.b活性化してない )
 			{
-#if TEST_Direct3D9Ex
-				this.tx描画用 = new CTexture( CDTXMania.app.Device, 320, 355, CDTXMania.app.GraphicsDeviceManager.CurrentSettings.BackBufferFormat, Pool.Default, Usage.Dynamic );
-#else
 				this.tx描画用 = new CTexture( TJAPlayer3.app.Device, 1280, 720, TJAPlayer3.app.GraphicsDeviceManager.CurrentSettings.BackBufferFormat, Pool.Managed );
 				this.tx窓描画用 = new CTexture( TJAPlayer3.app.Device, 1280, 720, TJAPlayer3.app.GraphicsDeviceManager.CurrentSettings.BackBufferFormat, Pool.Managed );
-#endif
 				base.OnManagedリソースの作成();
 			}
 		}

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -112,11 +112,11 @@ namespace TJAPlayer3
         {
             if( this.tx歌詞テクスチャ != null )
             {
-                if (TJAPlayer3.Skin.Game_Lyric_ReferencePoint == CSkin.ReferencePoint.Left)
+                if (TJAPlayer3.Skin.GameLyricHorizontalReferencePoint == HorizontalReferencePoint.Left)
                 {
                 this.tx歌詞テクスチャ.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lyric_XY[0] , TJAPlayer3.Skin.Game_Lyric_XY[1]);
                 }
-                else if (TJAPlayer3.Skin.Game_Lyric_ReferencePoint == CSkin.ReferencePoint.Right)
+                else if (TJAPlayer3.Skin.GameLyricHorizontalReferencePoint == HorizontalReferencePoint.Right)
                 {
                 this.tx歌詞テクスチャ.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lyric_XY[0] - this.tx歌詞テクスチャ.szテクスチャサイズ.Width, TJAPlayer3.Skin.Game_Lyric_XY[1]);
                 }
@@ -202,11 +202,11 @@ namespace TJAPlayer3
                         if (this.txMusicName.szテクスチャサイズ.Width <= 660.0f)
                             fRate = 1.0f;
                         this.txMusicName.vc拡大縮小倍率.X = fRate;
-                        if (TJAPlayer3.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Center)
+                        if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Center)
                         {
                             this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), TJAPlayer3.Skin.Game_MusicName_XY[1]);
                         }
-                        else if (TJAPlayer3.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Left)
+                        else if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Left)
                         {
                             this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0], TJAPlayer3.Skin.Game_MusicName_XY[1]);
                         }
@@ -262,11 +262,11 @@ namespace TJAPlayer3
 
                     if( this.txMusicName != null )
                     {
-                        if (TJAPlayer3.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Center)
+                        if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Center)
                         {
                             this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), TJAPlayer3.Skin.Game_MusicName_XY[1]);
                         }
-                        else if (TJAPlayer3.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Left)
+                        else if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Left)
                         {
                             this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0], TJAPlayer3.Skin.Game_MusicName_XY[1]);
                         }
@@ -276,11 +276,11 @@ namespace TJAPlayer3
                         }
                     }
                     if (this.tx難易度とステージ数 != null)
-                        if (TJAPlayer3.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Center)
+                        if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Center)
                         {
                             this.tx難易度とステージ数.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - (this.tx難易度とステージ数.szテクスチャサイズ.Width / 2), TJAPlayer3.Skin.Game_MusicName_XY[1]);
                         }
-                        else if (TJAPlayer3.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Left)
+                        else if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Left)
                         {
                             this.tx難易度とステージ数.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0], TJAPlayer3.Skin.Game_MusicName_XY[1]);
                         }

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -110,21 +110,7 @@ namespace TJAPlayer3
         /// </summary>
         public void t歌詞テクスチャを描画する()
         {
-            if( this.tx歌詞テクスチャ != null )
-            {
-                if (TJAPlayer3.Skin.GameLyricHorizontalReferencePoint == HorizontalReferencePoint.Left)
-                {
-                this.tx歌詞テクスチャ.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lyric_XY[0] , TJAPlayer3.Skin.Game_Lyric_XY[1]);
-                }
-                else if (TJAPlayer3.Skin.GameLyricHorizontalReferencePoint == HorizontalReferencePoint.Right)
-                {
-                this.tx歌詞テクスチャ.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lyric_XY[0] - this.tx歌詞テクスチャ.szテクスチャサイズ.Width, TJAPlayer3.Skin.Game_Lyric_XY[1]);
-                }
-                else
-                {
-                this.tx歌詞テクスチャ.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lyric_XY[0] - (this.tx歌詞テクスチャ.szテクスチャサイズ.Width / 2), TJAPlayer3.Skin.Game_Lyric_XY[1]);
-                }
-            }
+            tx歌詞テクスチャ?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lyric_XY[0] , TJAPlayer3.Skin.Game_Lyric_XY[1], TJAPlayer3.Skin.GameLyricHorizontalReferencePoint);
         }
 
 		// CActivity 実装
@@ -275,19 +261,8 @@ namespace TJAPlayer3
                             this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - (this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X), TJAPlayer3.Skin.Game_MusicName_XY[1]);
                         }
                     }
-                    if (this.tx難易度とステージ数 != null)
-                        if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Center)
-                        {
-                            this.tx難易度とステージ数.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - (this.tx難易度とステージ数.szテクスチャサイズ.Width / 2), TJAPlayer3.Skin.Game_MusicName_XY[1]);
-                        }
-                        else if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Left)
-                        {
-                            this.tx難易度とステージ数.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0], TJAPlayer3.Skin.Game_MusicName_XY[1]);
-                        }
-                        else
-                        {
-                            this.tx難易度とステージ数.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - this.tx難易度とステージ数.szテクスチャサイズ.Width, TJAPlayer3.Skin.Game_MusicName_XY[1]);
-                        }
+
+                    tx難易度とステージ数?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0], TJAPlayer3.Skin.Game_MusicName_XY[1], TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint);
                 }
             }
 		}

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -188,18 +188,7 @@ namespace TJAPlayer3
                         if (this.txMusicName.szテクスチャサイズ.Width <= 660.0f)
                             fRate = 1.0f;
                         this.txMusicName.vc拡大縮小倍率.X = fRate;
-                        if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Center)
-                        {
-                            this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), TJAPlayer3.Skin.Game_MusicName_XY[1]);
-                        }
-                        else if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Left)
-                        {
-                            this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0], TJAPlayer3.Skin.Game_MusicName_XY[1]);
-                        }
-                        else
-                        {
-                            this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - (this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X), TJAPlayer3.Skin.Game_MusicName_XY[1]);
-                        }
+                        this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0], TJAPlayer3.Skin.Game_MusicName_XY[1], TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint);
                     }
                 }
                 else
@@ -246,21 +235,7 @@ namespace TJAPlayer3
 
                     #endregion
 
-                    if( this.txMusicName != null )
-                    {
-                        if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Center)
-                        {
-                            this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), TJAPlayer3.Skin.Game_MusicName_XY[1]);
-                        }
-                        else if (TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Left)
-                        {
-                            this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0], TJAPlayer3.Skin.Game_MusicName_XY[1]);
-                        }
-                        else
-                        {
-                            this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0] - (this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X), TJAPlayer3.Skin.Game_MusicName_XY[1]);
-                        }
-                    }
+                    txMusicName?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0], TJAPlayer3.Skin.Game_MusicName_XY[1], TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint);
 
                     tx難易度とステージ数?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0], TJAPlayer3.Skin.Game_MusicName_XY[1], TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint);
                 }

--- a/TJAPlayer3/Stages/08.Result/CActResultSongBar.cs
+++ b/TJAPlayer3/Stages/08.Result/CActResultSongBar.cs
@@ -88,33 +88,11 @@ namespace TJAPlayer3
 			}
 			this.ct登場用.t進行();
 
-            if (TJAPlayer3.Skin.ResultMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Center)
-            {
-                this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), TJAPlayer3.Skin.Result_MusicName_XY[1]);
-            }
-            else if (TJAPlayer3.Skin.ResultMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Left)
-            {
-                this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_MusicName_XY[0], TJAPlayer3.Skin.Result_MusicName_XY[1]);
-            }
-            else
-            {
-                this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_MusicName_XY[0] - this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X, TJAPlayer3.Skin.Result_MusicName_XY[1]);
-            }
+            this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_MusicName_XY[0], TJAPlayer3.Skin.Result_MusicName_XY[1], TJAPlayer3.Skin.ResultMusicNameHorizontalReferencePoint);
 
             if(TJAPlayer3.stage選曲.n確定された曲の難易度 != (int)Difficulty.Dan)
             {
-                if (TJAPlayer3.Skin.ResultStageTextHorizontalReferencePoint == HorizontalReferencePoint.Center)
-                {
-                    this.txStageText.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_StageText_XY[0] - ((this.txStageText.szテクスチャサイズ.Width * txStageText.vc拡大縮小倍率.X) / 2), TJAPlayer3.Skin.Result_StageText_XY[1]);
-                }
-                else if (TJAPlayer3.Skin.ResultStageTextHorizontalReferencePoint == HorizontalReferencePoint.Right)
-                {
-                    this.txStageText.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_StageText_XY[0] - this.txStageText.szテクスチャサイズ.Width, TJAPlayer3.Skin.Result_StageText_XY[1]);
-                }
-                else
-                {
-                    this.txStageText.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_StageText_XY[0], TJAPlayer3.Skin.Result_StageText_XY[1]);
-                }
+                this.txStageText.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_StageText_XY[0], TJAPlayer3.Skin.Result_StageText_XY[1], TJAPlayer3.Skin.ResultStageTextHorizontalReferencePoint);
             }
 
 

--- a/TJAPlayer3/Stages/08.Result/CActResultSongBar.cs
+++ b/TJAPlayer3/Stages/08.Result/CActResultSongBar.cs
@@ -88,11 +88,11 @@ namespace TJAPlayer3
 			}
 			this.ct登場用.t進行();
 
-            if (TJAPlayer3.Skin.Result_MusicName_ReferencePoint == CSkin.ReferencePoint.Center)
+            if (TJAPlayer3.Skin.ResultMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Center)
             {
                 this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), TJAPlayer3.Skin.Result_MusicName_XY[1]);
             }
-            else if (TJAPlayer3.Skin.Result_MusicName_ReferencePoint == CSkin.ReferencePoint.Left)
+            else if (TJAPlayer3.Skin.ResultMusicNameHorizontalReferencePoint == HorizontalReferencePoint.Left)
             {
                 this.txMusicName.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_MusicName_XY[0], TJAPlayer3.Skin.Result_MusicName_XY[1]);
             }
@@ -103,11 +103,11 @@ namespace TJAPlayer3
 
             if(TJAPlayer3.stage選曲.n確定された曲の難易度 != (int)Difficulty.Dan)
             {
-                if (TJAPlayer3.Skin.Result_StageText_ReferencePoint == CSkin.ReferencePoint.Center)
+                if (TJAPlayer3.Skin.ResultStageTextHorizontalReferencePoint == HorizontalReferencePoint.Center)
                 {
                     this.txStageText.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_StageText_XY[0] - ((this.txStageText.szテクスチャサイズ.Width * txStageText.vc拡大縮小倍率.X) / 2), TJAPlayer3.Skin.Result_StageText_XY[1]);
                 }
-                else if (TJAPlayer3.Skin.Result_StageText_ReferencePoint == CSkin.ReferencePoint.Right)
+                else if (TJAPlayer3.Skin.ResultStageTextHorizontalReferencePoint == HorizontalReferencePoint.Right)
                 {
                     this.txStageText.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_StageText_XY[0] - this.txStageText.szテクスチャサイズ.Width, TJAPlayer3.Skin.Result_StageText_XY[1]);
                 }


### PR DESCRIPTION
TJAPlayer3 contains much duplicate code related to left/center/right-aligned drawing. Some of that code has skin-controlled alignment using a "reference point" enumeration type, and when this alignment was added it was done via a pile of copy/paste code. (This particular pattern of code was spotted during the recent batch of texture resource management improvements.)

One specific instance of this affected subtitle positioning logic, and was an obvious visible copy/pasta issue as noted in #47.

While much centering code still appears in various places, the code using these "reference point" enumerations has been gathered into CTexture and delegated to a single set of implementing code there. Future PRs will perform further de-duplication of similar left/center/right aligned drawing.

This fixes #47 as written, though further de-duplication should be performed as noted above.