### PR TITLE
Load and use textures, especially arrays of them, more safely

### DIFF
--- a/TJAPlayer3/Common/C文字コンソール.cs
+++ b/TJAPlayer3/Common/C文字コンソール.cs
@@ -81,8 +81,8 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-				this.txフォント8x16[ 0 ] = TJAPlayer3.Tx.TxC(@"Console_Font.png");
-				this.txフォント8x16[ 1 ] = TJAPlayer3.Tx.TxC(@"Console_Font_Small.png");
+				this.txフォント8x16[ 0 ] = TJAPlayer3.Tx.TxCUntracked(@"Console_Font.png");
+				this.txフォント8x16[ 1 ] = TJAPlayer3.Tx.TxCUntracked(@"Console_Font_Small.png");
                 base.OnManagedリソースの作成();
 			}
 		}

--- a/TJAPlayer3/Common/TJAPlayer3.cs
+++ b/TJAPlayer3/Common/TJAPlayer3.cs
@@ -1367,6 +1367,22 @@ for (int i = 0; i < 3; i++) {
             obj = null;
         }
 
+        public static void t安全にDisposeする<T>(ref T[][] array) where T : class, IDisposable
+        {
+            if (array == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < array.Length; i++)
+            {
+                t安全にDisposeする(array[i]);
+                array[i] = null;
+            }
+
+            array = null;
+        }
+
         public static void t安全にDisposeする<T>(ref T[] array) where T : class, IDisposable
         {
             t安全にDisposeする(array);

--- a/TJAPlayer3/Common/TJAPlayer3.cs
+++ b/TJAPlayer3/Common/TJAPlayer3.cs
@@ -1367,28 +1367,6 @@ for (int i = 0; i < 3; i++) {
             obj = null;
         }
 
-        public static void t安全にDisposeする<T>(ref T[][] array) where T : class, IDisposable
-        {
-            if (array == null)
-            {
-                return;
-            }
-
-            for (var i = 0; i < array.Length; i++)
-            {
-                t安全にDisposeする(array[i]);
-                array[i] = null;
-            }
-
-            array = null;
-        }
-
-        public static void t安全にDisposeする<T>(ref T[] array) where T : class, IDisposable
-        {
-            t安全にDisposeする(array);
-            array = null;
-        }
-
         public static void t安全にDisposeする<T>(T[] array) where T : class, IDisposable
         {
             if (array == null)
@@ -2014,7 +1992,8 @@ for (int i = 0; i < 3; i++) {
                 //---------------------
                 #endregion
                 #region TextureLoaderの処理
-                Tx.DisposeTexture();
+                Tx.Dispose();
+                Tx = null;
                 #endregion
                 #region [ スキンの終了処理 ]
                 //---------------------
@@ -2295,8 +2274,9 @@ for (int i = 0; i < 3; i++) {
             TJAPlayer3.Skin = new CSkin(TJAPlayer3.ConfigIni.strSystemSkinSubfolderFullName, false);
 
 
-            TJAPlayer3.Tx.DisposeTexture();
-            TJAPlayer3.Tx.LoadTexture();
+            TJAPlayer3.Tx.Dispose();
+            TJAPlayer3.Tx = new TextureLoader();
+            TJAPlayer3.Tx.Load();
 
             TJAPlayer3.act文字コンソール.On活性化();
         }

--- a/TJAPlayer3/Stages/01.StartUp/CStage起動.cs
+++ b/TJAPlayer3/Stages/01.StartUp/CStage起動.cs
@@ -136,7 +136,7 @@ namespace TJAPlayer3
 
 					case CStage.Eフェーズ.起動7_完了:
                         this.list進行文字列.Add("LOADING TEXTURES...");
-                        TJAPlayer3.Tx.LoadTexture();
+                        TJAPlayer3.Tx.Load();
                         this.list進行文字列.Add("LOADING TEXTURES...OK");
                         this.str現在進行中 = "Setup done.";
                         break;

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -298,7 +298,7 @@ namespace TJAPlayer3
             Taiko_LevelUp = TxC($"{GAME}{TAIKO}LevelUp.png");
             Taiko_LevelDown = TxC($"{GAME}{TAIKO}LevelDown.png");
 
-            Course_Symbol = TxC($"{GAME}{COURSESYMBOL}{{0}}.png", Course_Symbols);
+            Course_Symbol = TxC($"{GAME}{COURSESYMBOL}{{0}}.png", "Easy", "Normal", "Hard", "Oni", "Edit", "Tower", "Dan", "Shin");
 
             Taiko_Score = TxC($"{GAME}{TAIKO}Score{{0}}.png", "", "_1P", "_2P");
 
@@ -567,7 +567,6 @@ namespace TJAPlayer3
             Taiko_Combo_Effect,
             Taiko_Combo_Text;
 
-        private static readonly string[] Course_Symbols = { "Easy", "Normal", "Hard", "Oni", "Edit", "Tower", "Dan", "Shin" };
         public CTexture[] Course_Symbol;
         public CTexture[] Taiko_PlayerNumber;
         public CTexture[] Taiko_NamePlate; // ネームプレート

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -539,7 +539,7 @@ namespace TJAPlayer3
 
             DanC_Gauge = new CTexture[4];
             var type = new string[] { "Normal", "Reach", "Clear", "Flush" };
-            for (int i = 0; i < 4; i++)
+            for (int i = 0; i < DanC_Gauge.Length; i++)
             {
                 DanC_Gauge[i] = TxC(GAME + DANC + @"Gauge_" + type[i] + ".png");
             }

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -243,7 +243,7 @@ namespace TJAPlayer3
             if (TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn != 0)
             {
                 Chara_Become_Cleared = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn];
-                for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn; i++)
+                for (int i = 0; i < Chara_Become_Cleared.Length; i++)
                 {
                     Chara_Become_Cleared[i] = TxC(GAME + CHARA + @"ClearIn\" + i.ToString() + ".png");
                 }
@@ -667,7 +667,7 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Chara_10Combo_Maxed);
             TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart);
             TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart_Maxed);
-            TJAPlayer3.t安全にDisposeする(Chara_Become_Cleared);
+            TJAPlayer3.t安全にDisposeする(ref Chara_Become_Cleared);
             TJAPlayer3.t安全にDisposeする(Chara_Become_Maxed);
             TJAPlayer3.t安全にDisposeする(Chara_Balloon_Breaking);
             TJAPlayer3.t安全にDisposeする(Chara_Balloon_Broke);

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using FDK;
 
 namespace TJAPlayer3
@@ -46,26 +47,12 @@ namespace TJAPlayer3
 
         private CTexture[] TxC(int count, string format, int offset = 0)
         {
-            var array = new CTexture[count];
-
-            for (int i = 0; i < array.Length; i++)
-            {
-                array[i] = TxC(string.Format(format, i + offset));
-            }
-
-            return array;
+            return TxC(Enumerable.Range(offset, count).ToList(), format);
         }
 
-        private CTexture[] TxC(string[] parts, string format)
+        private CTexture[] TxC<T>(IEnumerable<T> parts, string format)
         {
-            var array = new CTexture[parts.Length];
-
-            for (int i = 0; i < array.Length; i++)
-            {
-                array[i] = TxC(string.Format(format, parts[i]));
-            }
-
-            return array;
+            return parts.Select(o => TxC(string.Format(format, o))).ToArray();
         }
 
         private CTexture TxC(string path)

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -44,13 +44,13 @@ namespace TJAPlayer3
 
         private readonly List<CTexture> _trackedTextures = new List<CTexture>();
 
-        private CTexture[] TxC(int count, string format)
+        private CTexture[] TxC(int count, string format, int offset = 0)
         {
             var array = new CTexture[count];
 
             for (int i = 0; i < array.Length; i++)
             {
-                array[i] = TxC(string.Format(format, i));
+                array[i] = TxC(string.Format(format, i + offset));
             }
 
             return array;
@@ -114,9 +114,7 @@ namespace TJAPlayer3
             Scanning_Loudness = TxC(@"Scanning_Loudness.png");
             Overlay = TxC(@"Overlay.png");
 
-            NamePlate = new CTexture[2];
-            NamePlate[0] = TxC(@"1P_NamePlate.png");
-            NamePlate[1] = TxC(@"2P_NamePlate.png");
+            NamePlate = TxC(2, @"{0}P_NamePlate.png", 1);
             #endregion
             #region 1_タイトル画面
             Title_Background = TxC(TITLE + @"Background.png");
@@ -276,36 +274,21 @@ namespace TJAPlayer3
             #endregion
             #region 背景
             Background = TxC(GAME + Background + @"0\" + @"Background.png");
-
-            Background_Up = new CTexture[2];
-            Background_Up[0] = TxC(GAME + BACKGROUND + @"0\" + @"1P_Up.png");
-            Background_Up[1] = TxC(GAME + BACKGROUND + @"0\" + @"2P_Up.png");
-
-            Background_Up_Clear = new CTexture[2];
-            Background_Up_Clear[0] = TxC(GAME + BACKGROUND + @"0\" + @"1P_Up_Clear.png");
-            Background_Up_Clear[1] = TxC(GAME + BACKGROUND + @"0\" + @"2P_Up_Clear.png");
-
+            Background_Up = TxC(2, GAME + BACKGROUND + @"0\" + @"{0}P_Up.png", 1);
+            Background_Up_Clear = TxC(2, GAME + BACKGROUND + @"0\" + @"{0}P_Up_Clear.png", 1);
             Background_Down = TxC(GAME + BACKGROUND + @"0\" + @"Down.png");
             Background_Down_Clear = TxC(GAME + BACKGROUND + @"0\" + @"Down_Clear.png");
             Background_Down_Scroll = TxC(GAME + BACKGROUND + @"0\" + @"Down_Scroll.png");
 
             #endregion
             #region 太鼓
-            Taiko_Background = new CTexture[2];
-            Taiko_Background[0] = TxC(GAME + TAIKO + @"1P_Background.png");
-            Taiko_Background[1] = TxC(GAME + TAIKO + @"2P_Background.png");
+            Taiko_Background = TxC(2, GAME + TAIKO + @"{0}P_Background.png", 1);
 
-            Taiko_Frame = new CTexture[2];
-            Taiko_Frame[0] = TxC(GAME + TAIKO + @"1P_Frame.png");
-            Taiko_Frame[1] = TxC(GAME + TAIKO + @"2P_Frame.png");
+            Taiko_Frame = TxC(2, GAME + TAIKO + @"{0}P_Frame.png", 1);
 
-            Taiko_PlayerNumber = new CTexture[2];
-            Taiko_PlayerNumber[0] = TxC(GAME + TAIKO + @"1P_PlayerNumber.png");
-            Taiko_PlayerNumber[1] = TxC(GAME + TAIKO + @"2P_PlayerNumber.png");
+            Taiko_PlayerNumber = TxC(2, GAME + TAIKO + @"{0}P_PlayerNumber.png", 1);
 
-            Taiko_NamePlate = new CTexture[2];
-            Taiko_NamePlate[0] = TxC(GAME + TAIKO + @"1P_NamePlate.png");
-            Taiko_NamePlate[1] = TxC(GAME + TAIKO + @"2P_NamePlate.png");
+            Taiko_NamePlate = TxC(2, GAME + TAIKO + @"{0}P_NamePlate.png", 1);
 
             Taiko_Base = TxC(GAME + TAIKO + @"Base.png");
             Taiko_Don_Left = TxC(GAME + TAIKO + @"Don.png");
@@ -317,75 +300,41 @@ namespace TJAPlayer3
 
             Course_Symbol = TxC(Course_Symbols, GAME + COURSESYMBOL + "{0}.png");
 
-            Taiko_Score = new CTexture[3];
-            Taiko_Score[0] = TxC(GAME + TAIKO + @"Score.png");
-            Taiko_Score[1] = TxC(GAME + TAIKO + @"Score_1P.png");
-            Taiko_Score[2] = TxC(GAME + TAIKO + @"Score_2P.png");
+            Taiko_Score = TxC(new[] {"", "_1P", "_2P"}, GAME + TAIKO + @"Score{0}.png");
 
-            Taiko_Combo = new CTexture[2];
-            Taiko_Combo[0] = TxC(GAME + TAIKO + @"Combo.png");
-            Taiko_Combo[1] = TxC(GAME + TAIKO + @"Combo_Big.png");
-
+            Taiko_Combo = TxC(new[] {"", "_Big"}, GAME + TAIKO + @"Combo{0}.png");
             Taiko_Combo_Effect = TxC(GAME + TAIKO + @"Combo_Effect.png");
             Taiko_Combo_Text = TxC(GAME + TAIKO + @"Combo_Text.png");
             #endregion
             #region ゲージ
 
-            Gauge = new CTexture[2];
-            Gauge[0] = TxC(GAME + GAUGE + @"1P.png");
-            Gauge[1] = TxC(GAME + GAUGE + @"2P.png");
-
-            Gauge_Hard = new CTexture[2];
-            Gauge_Hard[0] = TxC(GAME + GAUGE + @"1P_Hard.png");
-            Gauge_Hard[1] = TxC(GAME + GAUGE + @"2P_Hard.png");
-
-            Gauge_ExHard = new CTexture[2];
-            Gauge_ExHard[0] = TxC(GAME + GAUGE + @"1P_ExHard.png");
-            Gauge_ExHard[1] = TxC(GAME + GAUGE + @"2P_ExHard.png");
-
-            Gauge_Base = new CTexture[2];
-            Gauge_Base[0] = TxC(GAME + GAUGE + @"1P_Base.png");
-            Gauge_Base[1] = TxC(GAME + GAUGE + @"2P_Base.png");
-
-            Gauge_Base_Hard = new CTexture[2];
-            Gauge_Base_Hard[0] = TxC(GAME + GAUGE + @"1P_Base_Hard.png");
-            Gauge_Base_Hard[1] = TxC(GAME + GAUGE + @"2P_Base_Hard.png");
-
-            Gauge_Base_ExHard = new CTexture[2];
-            Gauge_Base_ExHard[0] = TxC(GAME + GAUGE + @"1P_Base_ExHard.png");
-            Gauge_Base_ExHard[1] = TxC(GAME + GAUGE + @"2P_Base_ExHard.png");
-
-            Gauge_Line = new CTexture[2];
-            Gauge_Line[0] = TxC(GAME + GAUGE + @"1P_Line.png");
-            Gauge_Line[1] = TxC(GAME + GAUGE + @"2P_Line.png");
-
-            Gauge_Line_Hard = new CTexture[2];
-            Gauge_Line_Hard[0] = TxC(GAME + GAUGE + @"1P_Line_Hard.png");
-            Gauge_Line_Hard[1] = TxC(GAME + GAUGE + @"2P_Line_Hard.png");
+            Gauge = TxC(2, GAME + GAUGE + @"{0}P.png", 1);
+            Gauge_Hard = TxC(2, GAME + GAUGE + @"{0}P_Hard.png", 1);
+            Gauge_ExHard = TxC(2, GAME + GAUGE + @"{0}P_ExHard.png", 1);
+            Gauge_Base = TxC(2, GAME + GAUGE + @"{0}P_Base.png", 1);
+            Gauge_Base_Hard = TxC(2, GAME + GAUGE + @"{0}P_Base_Hard.png", 1);
+            Gauge_Base_ExHard = TxC(2, GAME + GAUGE + @"{0}P_Base_ExHard.png", 1);
+            Gauge_Line = TxC(2, GAME + GAUGE + @"{0}P_Line.png", 1);
+            Gauge_Line_Hard = TxC(2, GAME + GAUGE + @"{0}P_Line_Hard.png", 1);
 
             TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + GAUGE + @"Rainbow\"));
             if (TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn != 0)
             {
                 Gauge_Rainbow = TxC(TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn, GAME + GAUGE + @"Rainbow\{0}.png");
             }
+
             Gauge_Soul = TxC(GAME + GAUGE + @"Soul.png");
             Gauge_Soul_Fire = TxC(GAME + GAUGE + @"Fire.png");
 
-            Gauge_Soul_Explosion = new CTexture[2];
-            Gauge_Soul_Explosion[0] = TxC(GAME + GAUGE + @"1P_Explosion.png");
-            Gauge_Soul_Explosion[1] = TxC(GAME + GAUGE + @"2P_Explosion.png");
+            Gauge_Soul_Explosion = TxC(2, GAME + GAUGE + @"{0}P_Explosion.png", 1);
 
             #endregion
             #region 吹き出し
-            Balloon_Combo = new CTexture[2];
-            Balloon_Combo[0] = TxC(GAME + BALLOON + @"Combo_1P.png");
-            Balloon_Combo[1] = TxC(GAME + BALLOON + @"Combo_2P.png");
-
+            Balloon_Combo = TxC(2, GAME + BALLOON + @"Combo_{0}P.png", 1);
             Balloon_Roll = TxC(GAME + BALLOON + @"Roll.png");
             Balloon_Balloon = TxC(GAME + BALLOON + @"Balloon.png");
             Balloon_Number_Roll = TxC(GAME + BALLOON + @"Number_Roll.png");
             Balloon_Number_Combo = TxC(GAME + BALLOON + @"Number_Combo.png");
-
             Balloon_Breaking = TxC(6, GAME + BALLOON + @"Breaking_{0}.png");
 
             #endregion

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -234,7 +234,7 @@ namespace TJAPlayer3
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max != 0)
             {
                 Chara_GoGoStart_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max];
-                for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max; i++)
+                for (int i = 0; i < Chara_GoGoStart_Maxed.Length; i++)
                 {
                     Chara_GoGoStart_Maxed[i] = TxC(GAME + CHARA + @"GoGoStart_Max\" + i.ToString() + ".png");
                 }
@@ -666,7 +666,7 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Chara_10Combo);
             TJAPlayer3.t安全にDisposeする(ref Chara_10Combo_Maxed);
             TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart);
-            TJAPlayer3.t安全にDisposeする(Chara_GoGoStart_Maxed);
+            TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart_Maxed);
             TJAPlayer3.t安全にDisposeする(Chara_Become_Cleared);
             TJAPlayer3.t安全にDisposeする(Chara_Become_Maxed);
             TJAPlayer3.t安全にDisposeする(Chara_Balloon_Breaking);

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -279,7 +279,7 @@ namespace TJAPlayer3
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss != 0)
             {
                 Chara_Balloon_Miss = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss];
-                for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss; i++)
+                for (int i = 0; i < Chara_Balloon_Miss.Length; i++)
                 {
                     Chara_Balloon_Miss[i] = TxC(GAME + CHARA + @"Balloon_Miss\" + i.ToString() + ".png");
                 }
@@ -671,7 +671,7 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Chara_Become_Maxed);
             TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Breaking);
             TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Broke);
-            TJAPlayer3.t安全にDisposeする(Chara_Balloon_Miss);
+            TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Miss);
             #endregion
             #region 踊り子
             for (int i = 0; i < Dancer.Length; i++)

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -100,157 +100,162 @@ namespace TJAPlayer3
 
         internal CTexture TxCGenreUntracked(string fileNameWithoutExtension)
         {
-            return TJAPlayer3.tテクスチャの生成(CSkin.Path(BASE + GAME + GENRE + fileNameWithoutExtension + ".png"));
+            return TJAPlayer3.tテクスチャの生成(CSkin.Path($"{BASE}{GAME}{GENRE}{fileNameWithoutExtension}.png"));
         }
 
         public void Load()
         {
             #region 共通
-            Tile_Black = TxC(@"Tile_Black.png");
-            Tile_White = TxC(@"Tile_White.png");
-            Menu_Title = TxC(@"Menu_Title.png");
-            Menu_Highlight = TxC(@"Menu_Highlight.png");
-            Enum_Song = TxC(@"Enum_Song.png");
-            Scanning_Loudness = TxC(@"Scanning_Loudness.png");
-            Overlay = TxC(@"Overlay.png");
+            Tile_Black = TxC("Tile_Black.png");
+            Tile_White = TxC("Tile_White.png");
+            Menu_Title = TxC("Menu_Title.png");
+            Menu_Highlight = TxC("Menu_Highlight.png");
+            Enum_Song = TxC("Enum_Song.png");
+            Scanning_Loudness = TxC("Scanning_Loudness.png");
+            Overlay = TxC("Overlay.png");
 
-            NamePlate = TxC(2, @"{0}P_NamePlate.png", 1);
+            NamePlate = TxC(2, "{0}P_NamePlate.png", 1);
             #endregion
             #region 1_タイトル画面
-            Title_Background = TxC(TITLE + @"Background.png");
-            Title_Menu = TxC(TITLE + @"Menu.png");
+            Title_Background = TxC($"{TITLE}Background.png");
+            Title_Menu = TxC($"{TITLE}Menu.png");
             #endregion
 
             #region 2_コンフィグ画面
-            Config_Background = TxC(CONFIG + @"Background.png");
-            Config_Cursor = TxC(CONFIG + @"Cursor.png");
-            Config_ItemBox = TxC(CONFIG + @"ItemBox.png");
-            Config_Arrow = TxC(CONFIG + @"Arrow.png");
-            Config_KeyAssign = TxC(CONFIG + @"KeyAssign.png");
-            Config_Font = TxC(CONFIG + @"Font.png");
-            Config_Font_Bold = TxC(CONFIG + @"Font_Bold.png");
-            Config_Enum_Song = TxC(CONFIG + @"Enum_Song.png");
+            Config_Background = TxC($"{CONFIG}Background.png");
+            Config_Cursor = TxC($"{CONFIG}Cursor.png");
+            Config_ItemBox = TxC($"{CONFIG}ItemBox.png");
+            Config_Arrow = TxC($"{CONFIG}Arrow.png");
+            Config_KeyAssign = TxC($"{CONFIG}KeyAssign.png");
+            Config_Font = TxC($"{CONFIG}Font.png");
+            Config_Font_Bold = TxC($"{CONFIG}Font_Bold.png");
+            Config_Enum_Song = TxC($"{CONFIG}Enum_Song.png");
             #endregion
 
             #region 3_選曲画面
-            SongSelect_Background = TxC(SONGSELECT + @"Background.png");
-            SongSelect_Header = TxC(SONGSELECT + @"Header.png");
-            SongSelect_Footer = TxC(SONGSELECT + @"Footer.png");
-            SongSelect_Difficulty = TxC(SONGSELECT + @"Difficulty.png");
-            SongSelect_Auto = TxC(SONGSELECT + @"Auto.png");
-            SongSelect_Level = TxC(SONGSELECT + @"Level.png");
-            SongSelect_Branch = TxC(SONGSELECT + @"Branch.png");
-            SongSelect_Branch_Text = TxC(SONGSELECT + @"Branch_Text.png");
-            SongSelect_Bar_Center = TxC(SONGSELECT + @"Bar_Center.png");
-            SongSelect_Frame_Score = TxC(SONGSELECT + @"Frame_Score.png");
-            SongSelect_Frame_BackBox = TxC(SONGSELECT + @"Frame_BackBox.png");
-            SongSelect_Frame_Random = TxC(SONGSELECT + @"Frame_Random.png");
-            SongSelect_Score_Select = TxC(SONGSELECT + @"Score_Select.png");
-            //SongSelect_Frame_Dani = TxC(SONGSELECT + @"Frame_Dani.png");
-            SongSelect_GenreText = TxC(SONGSELECT + @"GenreText.png");
-            SongSelect_Cursor_Left = TxC(SONGSELECT + @"Cursor_Left.png");
-            SongSelect_Cursor_Right = TxC(SONGSELECT + @"Cursor_Right.png");
-            SongSelect_Bar_Genre = TxC(9, SONGSELECT + "Bar_Genre_{0}.png");
-            SongSelect_Frame_Box = TxC(9, SONGSELECT + "Frame_Box_{0}.png");
-            SongSelect_ScoreWindow = TxC((int) Difficulty.Total, SONGSELECT + "ScoreWindow_{0}.png");
-            SongSelect_GenreBack = TxC(9, SONGSELECT + "GenreBackground_{0}.png");
-            SongSelect_ScoreWindow_Text = TxC(SONGSELECT + @"ScoreWindow_Text.png");
-            SongSelect_Rating = TxC(SONGSELECT + @"Rating.png");
+            SongSelect_Background = TxC($"{SONGSELECT}Background.png");
+            SongSelect_Header = TxC($"{SONGSELECT}Header.png");
+            SongSelect_Footer = TxC($"{SONGSELECT}Footer.png");
+            SongSelect_Difficulty = TxC($"{SONGSELECT}Difficulty.png");
+            SongSelect_Auto = TxC($"{SONGSELECT}Auto.png");
+            SongSelect_Level = TxC($"{SONGSELECT}Level.png");
+            SongSelect_Branch = TxC($"{SONGSELECT}Branch.png");
+            SongSelect_Branch_Text = TxC($"{SONGSELECT}Branch_Text.png");
+            SongSelect_Bar_Center = TxC($"{SONGSELECT}Bar_Center.png");
+            SongSelect_Frame_Score = TxC($"{SONGSELECT}Frame_Score.png");
+            SongSelect_Frame_BackBox = TxC($"{SONGSELECT}Frame_BackBox.png");
+            SongSelect_Frame_Random = TxC($"{SONGSELECT}Frame_Random.png");
+            SongSelect_Score_Select = TxC($"{SONGSELECT}Score_Select.png");
+            // SongSelect_Frame_Dani = TxC($"{SONGSELECT}Frame_Dani.png");
+            SongSelect_GenreText = TxC($"{SONGSELECT}GenreText.png");
+            SongSelect_Cursor_Left = TxC($"{SONGSELECT}Cursor_Left.png");
+            SongSelect_Cursor_Right = TxC($"{SONGSELECT}Cursor_Right.png");
+            SongSelect_Bar_Genre = TxC(9, $"{SONGSELECT}Bar_Genre_{{0}}.png");
+            SongSelect_Frame_Box = TxC(9, $"{SONGSELECT}Frame_Box_{{0}}.png");
+            SongSelect_ScoreWindow = TxC((int) Difficulty.Total, $"{SONGSELECT}ScoreWindow_{{0}}.png");
+            SongSelect_GenreBack = TxC(9, $"{SONGSELECT}GenreBackground_{{0}}.png");
+            SongSelect_ScoreWindow_Text = TxC($"{SONGSELECT}ScoreWindow_Text.png");
+            SongSelect_Rating = TxC($"{SONGSELECT}Rating.png");
             #endregion
 
             #region 4_読み込み画面
-            SongLoading_Plate = TxC(SONGLOADING + @"Plate.png");
-            SongLoading_FadeIn = TxC(SONGLOADING + @"FadeIn.png");
-            SongLoading_FadeOut = TxC(SONGLOADING + @"FadeOut.png");
+            SongLoading_Plate = TxC($"{SONGLOADING}Plate.png");
+            SongLoading_FadeIn = TxC($"{SONGLOADING}FadeIn.png");
+            SongLoading_FadeOut = TxC($"{SONGLOADING}FadeOut.png");
             #endregion
 
             #region 5_演奏画面
             #region 共通
-            Notes = TxC(GAME + @"Notes.png");
-            Judge_Frame = TxC(GAME + @"Notes.png");
-            SENotes = TxC(GAME + @"SENotes.png");
-            Notes_Arm = TxC(GAME + @"Notes_Arm.png");
-            Judge = TxC(GAME + @"Judge.png");
+            Notes = TxC($"{GAME}Notes.png");
+            Judge_Frame = TxC($"{GAME}Notes.png");
+            SENotes = TxC($"{GAME}SENotes.png");
+            Notes_Arm = TxC($"{GAME}Notes_Arm.png");
+            Judge = TxC($"{GAME}Judge.png");
 
-            Judge_Meter = TxC(GAME + @"Judge_Meter.png");
-            Bar = TxC(GAME + @"Bar.png");
-            Bar_Branch = TxC(GAME + @"Bar_Branch.png");
+            Judge_Meter = TxC($"{GAME}Judge_Meter.png");
+            Bar = TxC($"{GAME}Bar.png");
+            Bar_Branch = TxC($"{GAME}Bar_Branch.png");
 
             #endregion
             #region キャラクター
-            TJAPlayer3.Skin.Game_Chara_Ptn_Normal = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Normal\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_Normal = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Normal\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Normal != 0)
             {
-                Chara_Normal = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Normal, GAME + CHARA + @"Normal\{0}.png");
+                Chara_Normal = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Normal, $@"{GAME}{CHARA}Normal\{{0}}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_Clear = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Clear\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_Clear = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Clear\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
             {
-                Chara_Normal_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, GAME + CHARA + @"Clear\{0}.png");
+                Chara_Normal_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, $@"{GAME}{CHARA}Clear\{{0}}.png");
             }
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
             {
-                Chara_Normal_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, GAME + CHARA + @"Clear_Max\{0}.png");
+                Chara_Normal_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, $@"{GAME}{CHARA}Clear_Max\{{0}}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGo\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_GoGo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}GoGo\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
             {
-                Chara_GoGoTime = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, GAME + CHARA + @"GoGo\{0}.png");
+                Chara_GoGoTime = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, $@"{GAME}{CHARA}GoGo\{{0}}.png");
             }
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
             {
-                Chara_GoGoTime_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, GAME + CHARA + @"GoGo_Max\{0}.png");
+                Chara_GoGoTime_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, $@"{GAME}{CHARA}GoGo_Max\{{0}}.png");
             }
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_10combo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"10combo\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_10combo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}10combo\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo != 0)
             {
-                Chara_10Combo = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo, GAME + CHARA + @"10combo\{0}.png");
+                Chara_10Combo = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo, $@"{GAME}{CHARA}10combo\{{0}}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"10combo_Max\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}10combo_Max\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max != 0)
             {
-                Chara_10Combo_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max, GAME + CHARA + @"10combo_Max\{0}.png");
+                Chara_10Combo_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max,
+                    $@"{GAME}{CHARA}10combo_Max\{{0}}.png");
             }
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGoStart\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}GoGoStart\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart != 0)
             {
-                Chara_GoGoStart = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart, GAME + CHARA + @"GoGoStart\{0}.png");
+                Chara_GoGoStart = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart, $@"{GAME}{CHARA}GoGoStart\{{0}}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGoStart_Max\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}GoGoStart_Max\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max != 0)
             {
-                Chara_GoGoStart_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max, GAME + CHARA + @"GoGoStart_Max\{0}.png");
+                Chara_GoGoStart_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max,
+                    $@"{GAME}{CHARA}GoGoStart_Max\{{0}}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"ClearIn\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}ClearIn\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn != 0)
             {
-                Chara_Become_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn, GAME + CHARA + @"ClearIn\{0}.png");
+                Chara_Become_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn, $@"{GAME}{CHARA}ClearIn\{{0}}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"SoulIn\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}SoulIn\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn != 0)
             {
-                Chara_Become_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn, GAME + CHARA + @"SoulIn\{0}.png");
+                Chara_Become_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn, $@"{GAME}{CHARA}SoulIn\{{0}}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Breaking\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Balloon_Breaking\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking != 0)
             {
-                Chara_Balloon_Breaking = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking, GAME + CHARA + @"Balloon_Breaking\{0}.png");
+                Chara_Balloon_Breaking = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking,
+                    $@"{GAME}{CHARA}Balloon_Breaking\{{0}}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Broke\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Balloon_Broke\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke != 0)
             {
-                Chara_Balloon_Broke = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke, GAME + CHARA + @"Balloon_Broke\{0}.png");
+                Chara_Balloon_Broke = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke,
+                    $@"{GAME}{CHARA}Balloon_Broke\{{0}}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Miss\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Balloon_Miss\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss != 0)
             {
-                Chara_Balloon_Miss = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss, GAME + CHARA + @"Balloon_Miss\{0}.png");
+                Chara_Balloon_Miss = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss,
+                    $@"{GAME}{CHARA}Balloon_Miss\{{0}}.png");
             }
             #endregion
             #region 踊り子
-            TJAPlayer3.Skin.Game_Dancer_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + DANCER + @"1\"));
+            TJAPlayer3.Skin.Game_Dancer_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{DANCER}1\"));
             if (TJAPlayer3.Skin.Game_Dancer_Ptn != 0)
             {
                 Dancer = new CTexture[5][];
@@ -259,183 +264,183 @@ namespace TJAPlayer3
                     Dancer[i] = new CTexture[TJAPlayer3.Skin.Game_Dancer_Ptn];
                     for (int p = 0; p < TJAPlayer3.Skin.Game_Dancer_Ptn; p++)
                     {
-                        Dancer[i][p] = TxC(GAME + DANCER + (i + 1) + @"\" + p + ".png");
+                        Dancer[i][p] = TxC($@"{GAME}{DANCER}{(i + 1)}\{p}.png");
                     }
                 }
             }
             #endregion
             #region モブ
             TJAPlayer3.Skin.Game_Mob_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + MOB));
-            Mob = TxC(TJAPlayer3.Skin.Game_Mob_Ptn, GAME + MOB + "{0}.png");
+            Mob = TxC(TJAPlayer3.Skin.Game_Mob_Ptn, $"{GAME}{MOB}{{0}}.png");
 
             #endregion
             #region フッター
-            Mob_Footer = TxC(GAME + FOOTER + @"0.png");
+            Mob_Footer = TxC($"{GAME}{FOOTER}0.png");
             #endregion
             #region 背景
-            Background = TxC(GAME + Background + @"0\" + @"Background.png");
-            Background_Up = TxC(2, GAME + BACKGROUND + @"0\" + @"{0}P_Up.png", 1);
-            Background_Up_Clear = TxC(2, GAME + BACKGROUND + @"0\" + @"{0}P_Up_Clear.png", 1);
-            Background_Down = TxC(GAME + BACKGROUND + @"0\" + @"Down.png");
-            Background_Down_Clear = TxC(GAME + BACKGROUND + @"0\" + @"Down_Clear.png");
-            Background_Down_Scroll = TxC(GAME + BACKGROUND + @"0\" + @"Down_Scroll.png");
+            Background = TxC($@"{GAME}{Background}0\Background.png");
+            Background_Up = TxC(2, $@"{GAME}{BACKGROUND}0\{{0}}P_Up.png", 1);
+            Background_Up_Clear = TxC(2, $@"{GAME}{BACKGROUND}0\{{0}}P_Up_Clear.png", 1);
+            Background_Down = TxC($@"{GAME}{BACKGROUND}0\Down.png");
+            Background_Down_Clear = TxC($@"{GAME}{BACKGROUND}0\Down_Clear.png");
+            Background_Down_Scroll = TxC($@"{GAME}{BACKGROUND}0\Down_Scroll.png");
 
             #endregion
             #region 太鼓
-            Taiko_Background = TxC(2, GAME + TAIKO + @"{0}P_Background.png", 1);
+            Taiko_Background = TxC(2, $"{GAME}{TAIKO}{{0}}P_Background.png", 1);
 
-            Taiko_Frame = TxC(2, GAME + TAIKO + @"{0}P_Frame.png", 1);
+            Taiko_Frame = TxC(2, $"{GAME}{TAIKO}{{0}}P_Frame.png", 1);
 
-            Taiko_PlayerNumber = TxC(2, GAME + TAIKO + @"{0}P_PlayerNumber.png", 1);
+            Taiko_PlayerNumber = TxC(2, $"{GAME}{TAIKO}{{0}}P_PlayerNumber.png", 1);
 
-            Taiko_NamePlate = TxC(2, GAME + TAIKO + @"{0}P_NamePlate.png", 1);
+            Taiko_NamePlate = TxC(2, $"{GAME}{TAIKO}{{0}}P_NamePlate.png", 1);
 
-            Taiko_Base = TxC(GAME + TAIKO + @"Base.png");
-            Taiko_Don_Left = TxC(GAME + TAIKO + @"Don.png");
-            Taiko_Don_Right = TxC(GAME + TAIKO + @"Don.png");
-            Taiko_Ka_Left = TxC(GAME + TAIKO + @"Ka.png");
-            Taiko_Ka_Right = TxC(GAME + TAIKO + @"Ka.png");
-            Taiko_LevelUp = TxC(GAME + TAIKO + @"LevelUp.png");
-            Taiko_LevelDown = TxC(GAME + TAIKO + @"LevelDown.png");
+            Taiko_Base = TxC($"{GAME}{TAIKO}Base.png");
+            Taiko_Don_Left = TxC($"{GAME}{TAIKO}Don.png");
+            Taiko_Don_Right = TxC($"{GAME}{TAIKO}Don.png");
+            Taiko_Ka_Left = TxC($"{GAME}{TAIKO}Ka.png");
+            Taiko_Ka_Right = TxC($"{GAME}{TAIKO}Ka.png");
+            Taiko_LevelUp = TxC($"{GAME}{TAIKO}LevelUp.png");
+            Taiko_LevelDown = TxC($"{GAME}{TAIKO}LevelDown.png");
 
-            Course_Symbol = TxC(Course_Symbols, GAME + COURSESYMBOL + "{0}.png");
+            Course_Symbol = TxC(Course_Symbols, $"{GAME}{COURSESYMBOL}{{0}}.png");
 
-            Taiko_Score = TxC(new[] {"", "_1P", "_2P"}, GAME + TAIKO + @"Score{0}.png");
+            Taiko_Score = TxC(new[] {"", "_1P", "_2P"}, $"{GAME}{TAIKO}Score{{0}}.png");
 
-            Taiko_Combo = TxC(new[] {"", "_Big"}, GAME + TAIKO + @"Combo{0}.png");
-            Taiko_Combo_Effect = TxC(GAME + TAIKO + @"Combo_Effect.png");
-            Taiko_Combo_Text = TxC(GAME + TAIKO + @"Combo_Text.png");
+            Taiko_Combo = TxC(new[] {"", "_Big"}, $"{GAME}{TAIKO}Combo{{0}}.png");
+            Taiko_Combo_Effect = TxC($"{GAME}{TAIKO}Combo_Effect.png");
+            Taiko_Combo_Text = TxC($"{GAME}{TAIKO}Combo_Text.png");
             #endregion
             #region ゲージ
 
-            Gauge = TxC(2, GAME + GAUGE + @"{0}P.png", 1);
-            Gauge_Hard = TxC(2, GAME + GAUGE + @"{0}P_Hard.png", 1);
-            Gauge_ExHard = TxC(2, GAME + GAUGE + @"{0}P_ExHard.png", 1);
-            Gauge_Base = TxC(2, GAME + GAUGE + @"{0}P_Base.png", 1);
-            Gauge_Base_Hard = TxC(2, GAME + GAUGE + @"{0}P_Base_Hard.png", 1);
-            Gauge_Base_ExHard = TxC(2, GAME + GAUGE + @"{0}P_Base_ExHard.png", 1);
-            Gauge_Line = TxC(2, GAME + GAUGE + @"{0}P_Line.png", 1);
-            Gauge_Line_Hard = TxC(2, GAME + GAUGE + @"{0}P_Line_Hard.png", 1);
+            Gauge = TxC(2, $"{GAME}{GAUGE}{{0}}P.png", 1);
+            Gauge_Hard = TxC(2, $"{GAME}{GAUGE}{{0}}P_Hard.png", 1);
+            Gauge_ExHard = TxC(2, $"{GAME}{GAUGE}{{0}}P_ExHard.png", 1);
+            Gauge_Base = TxC(2, $"{GAME}{GAUGE}{{0}}P_Base.png", 1);
+            Gauge_Base_Hard = TxC(2, $"{GAME}{GAUGE}{{0}}P_Base_Hard.png", 1);
+            Gauge_Base_ExHard = TxC(2, $"{GAME}{GAUGE}{{0}}P_Base_ExHard.png", 1);
+            Gauge_Line = TxC(2, $"{GAME}{GAUGE}{{0}}P_Line.png", 1);
+            Gauge_Line_Hard = TxC(2, $"{GAME}{GAUGE}{{0}}P_Line_Hard.png", 1);
 
-            TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + GAUGE + @"Rainbow\"));
+            TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{GAUGE}Rainbow\"));
             if (TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn != 0)
             {
-                Gauge_Rainbow = TxC(TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn, GAME + GAUGE + @"Rainbow\{0}.png");
+                Gauge_Rainbow = TxC(TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn, $@"{GAME}{GAUGE}Rainbow\{{0}}.png");
             }
 
-            Gauge_Soul = TxC(GAME + GAUGE + @"Soul.png");
-            Gauge_Soul_Fire = TxC(GAME + GAUGE + @"Fire.png");
+            Gauge_Soul = TxC($"{GAME}{GAUGE}Soul.png");
+            Gauge_Soul_Fire = TxC($"{GAME}{GAUGE}Fire.png");
 
-            Gauge_Soul_Explosion = TxC(2, GAME + GAUGE + @"{0}P_Explosion.png", 1);
+            Gauge_Soul_Explosion = TxC(2, $"{GAME}{GAUGE}{{0}}P_Explosion.png", 1);
 
             #endregion
             #region 吹き出し
-            Balloon_Combo = TxC(2, GAME + BALLOON + @"Combo_{0}P.png", 1);
-            Balloon_Roll = TxC(GAME + BALLOON + @"Roll.png");
-            Balloon_Balloon = TxC(GAME + BALLOON + @"Balloon.png");
-            Balloon_Number_Roll = TxC(GAME + BALLOON + @"Number_Roll.png");
-            Balloon_Number_Combo = TxC(GAME + BALLOON + @"Number_Combo.png");
-            Balloon_Breaking = TxC(6, GAME + BALLOON + @"Breaking_{0}.png");
+            Balloon_Combo = TxC(2, $"{GAME}{BALLOON}Combo_{{0}}P.png", 1);
+            Balloon_Roll = TxC($"{GAME}{BALLOON}Roll.png");
+            Balloon_Balloon = TxC($"{GAME}{BALLOON}Balloon.png");
+            Balloon_Number_Roll = TxC($"{GAME}{BALLOON}Number_Roll.png");
+            Balloon_Number_Combo = TxC($"{GAME}{BALLOON}Number_Combo.png");
+            Balloon_Breaking = TxC(6, $"{GAME}{BALLOON}Breaking_{{0}}.png");
 
             #endregion
             #region エフェクト
-            Effects_Hit_Explosion = TxCAf(GAME + EFFECTS + @"Hit\Explosion.png");
+            Effects_Hit_Explosion = TxCAf($@"{GAME}{EFFECTS}Hit\Explosion.png");
             if (Effects_Hit_Explosion != null) Effects_Hit_Explosion.b加算合成 = TJAPlayer3.Skin.Game_Effect_HitExplosion_AddBlend;
-            Effects_Hit_Explosion_Big = TxC(GAME + EFFECTS + @"Hit\Explosion_Big.png");
+            Effects_Hit_Explosion_Big = TxC($@"{GAME}{EFFECTS}Hit\Explosion_Big.png");
             if (Effects_Hit_Explosion_Big != null) Effects_Hit_Explosion_Big.b加算合成 = TJAPlayer3.Skin.Game_Effect_HitExplosionBig_AddBlend;
-            Effects_Hit_FireWorks = TxC(GAME + EFFECTS + @"Hit\FireWorks.png");
+            Effects_Hit_FireWorks = TxC($@"{GAME}{EFFECTS}Hit\FireWorks.png");
             if (Effects_Hit_FireWorks != null) Effects_Hit_FireWorks.b加算合成 = TJAPlayer3.Skin.Game_Effect_FireWorks_AddBlend;
 
 
-            Effects_Fire = TxC(GAME + EFFECTS + @"Fire.png");
+            Effects_Fire = TxC($"{GAME}{EFFECTS}Fire.png");
             if (Effects_Fire != null) Effects_Fire.b加算合成 = TJAPlayer3.Skin.Game_Effect_Fire_AddBlend;
 
-            Effects_Rainbow = TxC(GAME + EFFECTS + @"Rainbow.png");
+            Effects_Rainbow = TxC($"{GAME}{EFFECTS}Rainbow.png");
 
-            Effects_GoGoSplash = TxC(GAME + EFFECTS + @"GoGoSplash.png");
+            Effects_GoGoSplash = TxC($"{GAME}{EFFECTS}GoGoSplash.png");
             if (Effects_GoGoSplash != null) Effects_GoGoSplash.b加算合成 = TJAPlayer3.Skin.Game_Effect_GoGoSplash_AddBlend;
 
-            Effects_Hit_Good = TxC(15, GAME + EFFECTS + @"Hit\" + @"Good\{0}.png");
-            Effects_Hit_Good_Big = TxC(15, GAME + EFFECTS + @"Hit\" + @"Good_Big\{0}.png");
-            Effects_Hit_Great = TxC(15, GAME + EFFECTS + @"Hit\" + @"Great\{0}.png");
-            Effects_Hit_Great_Big = TxC(15, GAME + EFFECTS + @"Hit\" + @"Great_Big\{0}.png");
+            Effects_Hit_Good = TxC(15, $@"{GAME}{EFFECTS}Hit\Good\{{0}}.png");
+            Effects_Hit_Good_Big = TxC(15, $@"{GAME}{EFFECTS}Hit\Good_Big\{{0}}.png");
+            Effects_Hit_Great = TxC(15, $@"{GAME}{EFFECTS}Hit\Great\{{0}}.png");
+            Effects_Hit_Great_Big = TxC(15, $@"{GAME}{EFFECTS}Hit\Great_Big\{{0}}.png");
 
-            TJAPlayer3.Skin.Game_Effect_Roll_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + EFFECTS + @"Roll\"));
-            Effects_Roll = TxC(TJAPlayer3.Skin.Game_Effect_Roll_Ptn, GAME + EFFECTS + @"Roll\{0}.png");
+            TJAPlayer3.Skin.Game_Effect_Roll_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{EFFECTS}Roll\"));
+            Effects_Roll = TxC(TJAPlayer3.Skin.Game_Effect_Roll_Ptn, $@"{GAME}{EFFECTS}Roll\{{0}}.png");
 
             #endregion
             #region レーン
             var lanes = new[] { "Normal", "Expert", "Master" };
-            Lane_Base = TxC(lanes, GAME + LANE + "Base_{0}.png");
-            Lane_Text = TxC(lanes, GAME + LANE + "Text_{0}.png");
+            Lane_Base = TxC(lanes, $"{GAME}{LANE}Base_{{0}}.png");
+            Lane_Text = TxC(lanes, $"{GAME}{LANE}Text_{{0}}.png");
 
-            Lane_Red = TxC(GAME + LANE + @"Red.png");
-            Lane_Blue = TxC(GAME + LANE + @"Blue.png");
-            Lane_Yellow = TxC(GAME + LANE + @"Yellow.png");
-            Lane_Background_Main = TxC(GAME + LANE + @"Background_Main.png");
-            Lane_Background_Sub = TxC(GAME + LANE + @"Background_Sub.png");
-            Lane_Background_GoGo = TxC(GAME + LANE + @"Background_GoGo.png");
+            Lane_Red = TxC($"{GAME}{LANE}Red.png");
+            Lane_Blue = TxC($"{GAME}{LANE}Blue.png");
+            Lane_Yellow = TxC($"{GAME}{LANE}Yellow.png");
+            Lane_Background_Main = TxC($"{GAME}{LANE}Background_Main.png");
+            Lane_Background_Sub = TxC($"{GAME}{LANE}Background_Sub.png");
+            Lane_Background_GoGo = TxC($"{GAME}{LANE}Background_GoGo.png");
 
             #endregion
             #region 終了演出
 
-            End_Clear_L = TxC(5, GAME + END + @"Clear_L_{0}.png");
-            End_Clear_R = TxC(5, GAME + END + @"Clear_R_{0}.png");
+            End_Clear_L = TxC(5, $"{GAME}{END}Clear_L_{{0}}.png");
+            End_Clear_R = TxC(5, $"{GAME}{END}Clear_R_{{0}}.png");
 
-            End_Clear_Text = TxC(GAME + END + @"Clear_Text.png");
-            End_Clear_Text_Effect = TxC(GAME + END + @"Clear_Text_Effect.png");
+            End_Clear_Text = TxC($"{GAME}{END}Clear_Text.png");
+            End_Clear_Text_Effect = TxC($"{GAME}{END}Clear_Text_Effect.png");
             if (End_Clear_Text_Effect != null) End_Clear_Text_Effect.b加算合成 = true;
             #endregion
             #region ゲームモード
-            GameMode_Timer_Tick = TxC(GAME + GAMEMODE + @"Timer_Tick.png");
-            GameMode_Timer_Frame = TxC(GAME + GAMEMODE + @"Timer_Frame.png");
+            GameMode_Timer_Tick = TxC($"{GAME}{GAMEMODE}Timer_Tick.png");
+            GameMode_Timer_Frame = TxC($"{GAME}{GAMEMODE}Timer_Frame.png");
             #endregion
             #region ステージ失敗
-            Failed_Game = TxC(GAME + FAILED + @"Game.png");
-            Failed_Stage = TxC(GAME + FAILED + @"Stage.png");
+            Failed_Game = TxC($"{GAME}{FAILED}Game.png");
+            Failed_Stage = TxC($"{GAME}{FAILED}Stage.png");
             #endregion
             #region ランナー
-            Runner = TxC(GAME + RUNNER + @"0.png");
+            Runner = TxC($"{GAME}{RUNNER}0.png");
             #endregion
             #region DanC
-            DanC_Background = TxC(GAME + DANC + @"Background.png");
+            DanC_Background = TxC($"{GAME}{DANC}Background.png");
 
             var type = new string[] { "Normal", "Reach", "Clear", "Flush" };
-            DanC_Gauge = TxC(type, GAME + DANC + "Gauge_{0}.png");
+            DanC_Gauge = TxC(type, $"{GAME}{DANC}Gauge_{{0}}.png");
 
-            DanC_Base = TxC(GAME + DANC + @"Base.png");
-            DanC_Failed = TxC(GAME + DANC + @"Failed.png");
-            DanC_Number = TxC(GAME + DANC + @"Number.png");
-            DanC_ExamType = TxC(GAME + DANC + @"ExamType.png");
-            DanC_ExamRange = TxC(GAME + DANC + @"ExamRange.png");
-            DanC_ExamUnit = TxC(GAME + DANC + @"ExamUnit.png");
-            DanC_Screen = TxC(GAME + DANC + @"Screen.png");
+            DanC_Base = TxC($"{GAME}{DANC}Base.png");
+            DanC_Failed = TxC($"{GAME}{DANC}Failed.png");
+            DanC_Number = TxC($"{GAME}{DANC}Number.png");
+            DanC_ExamType = TxC($"{GAME}{DANC}ExamType.png");
+            DanC_ExamRange = TxC($"{GAME}{DANC}ExamRange.png");
+            DanC_ExamUnit = TxC($"{GAME}{DANC}ExamUnit.png");
+            DanC_Screen = TxC($"{GAME}{DANC}Screen.png");
             #endregion
             #region PuichiChara
-            PuchiChara = TxC(GAME + PUCHICHARA + @"0.png");
+            PuchiChara = TxC($"{GAME}{PUCHICHARA}0.png");
             #endregion
             #endregion
 
             #region 6_結果発表
-            Result_Background = TxC(RESULT + @"Background.png");
-            Result_FadeIn = TxC(RESULT + @"FadeIn.png");
-            Result_Gauge = TxC(RESULT + @"Gauge.png");
-            Result_Gauge_Base = TxC(RESULT + @"Gauge_Base.png");
-            Result_Gauge_Hard = TxC(RESULT + @"Gauge_Hard.png");
-            Result_Gauge_ExHard = TxC(RESULT + @"Gauge_ExHard.png");
-            Result_Gauge_Base_Hard = TxC(RESULT + @"Gauge_Base_Hard.png");
-            Result_Gauge_Base_ExHard = TxC(RESULT + @"Gauge_Base_ExHard.png");
-            Result_Judge = TxC(RESULT + @"Judge.png");
-            Result_Header = TxC(RESULT + @"Header.png");
-            Result_Number = TxC(RESULT + @"Number.png");
-            Result_Panel = TxC(RESULT + @"Panel.png");
-            Result_Score_Text = TxC(RESULT + @"Score_Text.png");
-            Result_Score_Number = TxC(RESULT + @"Score_Number.png");
-            Result_Dan = TxC(RESULT + @"Dan.png");
+            Result_Background = TxC($"{RESULT}Background.png");
+            Result_FadeIn = TxC($"{RESULT}FadeIn.png");
+            Result_Gauge = TxC($"{RESULT}Gauge.png");
+            Result_Gauge_Base = TxC($"{RESULT}Gauge_Base.png");
+            Result_Gauge_Hard = TxC($"{RESULT}Gauge_Hard.png");
+            Result_Gauge_ExHard = TxC($"{RESULT}Gauge_ExHard.png");
+            Result_Gauge_Base_Hard = TxC($"{RESULT}Gauge_Base_Hard.png");
+            Result_Gauge_Base_ExHard = TxC($"{RESULT}Gauge_Base_ExHard.png");
+            Result_Judge = TxC($"{RESULT}Judge.png");
+            Result_Header = TxC($"{RESULT}Header.png");
+            Result_Number = TxC($"{RESULT}Number.png");
+            Result_Panel = TxC($"{RESULT}Panel.png");
+            Result_Score_Text = TxC($"{RESULT}Score_Text.png");
+            Result_Score_Number = TxC($"{RESULT}Score_Number.png");
+            Result_Dan = TxC($"{RESULT}Dan.png");
             #endregion
 
             #region 7_終了画面
-            Exit_Background = TxC(EXIT + @"Background.png");
+            Exit_Background = TxC($"{EXIT}Background.png");
             #endregion
 
         }

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -45,12 +45,12 @@ namespace TJAPlayer3
 
         private readonly List<CTexture> _trackedTextures = new List<CTexture>();
 
-        private CTexture[] TxC(int count, string format, int offset = 0)
+        private CTexture[] TxC(int count, string format, int start = 0)
         {
-            return TxC(Enumerable.Range(offset, count).ToList(), format);
+            return TxC(format, Enumerable.Range(start, count).Select(o => o.ToString()).ToArray());
         }
 
-        private CTexture[] TxC<T>(IEnumerable<T> parts, string format)
+        private CTexture[] TxC(string format, params string[] parts)
         {
             return parts.Select(o => TxC(string.Format(format, o))).ToArray();
         }
@@ -197,8 +197,7 @@ namespace TJAPlayer3
             TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}10combo_Max\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max != 0)
             {
-                Chara_10Combo_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max,
-                    $@"{GAME}{CHARA}10combo_Max\{{0}}.png");
+                Chara_10Combo_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max, $@"{GAME}{CHARA}10combo_Max\{{0}}.png");
             }
 
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}GoGoStart\"));
@@ -209,8 +208,7 @@ namespace TJAPlayer3
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}GoGoStart_Max\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max != 0)
             {
-                Chara_GoGoStart_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max,
-                    $@"{GAME}{CHARA}GoGoStart_Max\{{0}}.png");
+                Chara_GoGoStart_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max, $@"{GAME}{CHARA}GoGoStart_Max\{{0}}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}ClearIn\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn != 0)
@@ -225,20 +223,17 @@ namespace TJAPlayer3
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Balloon_Breaking\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking != 0)
             {
-                Chara_Balloon_Breaking = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking,
-                    $@"{GAME}{CHARA}Balloon_Breaking\{{0}}.png");
+                Chara_Balloon_Breaking = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking, $@"{GAME}{CHARA}Balloon_Breaking\{{0}}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Balloon_Broke\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke != 0)
             {
-                Chara_Balloon_Broke = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke,
-                    $@"{GAME}{CHARA}Balloon_Broke\{{0}}.png");
+                Chara_Balloon_Broke = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke, $@"{GAME}{CHARA}Balloon_Broke\{{0}}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Balloon_Miss\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss != 0)
             {
-                Chara_Balloon_Miss = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss,
-                    $@"{GAME}{CHARA}Balloon_Miss\{{0}}.png");
+                Chara_Balloon_Miss = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss, $@"{GAME}{CHARA}Balloon_Miss\{{0}}.png");
             }
             #endregion
             #region 踊り子
@@ -290,11 +285,11 @@ namespace TJAPlayer3
             Taiko_LevelUp = TxC($"{GAME}{TAIKO}LevelUp.png");
             Taiko_LevelDown = TxC($"{GAME}{TAIKO}LevelDown.png");
 
-            Course_Symbol = TxC(Course_Symbols, $"{GAME}{COURSESYMBOL}{{0}}.png");
+            Course_Symbol = TxC($"{GAME}{COURSESYMBOL}{{0}}.png", Course_Symbols);
 
-            Taiko_Score = TxC(new[] {"", "_1P", "_2P"}, $"{GAME}{TAIKO}Score{{0}}.png");
+            Taiko_Score = TxC($"{GAME}{TAIKO}Score{{0}}.png", "", "_1P", "_2P");
 
-            Taiko_Combo = TxC(new[] {"", "_Big"}, $"{GAME}{TAIKO}Combo{{0}}.png");
+            Taiko_Combo = TxC($"{GAME}{TAIKO}Combo{{0}}.png", "", "_Big");
             Taiko_Combo_Effect = TxC($"{GAME}{TAIKO}Combo_Effect.png");
             Taiko_Combo_Text = TxC($"{GAME}{TAIKO}Combo_Text.png");
             #endregion
@@ -358,8 +353,8 @@ namespace TJAPlayer3
             #endregion
             #region レーン
             var lanes = new[] { "Normal", "Expert", "Master" };
-            Lane_Base = TxC(lanes, $"{GAME}{LANE}Base_{{0}}.png");
-            Lane_Text = TxC(lanes, $"{GAME}{LANE}Text_{{0}}.png");
+            Lane_Base = TxC($"{GAME}{LANE}Base_{{0}}.png", lanes);
+            Lane_Text = TxC($"{GAME}{LANE}Text_{{0}}.png", lanes);
 
             Lane_Red = TxC($"{GAME}{LANE}Red.png");
             Lane_Blue = TxC($"{GAME}{LANE}Blue.png");
@@ -392,8 +387,7 @@ namespace TJAPlayer3
             #region DanC
             DanC_Background = TxC($"{GAME}{DANC}Background.png");
 
-            var type = new string[] { "Normal", "Reach", "Clear", "Flush" };
-            DanC_Gauge = TxC(type, $"{GAME}{DANC}Gauge_{{0}}.png");
+            DanC_Gauge = TxC($"{GAME}{DANC}Gauge_{{0}}.png", "Normal", "Reach", "Clear", "Flush");
 
             DanC_Base = TxC($"{GAME}{DANC}Base.png");
             DanC_Failed = TxC($"{GAME}{DANC}Failed.png");

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -270,7 +270,7 @@ namespace TJAPlayer3
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke != 0)
             {
                 Chara_Balloon_Broke = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke];
-                for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke; i++)
+                for (int i = 0; i < Chara_Balloon_Broke.Length; i++)
                 {
                     Chara_Balloon_Broke[i] = TxC(GAME + CHARA + @"Balloon_Broke\" + i.ToString() + ".png");
                 }
@@ -670,7 +670,7 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Chara_Become_Cleared);
             TJAPlayer3.t安全にDisposeする(ref Chara_Become_Maxed);
             TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Breaking);
-            TJAPlayer3.t安全にDisposeする(Chara_Balloon_Broke);
+            TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Broke);
             TJAPlayer3.t安全にDisposeする(Chara_Balloon_Miss);
             #endregion
             #region 踊り子

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -114,25 +114,25 @@ namespace TJAPlayer3
             SongSelect_Bar_Genre = new CTexture[9];
             for (int i = 0; i < SongSelect_Bar_Genre.Length; i++)
             {
-                SongSelect_Bar_Genre[i] = TxC(SONGSELECT + @"Bar_Genre_" + i + ".png");
+                SongSelect_Bar_Genre[i] = TxC(string.Format(SONGSELECT + "Bar_Genre_{0}.png", i));
             }
 
             SongSelect_Frame_Box = new CTexture[9];
             for (int i = 0; i < SongSelect_Frame_Box.Length; i++)
             {
-                SongSelect_Frame_Box[i] = TxC(SONGSELECT + @"Frame_Box_" + i + ".png");
+                SongSelect_Frame_Box[i] = TxC(string.Format(SONGSELECT + "Frame_Box_{0}.png", i));
             }
 
             SongSelect_ScoreWindow = new CTexture[(int) Difficulty.Total];
             for (int i = 0; i < SongSelect_ScoreWindow.Length; i++)
             {
-                SongSelect_ScoreWindow[i] = TxC(SONGSELECT + @"ScoreWindow_" + i + ".png");
+                SongSelect_ScoreWindow[i] = TxC(string.Format(SONGSELECT + "ScoreWindow_{0}.png", i));
             }
 
             SongSelect_GenreBack = new CTexture[9];
             for (int i = 0; i < SongSelect_GenreBack.Length; i++)
             {
-                SongSelect_GenreBack[i] = TxC(SONGSELECT + @"GenreBackground_" + i + ".png");
+                SongSelect_GenreBack[i] = TxC(string.Format(SONGSELECT + "GenreBackground_{0}.png", i));
             }
             SongSelect_ScoreWindow_Text = TxC(SONGSELECT + @"ScoreWindow_Text.png");
             SongSelect_Rating = TxC(SONGSELECT + @"Rating.png");
@@ -164,7 +164,7 @@ namespace TJAPlayer3
                 Chara_Normal = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Normal];
                 for (int i = 0; i < Chara_Normal.Length; i++)
                 {
-                    Chara_Normal[i] = TxC(GAME + CHARA + @"Normal\" + i + ".png");
+                    Chara_Normal[i] = TxC(string.Format(GAME + CHARA + @"Normal\{0}.png", i));
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Clear = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Clear\"));
@@ -173,7 +173,7 @@ namespace TJAPlayer3
                 Chara_Normal_Cleared = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Clear];
                 for (int i = 0; i < Chara_Normal_Cleared.Length; i++)
                 {
-                    Chara_Normal_Cleared[i] = TxC(GAME + CHARA + @"Clear\" + i + ".png");
+                    Chara_Normal_Cleared[i] = TxC(string.Format(GAME + CHARA + @"Clear\{0}.png", i));
                 }
             }
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
@@ -181,7 +181,7 @@ namespace TJAPlayer3
                 Chara_Normal_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Clear];
                 for (int i = 0; i < Chara_Normal_Maxed.Length; i++)
                 {
-                    Chara_Normal_Maxed[i] = TxC(GAME + CHARA + @"Clear_Max\" + i + ".png");
+                    Chara_Normal_Maxed[i] = TxC(string.Format(GAME + CHARA + @"Clear_Max\{0}.png", i));
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGo\"));
@@ -190,7 +190,7 @@ namespace TJAPlayer3
                 Chara_GoGoTime = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGo];
                 for (int i = 0; i < Chara_GoGoTime.Length; i++)
                 {
-                    Chara_GoGoTime[i] = TxC(GAME + CHARA + @"GoGo\" + i + ".png");
+                    Chara_GoGoTime[i] = TxC(string.Format(GAME + CHARA + @"GoGo\{0}.png", i));
                 }
             }
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
@@ -198,7 +198,7 @@ namespace TJAPlayer3
                 Chara_GoGoTime_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGo];
                 for (int i = 0; i < Chara_GoGoTime_Maxed.Length; i++)
                 {
-                    Chara_GoGoTime_Maxed[i] = TxC(GAME + CHARA + @"GoGo_Max\" + i + ".png");
+                    Chara_GoGoTime_Maxed[i] = TxC(string.Format(GAME + CHARA + @"GoGo_Max\{0}.png", i));
                 }
             }
 
@@ -208,7 +208,7 @@ namespace TJAPlayer3
                 Chara_10Combo = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_10combo];
                 for (int i = 0; i < Chara_10Combo.Length; i++)
                 {
-                    Chara_10Combo[i] = TxC(GAME + CHARA + @"10combo\" + i + ".png");
+                    Chara_10Combo[i] = TxC(string.Format(GAME + CHARA + @"10combo\{0}.png", i));
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"10combo_Max\"));
@@ -217,7 +217,7 @@ namespace TJAPlayer3
                 Chara_10Combo_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max];
                 for (int i = 0; i < Chara_10Combo_Maxed.Length; i++)
                 {
-                    Chara_10Combo_Maxed[i] = TxC(GAME + CHARA + @"10combo_Max\" + i + ".png");
+                    Chara_10Combo_Maxed[i] = TxC(string.Format(GAME + CHARA + @"10combo_Max\{0}.png", i));
                 }
             }
 
@@ -227,7 +227,7 @@ namespace TJAPlayer3
                 Chara_GoGoStart = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart];
                 for (int i = 0; i < Chara_GoGoStart.Length; i++)
                 {
-                    Chara_GoGoStart[i] = TxC(GAME + CHARA + @"GoGoStart\" + i + ".png");
+                    Chara_GoGoStart[i] = TxC(string.Format(GAME + CHARA + @"GoGoStart\{0}.png", i));
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGoStart_Max\"));
@@ -236,7 +236,7 @@ namespace TJAPlayer3
                 Chara_GoGoStart_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max];
                 for (int i = 0; i < Chara_GoGoStart_Maxed.Length; i++)
                 {
-                    Chara_GoGoStart_Maxed[i] = TxC(GAME + CHARA + @"GoGoStart_Max\" + i + ".png");
+                    Chara_GoGoStart_Maxed[i] = TxC(string.Format(GAME + CHARA + @"GoGoStart_Max\{0}.png", i));
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"ClearIn\"));
@@ -245,7 +245,7 @@ namespace TJAPlayer3
                 Chara_Become_Cleared = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn];
                 for (int i = 0; i < Chara_Become_Cleared.Length; i++)
                 {
-                    Chara_Become_Cleared[i] = TxC(GAME + CHARA + @"ClearIn\" + i + ".png");
+                    Chara_Become_Cleared[i] = TxC(string.Format(GAME + CHARA + @"ClearIn\{0}.png", i));
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"SoulIn\"));
@@ -254,7 +254,7 @@ namespace TJAPlayer3
                 Chara_Become_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn];
                 for (int i = 0; i < Chara_Become_Maxed.Length; i++)
                 {
-                    Chara_Become_Maxed[i] = TxC(GAME + CHARA + @"SoulIn\" + i + ".png");
+                    Chara_Become_Maxed[i] = TxC(string.Format(GAME + CHARA + @"SoulIn\{0}.png", i));
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Breaking\"));
@@ -263,7 +263,7 @@ namespace TJAPlayer3
                 Chara_Balloon_Breaking = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking];
                 for (int i = 0; i < Chara_Balloon_Breaking.Length; i++)
                 {
-                    Chara_Balloon_Breaking[i] = TxC(GAME + CHARA + @"Balloon_Breaking\" + i + ".png");
+                    Chara_Balloon_Breaking[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Breaking\{0}.png", i));
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Broke\"));
@@ -272,7 +272,7 @@ namespace TJAPlayer3
                 Chara_Balloon_Broke = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke];
                 for (int i = 0; i < Chara_Balloon_Broke.Length; i++)
                 {
-                    Chara_Balloon_Broke[i] = TxC(GAME + CHARA + @"Balloon_Broke\" + i + ".png");
+                    Chara_Balloon_Broke[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Broke\{0}.png", i));
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Miss\"));
@@ -281,7 +281,7 @@ namespace TJAPlayer3
                 Chara_Balloon_Miss = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss];
                 for (int i = 0; i < Chara_Balloon_Miss.Length; i++)
                 {
-                    Chara_Balloon_Miss[i] = TxC(GAME + CHARA + @"Balloon_Miss\" + i + ".png");
+                    Chara_Balloon_Miss[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Miss\{0}.png", i));
                 }
             }
             #endregion
@@ -305,7 +305,7 @@ namespace TJAPlayer3
             Mob = new CTexture[TJAPlayer3.Skin.Game_Mob_Ptn];
             for (int i = 0; i < Mob.Length; i++)
             {
-                Mob[i] = TxC(GAME + MOB + i + ".png");
+                Mob[i] = TxC(string.Format(GAME + MOB + "{0}.png", i));
             }
             #endregion
             #region フッター
@@ -410,7 +410,7 @@ namespace TJAPlayer3
                 Gauge_Rainbow = new CTexture[TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn];
                 for (int i = 0; i < TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn; i++)
                 {
-                    Gauge_Rainbow[i] = TxC(GAME + GAUGE + @"Rainbow\" + i + ".png");
+                    Gauge_Rainbow[i] = TxC(string.Format(GAME + GAUGE + @"Rainbow\{0}.png", i));
                 }
             }
             Gauge_Soul = TxC(GAME + GAUGE + @"Soul.png");
@@ -434,7 +434,7 @@ namespace TJAPlayer3
             Balloon_Breaking = new CTexture[6];
             for (int i = 0; i < Balloon_Breaking.Length; i++)
             {
-                Balloon_Breaking[i] = TxC(GAME + BALLOON + @"Breaking_" + i + ".png");
+                Balloon_Breaking[i] = TxC(string.Format(GAME + BALLOON + @"Breaking_{0}.png", i));
             }
             #endregion
             #region エフェクト
@@ -457,32 +457,32 @@ namespace TJAPlayer3
             Effects_Hit_Good = new CTexture[15];
             for (int i = 0; i < Effects_Hit_Good.Length; i++)
             {
-                Effects_Hit_Good[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Good\" + i + ".png");
+                Effects_Hit_Good[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Good\{0}.png", i));
             }
 
             Effects_Hit_Good_Big = new CTexture[15];
             for (int i = 0; i < Effects_Hit_Good_Big.Length; i++)
             {
-                Effects_Hit_Good_Big[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Good_Big\" + i + ".png");
+                Effects_Hit_Good_Big[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Good_Big\{0}.png", i));
             }
 
             Effects_Hit_Great = new CTexture[15];
             for (int i = 0; i < Effects_Hit_Great.Length; i++)
             {
-                Effects_Hit_Great[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Great\" + i + ".png");
+                Effects_Hit_Great[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Great\{0}.png", i));
             }
 
             Effects_Hit_Great_Big = new CTexture[15];
             for (int i = 0; i < Effects_Hit_Great_Big.Length; i++)
             {
-                Effects_Hit_Great_Big[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Great_Big\" + i + ".png");
+                Effects_Hit_Great_Big[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Great_Big\{0}.png", i));
             }
 
             TJAPlayer3.Skin.Game_Effect_Roll_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + EFFECTS + @"Roll\"));
             Effects_Roll = new CTexture[TJAPlayer3.Skin.Game_Effect_Roll_Ptn];
             for (int i = 0; i < TJAPlayer3.Skin.Game_Effect_Roll_Ptn; i++)
             {
-                Effects_Roll[i] = TxC(GAME + EFFECTS + @"Roll\" + i + ".png");
+                Effects_Roll[i] = TxC(string.Format(GAME + EFFECTS + @"Roll\{0}.png", i));
             }
             #endregion
             #region レーン
@@ -511,12 +511,12 @@ namespace TJAPlayer3
             End_Clear_L = new CTexture[5];
             for (int i = 0; i < End_Clear_L.Length; i++)
             {
-                End_Clear_L[i] = TxC(GAME + END + @"Clear_L_" + i + ".png");
+                End_Clear_L[i] = TxC(string.Format(GAME + END + @"Clear_L_{0}.png", i));
             }
             End_Clear_R = new CTexture[5];
             for (int i = 0; i < End_Clear_R.Length; i++)
             {
-                End_Clear_R[i] = TxC(GAME + END + @"Clear_R_" + i + ".png");
+                End_Clear_R[i] = TxC(string.Format(GAME + END + @"Clear_R_{0}.png", i));
             }
 
             End_Clear_Text = TxC(GAME + END + @"Clear_Text.png");

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -252,7 +252,7 @@ namespace TJAPlayer3
             if (TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn != 0)
             {
                 Chara_Become_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn];
-                for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn; i++)
+                for (int i = 0; i < Chara_Become_Maxed.Length; i++)
                 {
                     Chara_Become_Maxed[i] = TxC(GAME + CHARA + @"SoulIn\" + i.ToString() + ".png");
                 }
@@ -668,7 +668,7 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart);
             TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart_Maxed);
             TJAPlayer3.t安全にDisposeする(ref Chara_Become_Cleared);
-            TJAPlayer3.t安全にDisposeする(Chara_Become_Maxed);
+            TJAPlayer3.t安全にDisposeする(ref Chara_Become_Maxed);
             TJAPlayer3.t安全にDisposeする(Chara_Balloon_Breaking);
             TJAPlayer3.t安全にDisposeする(Chara_Balloon_Broke);
             TJAPlayer3.t安全にDisposeする(Chara_Balloon_Miss);

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -303,7 +303,7 @@ namespace TJAPlayer3
             #region モブ
             TJAPlayer3.Skin.Game_Mob_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + MOB));
             Mob = new CTexture[TJAPlayer3.Skin.Game_Mob_Ptn];
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Mob_Ptn; i++)
+            for (int i = 0; i < Mob.Length; i++)
             {
                 Mob[i] = TxC(GAME + MOB + i.ToString() + ".png");
             }
@@ -677,7 +677,7 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Dancer);
             #endregion
             #region モブ
-            TJAPlayer3.t安全にDisposeする(Mob);
+            TJAPlayer3.t安全にDisposeする(ref Mob);
             #endregion
             #region フッター
             TJAPlayer3.t安全にDisposeする(ref Mob_Footer);

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -225,7 +225,7 @@ namespace TJAPlayer3
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart != 0)
             {
                 Chara_GoGoStart = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart];
-                for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart; i++)
+                for (int i = 0; i < Chara_GoGoStart.Length; i++)
                 {
                     Chara_GoGoStart[i] = TxC(GAME + CHARA + @"GoGoStart\" + i.ToString() + ".png");
                 }
@@ -665,7 +665,7 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Chara_GoGoTime_Maxed);
             TJAPlayer3.t安全にDisposeする(ref Chara_10Combo);
             TJAPlayer3.t安全にDisposeする(ref Chara_10Combo_Maxed);
-            TJAPlayer3.t安全にDisposeする(Chara_GoGoStart);
+            TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart);
             TJAPlayer3.t安全にDisposeする(Chara_GoGoStart_Maxed);
             TJAPlayer3.t安全にDisposeする(Chara_Become_Cleared);
             TJAPlayer3.t安全にDisposeする(Chara_Become_Maxed);

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -41,13 +41,6 @@ namespace TJAPlayer3
         const string ROLL = @"Roll\";
         const string SPLASH = @"Splash\";
 
-
-        public TextureLoader()
-        {
-            // コンストラクタ
-
-        }
-
         private CTexture[] TxC(int count, string format)
         {
             var array = new CTexture[count];
@@ -72,17 +65,29 @@ namespace TJAPlayer3
             return array;
         }
 
-        internal CTexture TxC(string FileName)
+        private CTexture TxC(string path)
         {
-            return TJAPlayer3.tテクスチャの生成(CSkin.Path(BASE + FileName));
+            return TxCUntracked(path);
         }
-        internal CTextureAf TxCAf(string FileName)
+
+        private CTextureAf TxCAf(string path)
         {
-            return TJAPlayer3.tテクスチャの生成Af(CSkin.Path(BASE + FileName));
+            return TxCAfUntracked(path);
         }
-        internal CTexture TxCGen(string FileName)
+
+        internal CTexture TxCUntracked(string path)
         {
-            return TJAPlayer3.tテクスチャの生成(CSkin.Path(BASE + GAME + GENRE + FileName + ".png"));
+            return TJAPlayer3.tテクスチャの生成(CSkin.Path(BASE + path));
+        }
+
+        private CTextureAf TxCAfUntracked(string path)
+        {
+            return TJAPlayer3.tテクスチャの生成Af(CSkin.Path(BASE + path));
+        }
+
+        internal CTexture TxCGenreUntracked(string fileNameWithoutExtension)
+        {
+            return TJAPlayer3.tテクスチャの生成(CSkin.Path(BASE + GAME + GENRE + fileNameWithoutExtension + ".png"));
         }
 
         public void LoadTexture()

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -114,25 +114,25 @@ namespace TJAPlayer3
             SongSelect_Bar_Genre = new CTexture[9];
             for (int i = 0; i < SongSelect_Bar_Genre.Length; i++)
             {
-                SongSelect_Bar_Genre[i] = TxC(SONGSELECT + @"Bar_Genre_" + i.ToString() + ".png");
+                SongSelect_Bar_Genre[i] = TxC(SONGSELECT + @"Bar_Genre_" + i + ".png");
             }
 
             SongSelect_Frame_Box = new CTexture[9];
             for (int i = 0; i < SongSelect_Frame_Box.Length; i++)
             {
-                SongSelect_Frame_Box[i] = TxC(SONGSELECT + @"Frame_Box_" + i.ToString() + ".png");
+                SongSelect_Frame_Box[i] = TxC(SONGSELECT + @"Frame_Box_" + i + ".png");
             }
 
             SongSelect_ScoreWindow = new CTexture[(int) Difficulty.Total];
             for (int i = 0; i < SongSelect_ScoreWindow.Length; i++)
             {
-                SongSelect_ScoreWindow[i] = TxC(SONGSELECT + @"ScoreWindow_" + i.ToString() + ".png");
+                SongSelect_ScoreWindow[i] = TxC(SONGSELECT + @"ScoreWindow_" + i + ".png");
             }
 
             SongSelect_GenreBack = new CTexture[9];
             for (int i = 0; i < SongSelect_GenreBack.Length; i++)
             {
-                SongSelect_GenreBack[i] = TxC(SONGSELECT + @"GenreBackground_" + i.ToString() + ".png");
+                SongSelect_GenreBack[i] = TxC(SONGSELECT + @"GenreBackground_" + i + ".png");
             }
             SongSelect_ScoreWindow_Text = TxC(SONGSELECT + @"ScoreWindow_Text.png");
             SongSelect_Rating = TxC(SONGSELECT + @"Rating.png");
@@ -164,7 +164,7 @@ namespace TJAPlayer3
                 Chara_Normal = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Normal];
                 for (int i = 0; i < Chara_Normal.Length; i++)
                 {
-                    Chara_Normal[i] = TxC(GAME + CHARA + @"Normal\" + i.ToString() + ".png");
+                    Chara_Normal[i] = TxC(GAME + CHARA + @"Normal\" + i + ".png");
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Clear = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Clear\"));
@@ -173,7 +173,7 @@ namespace TJAPlayer3
                 Chara_Normal_Cleared = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Clear];
                 for (int i = 0; i < Chara_Normal_Cleared.Length; i++)
                 {
-                    Chara_Normal_Cleared[i] = TxC(GAME + CHARA + @"Clear\" + i.ToString() + ".png");
+                    Chara_Normal_Cleared[i] = TxC(GAME + CHARA + @"Clear\" + i + ".png");
                 }
             }
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
@@ -181,7 +181,7 @@ namespace TJAPlayer3
                 Chara_Normal_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Clear];
                 for (int i = 0; i < Chara_Normal_Maxed.Length; i++)
                 {
-                    Chara_Normal_Maxed[i] = TxC(GAME + CHARA + @"Clear_Max\" + i.ToString() + ".png");
+                    Chara_Normal_Maxed[i] = TxC(GAME + CHARA + @"Clear_Max\" + i + ".png");
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGo\"));
@@ -190,7 +190,7 @@ namespace TJAPlayer3
                 Chara_GoGoTime = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGo];
                 for (int i = 0; i < Chara_GoGoTime.Length; i++)
                 {
-                    Chara_GoGoTime[i] = TxC(GAME + CHARA + @"GoGo\" + i.ToString() + ".png");
+                    Chara_GoGoTime[i] = TxC(GAME + CHARA + @"GoGo\" + i + ".png");
                 }
             }
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
@@ -198,7 +198,7 @@ namespace TJAPlayer3
                 Chara_GoGoTime_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGo];
                 for (int i = 0; i < Chara_GoGoTime_Maxed.Length; i++)
                 {
-                    Chara_GoGoTime_Maxed[i] = TxC(GAME + CHARA + @"GoGo_Max\" + i.ToString() + ".png");
+                    Chara_GoGoTime_Maxed[i] = TxC(GAME + CHARA + @"GoGo_Max\" + i + ".png");
                 }
             }
 
@@ -208,7 +208,7 @@ namespace TJAPlayer3
                 Chara_10Combo = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_10combo];
                 for (int i = 0; i < Chara_10Combo.Length; i++)
                 {
-                    Chara_10Combo[i] = TxC(GAME + CHARA + @"10combo\" + i.ToString() + ".png");
+                    Chara_10Combo[i] = TxC(GAME + CHARA + @"10combo\" + i + ".png");
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"10combo_Max\"));
@@ -217,7 +217,7 @@ namespace TJAPlayer3
                 Chara_10Combo_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max];
                 for (int i = 0; i < Chara_10Combo_Maxed.Length; i++)
                 {
-                    Chara_10Combo_Maxed[i] = TxC(GAME + CHARA + @"10combo_Max\" + i.ToString() + ".png");
+                    Chara_10Combo_Maxed[i] = TxC(GAME + CHARA + @"10combo_Max\" + i + ".png");
                 }
             }
 
@@ -227,7 +227,7 @@ namespace TJAPlayer3
                 Chara_GoGoStart = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart];
                 for (int i = 0; i < Chara_GoGoStart.Length; i++)
                 {
-                    Chara_GoGoStart[i] = TxC(GAME + CHARA + @"GoGoStart\" + i.ToString() + ".png");
+                    Chara_GoGoStart[i] = TxC(GAME + CHARA + @"GoGoStart\" + i + ".png");
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGoStart_Max\"));
@@ -236,7 +236,7 @@ namespace TJAPlayer3
                 Chara_GoGoStart_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max];
                 for (int i = 0; i < Chara_GoGoStart_Maxed.Length; i++)
                 {
-                    Chara_GoGoStart_Maxed[i] = TxC(GAME + CHARA + @"GoGoStart_Max\" + i.ToString() + ".png");
+                    Chara_GoGoStart_Maxed[i] = TxC(GAME + CHARA + @"GoGoStart_Max\" + i + ".png");
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"ClearIn\"));
@@ -245,7 +245,7 @@ namespace TJAPlayer3
                 Chara_Become_Cleared = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn];
                 for (int i = 0; i < Chara_Become_Cleared.Length; i++)
                 {
-                    Chara_Become_Cleared[i] = TxC(GAME + CHARA + @"ClearIn\" + i.ToString() + ".png");
+                    Chara_Become_Cleared[i] = TxC(GAME + CHARA + @"ClearIn\" + i + ".png");
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"SoulIn\"));
@@ -254,7 +254,7 @@ namespace TJAPlayer3
                 Chara_Become_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn];
                 for (int i = 0; i < Chara_Become_Maxed.Length; i++)
                 {
-                    Chara_Become_Maxed[i] = TxC(GAME + CHARA + @"SoulIn\" + i.ToString() + ".png");
+                    Chara_Become_Maxed[i] = TxC(GAME + CHARA + @"SoulIn\" + i + ".png");
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Breaking\"));
@@ -263,7 +263,7 @@ namespace TJAPlayer3
                 Chara_Balloon_Breaking = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking];
                 for (int i = 0; i < Chara_Balloon_Breaking.Length; i++)
                 {
-                    Chara_Balloon_Breaking[i] = TxC(GAME + CHARA + @"Balloon_Breaking\" + i.ToString() + ".png");
+                    Chara_Balloon_Breaking[i] = TxC(GAME + CHARA + @"Balloon_Breaking\" + i + ".png");
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Broke\"));
@@ -272,7 +272,7 @@ namespace TJAPlayer3
                 Chara_Balloon_Broke = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke];
                 for (int i = 0; i < Chara_Balloon_Broke.Length; i++)
                 {
-                    Chara_Balloon_Broke[i] = TxC(GAME + CHARA + @"Balloon_Broke\" + i.ToString() + ".png");
+                    Chara_Balloon_Broke[i] = TxC(GAME + CHARA + @"Balloon_Broke\" + i + ".png");
                 }
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Miss\"));
@@ -281,7 +281,7 @@ namespace TJAPlayer3
                 Chara_Balloon_Miss = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss];
                 for (int i = 0; i < Chara_Balloon_Miss.Length; i++)
                 {
-                    Chara_Balloon_Miss[i] = TxC(GAME + CHARA + @"Balloon_Miss\" + i.ToString() + ".png");
+                    Chara_Balloon_Miss[i] = TxC(GAME + CHARA + @"Balloon_Miss\" + i + ".png");
                 }
             }
             #endregion
@@ -295,7 +295,7 @@ namespace TJAPlayer3
                     Dancer[i] = new CTexture[TJAPlayer3.Skin.Game_Dancer_Ptn];
                     for (int p = 0; p < TJAPlayer3.Skin.Game_Dancer_Ptn; p++)
                     {
-                        Dancer[i][p] = TxC(GAME + DANCER + (i + 1) + @"\" + p.ToString() + ".png");
+                        Dancer[i][p] = TxC(GAME + DANCER + (i + 1) + @"\" + p + ".png");
                     }
                 }
             }
@@ -305,7 +305,7 @@ namespace TJAPlayer3
             Mob = new CTexture[TJAPlayer3.Skin.Game_Mob_Ptn];
             for (int i = 0; i < Mob.Length; i++)
             {
-                Mob[i] = TxC(GAME + MOB + i.ToString() + ".png");
+                Mob[i] = TxC(GAME + MOB + i + ".png");
             }
             #endregion
             #region フッター
@@ -410,7 +410,7 @@ namespace TJAPlayer3
                 Gauge_Rainbow = new CTexture[TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn];
                 for (int i = 0; i < TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn; i++)
                 {
-                    Gauge_Rainbow[i] = TxC(GAME + GAUGE + @"Rainbow\" + i.ToString() + ".png");
+                    Gauge_Rainbow[i] = TxC(GAME + GAUGE + @"Rainbow\" + i + ".png");
                 }
             }
             Gauge_Soul = TxC(GAME + GAUGE + @"Soul.png");
@@ -434,7 +434,7 @@ namespace TJAPlayer3
             Balloon_Breaking = new CTexture[6];
             for (int i = 0; i < Balloon_Breaking.Length; i++)
             {
-                Balloon_Breaking[i] = TxC(GAME + BALLOON + @"Breaking_" + i.ToString() + ".png");
+                Balloon_Breaking[i] = TxC(GAME + BALLOON + @"Breaking_" + i + ".png");
             }
             #endregion
             #region エフェクト
@@ -457,32 +457,32 @@ namespace TJAPlayer3
             Effects_Hit_Good = new CTexture[15];
             for (int i = 0; i < Effects_Hit_Good.Length; i++)
             {
-                Effects_Hit_Good[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Good\" + i.ToString() + ".png");
+                Effects_Hit_Good[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Good\" + i + ".png");
             }
 
             Effects_Hit_Good_Big = new CTexture[15];
             for (int i = 0; i < Effects_Hit_Good_Big.Length; i++)
             {
-                Effects_Hit_Good_Big[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Good_Big\" + i.ToString() + ".png");
+                Effects_Hit_Good_Big[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Good_Big\" + i + ".png");
             }
 
             Effects_Hit_Great = new CTexture[15];
             for (int i = 0; i < Effects_Hit_Great.Length; i++)
             {
-                Effects_Hit_Great[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Great\" + i.ToString() + ".png");
+                Effects_Hit_Great[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Great\" + i + ".png");
             }
 
             Effects_Hit_Great_Big = new CTexture[15];
             for (int i = 0; i < Effects_Hit_Great_Big.Length; i++)
             {
-                Effects_Hit_Great_Big[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Great_Big\" + i.ToString() + ".png");
+                Effects_Hit_Great_Big[i] = TxC(GAME + EFFECTS + @"Hit\" + @"Great_Big\" + i + ".png");
             }
 
             TJAPlayer3.Skin.Game_Effect_Roll_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + EFFECTS + @"Roll\"));
             Effects_Roll = new CTexture[TJAPlayer3.Skin.Game_Effect_Roll_Ptn];
             for (int i = 0; i < TJAPlayer3.Skin.Game_Effect_Roll_Ptn; i++)
             {
-                Effects_Roll[i] = TxC(GAME + EFFECTS + @"Roll\" + i.ToString() + ".png");
+                Effects_Roll[i] = TxC(GAME + EFFECTS + @"Roll\" + i + ".png");
             }
             #endregion
             #region レーン
@@ -511,12 +511,12 @@ namespace TJAPlayer3
             End_Clear_L = new CTexture[5];
             for (int i = 0; i < End_Clear_L.Length; i++)
             {
-                End_Clear_L[i] = TxC(GAME + END + @"Clear_L_" + i.ToString() + ".png");
+                End_Clear_L[i] = TxC(GAME + END + @"Clear_L_" + i + ".png");
             }
             End_Clear_R = new CTexture[5];
             for (int i = 0; i < End_Clear_R.Length; i++)
             {
-                End_Clear_R[i] = TxC(GAME + END + @"Clear_R_" + i.ToString() + ".png");
+                End_Clear_R[i] = TxC(GAME + END + @"Clear_R_" + i + ".png");
             }
 
             End_Clear_Text = TxC(GAME + END + @"Clear_Text.png");

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -165,108 +165,117 @@ namespace TJAPlayer3
 
             #endregion
             #region キャラクター
-            TJAPlayer3.Skin.Game_Chara_Ptn_Normal = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}Normal\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_Normal != 0)
-            {
-                Chara_Normal = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Normal, $@"{GAME}{CHARA}Normal\" + "{0}.png");
-            }
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_Clear = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}Clear\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
-            {
-                Chara_Normal_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, $@"{GAME}{CHARA}Clear\" + "{0}.png");
-            }
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
-            {
-                Chara_Normal_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, $@"{GAME}{CHARA}Clear_Max\" + "{0}.png");
-            }
+            var s = $@"{GAME}{CHARA}Normal\";
+            var skinGameCharaPtnNormal = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s));
+            var charaNormal = skinGameCharaPtnNormal != 0 ? TxC(skinGameCharaPtnNormal, s + "{0}.png") : null;
+            Chara_Normal = charaNormal;
+            TJAPlayer3.Skin.Game_Chara_Ptn_Normal = skinGameCharaPtnNormal;
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}GoGo\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
-            {
-                Chara_GoGoTime = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, $@"{GAME}{CHARA}GoGo\" + "{0}.png");
-            }
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
-            {
-                Chara_GoGoTime_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, $@"{GAME}{CHARA}GoGo_Max\" + "{0}.png");
-            }
+            var s1 = $@"{GAME}{CHARA}Clear\";
+            var skinGameCharaPtnClear = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s1));
+            var charaNormalCleared = skinGameCharaPtnClear != 0 ? TxC(skinGameCharaPtnClear, s1 + "{0}.png") : null;
+            Chara_Normal_Cleared = charaNormalCleared;
+            TJAPlayer3.Skin.Game_Chara_Ptn_Clear = skinGameCharaPtnClear;
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_10combo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}10combo\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo != 0)
-            {
-                Chara_10Combo = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo, $@"{GAME}{CHARA}10combo\" + "{0}.png");
-            }
+            var s2 = $@"{GAME}{CHARA}Clear_Max\";
+            var skinGameCharaPtnClearMax = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s2));
+            var charaNormalMaxed = skinGameCharaPtnClearMax != 0 ? TxC(skinGameCharaPtnClearMax, s2 + "{0}.png") : null;
+            Chara_Normal_Maxed = charaNormalMaxed;
+            // no assignment
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}10combo_Max\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max != 0)
-            {
-                Chara_10Combo_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max, $@"{GAME}{CHARA}10combo_Max\" + "{0}.png");
-            }
+            var s3 = $@"{GAME}{CHARA}GoGo\";
+            var skinGameCharaPtnGoGo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s3));
+            var charaGoGoTime = skinGameCharaPtnGoGo != 0 ? TxC(skinGameCharaPtnGoGo, s3 + "{0}.png") : null;
+            Chara_GoGoTime = charaGoGoTime;
+            TJAPlayer3.Skin.Game_Chara_Ptn_GoGo = skinGameCharaPtnGoGo;
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}GoGoStart\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart != 0)
-            {
-                Chara_GoGoStart = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart, $@"{GAME}{CHARA}GoGoStart\" + "{0}.png");
-            }
+            var s4 = $@"{GAME}{CHARA}GoGo_Max\";
+            var skinGameCharaPtnGoGoMax = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s4));
+            var charaGoGoTimeMaxed = skinGameCharaPtnGoGoMax != 0 ? TxC(skinGameCharaPtnGoGoMax, s4 + "{0}.png") : null;
+            Chara_GoGoTime_Maxed = charaGoGoTimeMaxed;
+            // no assignment
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}GoGoStart_Max\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max != 0)
-            {
-                Chara_GoGoStart_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max, $@"{GAME}{CHARA}GoGoStart_Max\" + "{0}.png");
-            }
+            var s5 = $@"{GAME}{CHARA}10combo\";
+            var skinGameCharaPtn10Combo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s5));
+            var chara10Combo = skinGameCharaPtn10Combo != 0 ? TxC(skinGameCharaPtn10Combo, s5 + "{0}.png") : null;
+            Chara_10Combo = chara10Combo;
+            TJAPlayer3.Skin.Game_Chara_Ptn_10combo = skinGameCharaPtn10Combo;
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}ClearIn\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn != 0)
-            {
-                Chara_Become_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn, $@"{GAME}{CHARA}ClearIn\" + "{0}.png");
-            }
+            var s6 = $@"{GAME}{CHARA}10combo_Max\";
+            var skinGameCharaPtn10ComboMax = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s6));
+            var chara10ComboMaxed = skinGameCharaPtn10ComboMax != 0 ? TxC(skinGameCharaPtn10ComboMax, s6 + "{0}.png") : null;
+            Chara_10Combo_Maxed = chara10ComboMaxed;
+            TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = skinGameCharaPtn10ComboMax;
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}SoulIn\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn != 0)
-            {
-                Chara_Become_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn, $@"{GAME}{CHARA}SoulIn\" + "{0}.png");
-            }
+            var s7 = $@"{GAME}{CHARA}GoGoStart\";
+            var skinGameCharaPtnGoGoStart = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s7));
+            var charaGoGoStart = skinGameCharaPtnGoGoStart != 0 ? TxC(skinGameCharaPtnGoGoStart, s7 + "{0}.png") : null;
+            Chara_GoGoStart = charaGoGoStart;
+            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart = skinGameCharaPtnGoGoStart;
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}Balloon_Breaking\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking != 0)
-            {
-                Chara_Balloon_Breaking = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking, $@"{GAME}{CHARA}Balloon_Breaking\" + "{0}.png");
-            }
+            var s8 = $@"{GAME}{CHARA}GoGoStart_Max\";
+            var skinGameCharaPtnGoGoStartMax = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s8));
+            var charaGoGoStartMaxed = skinGameCharaPtnGoGoStartMax != 0 ? TxC(skinGameCharaPtnGoGoStartMax, s8 + "{0}.png") : null;
+            Chara_GoGoStart_Maxed = charaGoGoStartMaxed;
+            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = skinGameCharaPtnGoGoStartMax;
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}Balloon_Broke\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke != 0)
-            {
-                Chara_Balloon_Broke = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke, $@"{GAME}{CHARA}Balloon_Broke\" + "{0}.png");
-            }
+            var s9 = $@"{GAME}{CHARA}ClearIn\";
+            var skinGameCharaPtnClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s9));
+            var charaBecomeCleared = skinGameCharaPtnClearIn != 0 ? TxC(skinGameCharaPtnClearIn, s9 + "{0}.png") : null;
+            Chara_Become_Cleared = charaBecomeCleared;
+            TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = skinGameCharaPtnClearIn;
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}Balloon_Miss\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss != 0)
-            {
-                Chara_Balloon_Miss = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss, $@"{GAME}{CHARA}Balloon_Miss\" + "{0}.png");
-            }
+            var s10 = $@"{GAME}{CHARA}SoulIn\";
+            var skinGameCharaPtnSoulIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s10));
+            var charaBecomeMaxed = skinGameCharaPtnSoulIn != 0 ? TxC(skinGameCharaPtnSoulIn, s10 + "{0}.png") : null;
+            Chara_Become_Maxed = charaBecomeMaxed;
+            TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn = skinGameCharaPtnSoulIn;
+
+            var s11 = $@"{GAME}{CHARA}Balloon_Breaking\";
+            var skinGameCharaPtnBalloonBreaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s11));
+            var charaBalloonBreaking = skinGameCharaPtnBalloonBreaking != 0 ? TxC(skinGameCharaPtnBalloonBreaking, s11 + "{0}.png") : null;
+            Chara_Balloon_Breaking = charaBalloonBreaking;
+            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = skinGameCharaPtnBalloonBreaking;
+
+            var s12 = $@"{GAME}{CHARA}Balloon_Broke\";
+            var skinGameCharaPtnBalloonBroke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s12));
+            var charaBalloonBroke = skinGameCharaPtnBalloonBroke != 0 ? TxC(skinGameCharaPtnBalloonBroke, s12 + "{0}.png") : null;
+            Chara_Balloon_Broke = charaBalloonBroke;
+            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = skinGameCharaPtnBalloonBroke;
+
+            var s13 = $@"{GAME}{CHARA}Balloon_Miss\";
+            var skinGameCharaPtnBalloonMiss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s13));
+            var charaBalloonMiss = skinGameCharaPtnBalloonMiss != 0 ? TxC(skinGameCharaPtnBalloonMiss, s13 + "{0}.png") : null;
+            Chara_Balloon_Miss = charaBalloonMiss;
+            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = skinGameCharaPtnBalloonMiss;
 
             #endregion
             #region 踊り子
-            TJAPlayer3.Skin.Game_Dancer_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{DANCER}1\"));
-            if (TJAPlayer3.Skin.Game_Dancer_Ptn != 0)
+
+            var skinGameDancerPtn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{DANCER}1\"));
+            if (skinGameDancerPtn != 0)
             {
                 Dancer = new CTexture[5][];
                 for (int i = 0; i < Dancer.Length; i++)
                 {
-                    Dancer[i] = new CTexture[TJAPlayer3.Skin.Game_Dancer_Ptn];
-                    for (int p = 0; p < TJAPlayer3.Skin.Game_Dancer_Ptn; p++)
+                    Dancer[i] = new CTexture[skinGameDancerPtn];
+                    for (int p = 0; p < skinGameDancerPtn; p++)
                     {
                         Dancer[i][p] = TxC($@"{GAME}{DANCER}{(i + 1)}\{p}.png");
                     }
                 }
             }
+            TJAPlayer3.Skin.Game_Dancer_Ptn = skinGameDancerPtn;
+
             #endregion
             #region モブ
-            TJAPlayer3.Skin.Game_Mob_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $"{GAME}{MOB}"));
-            if (TJAPlayer3.Skin.Game_Mob_Ptn != 0)
-            {
-                Mob = TxC(TJAPlayer3.Skin.Game_Mob_Ptn, $"{GAME}{MOB}" + "{0}.png");
-            }
+
+            var s14 = $"{GAME}{MOB}";
+            var skinGameMobPtn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s14));
+            var mob = skinGameMobPtn != 0 ? TxC(skinGameMobPtn, s14 + "{0}.png") : null;
+            Mob = mob;
+            TJAPlayer3.Skin.Game_Mob_Ptn = skinGameMobPtn;
 
             #endregion
             #region フッター
@@ -317,11 +326,11 @@ namespace TJAPlayer3
             Gauge_Line = TxC(2, $"{GAME}{GAUGE}{{0}}P_Line.png", 1);
             Gauge_Line_Hard = TxC(2, $"{GAME}{GAUGE}{{0}}P_Line_Hard.png", 1);
 
-            TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{GAUGE}Rainbow\"));
-            if (TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn != 0)
-            {
-                Gauge_Rainbow = TxC(TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn, $@"{GAME}{GAUGE}Rainbow\" + "{0}.png");
-            }
+            var s15 = $@"{GAME}{GAUGE}Rainbow\";
+            var skinGameGaugeRainbowPtn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s15));
+            var gaugeRainbow = skinGameGaugeRainbowPtn != 0 ? TxC(skinGameGaugeRainbowPtn, s15 + "{0}.png") : null;
+            Gauge_Rainbow = gaugeRainbow;
+            TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn = skinGameGaugeRainbowPtn;
 
             Gauge_Soul = TxC($"{GAME}{GAUGE}Soul.png");
             Gauge_Soul_Fire = TxC($"{GAME}{GAUGE}Fire.png");
@@ -360,11 +369,11 @@ namespace TJAPlayer3
             Effects_Hit_Great = TxC(15, $@"{GAME}{EFFECTS}Hit\Great\{{0}}.png");
             Effects_Hit_Great_Big = TxC(15, $@"{GAME}{EFFECTS}Hit\Great_Big\{{0}}.png");
 
-            TJAPlayer3.Skin.Game_Effect_Roll_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{EFFECTS}Roll\"));
-            if (TJAPlayer3.Skin.Game_Effect_Roll_Ptn != 0)
-            {
-                Effects_Roll = TxC(TJAPlayer3.Skin.Game_Effect_Roll_Ptn, $@"{GAME}{EFFECTS}Roll\" + "{0}.png");
-            }
+            var s16 = $@"{GAME}{EFFECTS}Roll\";
+            var skinGameEffectRollPtn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s16));
+            var effectsRoll = skinGameEffectRollPtn != 0 ? TxC(skinGameEffectRollPtn, s16 + "{0}.png") : null;
+            Effects_Roll = effectsRoll;
+            TJAPlayer3.Skin.Game_Effect_Roll_Ptn = skinGameEffectRollPtn;
 
             #endregion
             #region レーン

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -261,7 +261,7 @@ namespace TJAPlayer3
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking != 0)
             {
                 Chara_Balloon_Breaking = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking];
-                for (int i = 0; i < TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking; i++)
+                for (int i = 0; i < Chara_Balloon_Breaking.Length; i++)
                 {
                     Chara_Balloon_Breaking[i] = TxC(GAME + CHARA + @"Balloon_Breaking\" + i.ToString() + ".png");
                 }
@@ -669,7 +669,7 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart_Maxed);
             TJAPlayer3.t安全にDisposeする(ref Chara_Become_Cleared);
             TJAPlayer3.t安全にDisposeする(ref Chara_Become_Maxed);
-            TJAPlayer3.t安全にDisposeする(Chara_Balloon_Breaking);
+            TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Breaking);
             TJAPlayer3.t安全にDisposeする(Chara_Balloon_Broke);
             TJAPlayer3.t安全にDisposeする(Chara_Balloon_Miss);
             #endregion

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using FDK;
 
 namespace TJAPlayer3
@@ -41,6 +42,8 @@ namespace TJAPlayer3
         const string ROLL = @"Roll\";
         const string SPLASH = @"Splash\";
 
+        private readonly List<CTexture> _trackedTextures = new List<CTexture>();
+
         private CTexture[] TxC(int count, string format)
         {
             var array = new CTexture[count];
@@ -67,12 +70,22 @@ namespace TJAPlayer3
 
         private CTexture TxC(string path)
         {
-            return TxCUntracked(path);
+            return Track(TxCUntracked(path));
         }
 
         private CTextureAf TxCAf(string path)
         {
-            return TxCAfUntracked(path);
+            return Track(TxCAfUntracked(path));
+        }
+
+        private T Track<T>(T texture) where T : CTexture
+        {
+            if (texture != null)
+            {
+                _trackedTextures.Add(texture);
+            }
+
+            return texture;
         }
 
         internal CTexture TxCUntracked(string path)
@@ -90,7 +103,7 @@ namespace TJAPlayer3
             return TJAPlayer3.tテクスチャの生成(CSkin.Path(BASE + GAME + GENRE + fileNameWithoutExtension + ".png"));
         }
 
-        public void LoadTexture()
+        public void Load()
         {
             #region 共通
             Tile_Black = TxC(@"Tile_Black.png");
@@ -478,239 +491,13 @@ namespace TJAPlayer3
 
         }
 
-        public void DisposeTexture()
+        public void Dispose()
         {
-            TJAPlayer3.t安全にDisposeする(ref Title_Background);
-            TJAPlayer3.t安全にDisposeする(ref Title_Menu);
-            #region 共通
-            TJAPlayer3.t安全にDisposeする(ref Tile_Black);
-            TJAPlayer3.t安全にDisposeする(ref Tile_White);
-            TJAPlayer3.t安全にDisposeする(ref Menu_Title);
-            TJAPlayer3.t安全にDisposeする(ref Menu_Highlight);
-            TJAPlayer3.t安全にDisposeする(ref Enum_Song);
-            TJAPlayer3.t安全にDisposeする(ref Scanning_Loudness);
-            TJAPlayer3.t安全にDisposeする(ref Overlay);
-            TJAPlayer3.t安全にDisposeする(ref NamePlate);
-
-            #endregion
-            #region 1_タイトル画面
-            TJAPlayer3.t安全にDisposeする(ref Title_Background);
-            TJAPlayer3.t安全にDisposeする(ref Title_Menu);
-            #endregion
-
-            #region 2_コンフィグ画面
-            TJAPlayer3.t安全にDisposeする(ref Config_Background);
-            TJAPlayer3.t安全にDisposeする(ref Config_Cursor);
-            TJAPlayer3.t安全にDisposeする(ref Config_ItemBox);
-            TJAPlayer3.t安全にDisposeする(ref Config_Arrow);
-            TJAPlayer3.t安全にDisposeする(ref Config_KeyAssign);
-            TJAPlayer3.t安全にDisposeする(ref Config_Font);
-            TJAPlayer3.t安全にDisposeする(ref Config_Font_Bold);
-            TJAPlayer3.t安全にDisposeする(ref Config_Enum_Song);
-            #endregion
-
-            #region 3_選曲画面
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Background);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Header);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Footer);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Difficulty);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Auto);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Level);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Branch);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Branch_Text);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Bar_Center);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Frame_Score);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Frame_BackBox);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Frame_Random);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Score_Select);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_GenreText);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Cursor_Left);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Cursor_Right);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Bar_Genre);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Frame_Box);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_ScoreWindow);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_GenreBack);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_ScoreWindow_Text);
-            TJAPlayer3.t安全にDisposeする(ref SongSelect_Rating);
-            #endregion
-
-            #region 4_読み込み画面
-            TJAPlayer3.t安全にDisposeする(ref SongLoading_Plate);
-            TJAPlayer3.t安全にDisposeする(ref SongLoading_FadeIn);
-            TJAPlayer3.t安全にDisposeする(ref SongLoading_FadeOut);
-            #endregion
-
-            #region 5_演奏画面
-            #region 共通
-            TJAPlayer3.t安全にDisposeする(ref Notes);
-            TJAPlayer3.t安全にDisposeする(ref Judge_Frame);
-            TJAPlayer3.t安全にDisposeする(ref SENotes);
-            TJAPlayer3.t安全にDisposeする(ref Notes_Arm);
-            TJAPlayer3.t安全にDisposeする(ref Judge);
-
-            TJAPlayer3.t安全にDisposeする(ref Judge_Meter);
-            TJAPlayer3.t安全にDisposeする(ref Bar);
-            TJAPlayer3.t安全にDisposeする(ref Bar_Branch);
-
-            #endregion
-            #region キャラクター
-
-            TJAPlayer3.t安全にDisposeする(ref Chara_Normal);
-            TJAPlayer3.t安全にDisposeする(ref Chara_Normal_Cleared);
-            TJAPlayer3.t安全にDisposeする(ref Chara_Normal_Maxed);
-            TJAPlayer3.t安全にDisposeする(ref Chara_GoGoTime);
-            TJAPlayer3.t安全にDisposeする(ref Chara_GoGoTime_Maxed);
-            TJAPlayer3.t安全にDisposeする(ref Chara_10Combo);
-            TJAPlayer3.t安全にDisposeする(ref Chara_10Combo_Maxed);
-            TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart);
-            TJAPlayer3.t安全にDisposeする(ref Chara_GoGoStart_Maxed);
-            TJAPlayer3.t安全にDisposeする(ref Chara_Become_Cleared);
-            TJAPlayer3.t安全にDisposeする(ref Chara_Become_Maxed);
-            TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Breaking);
-            TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Broke);
-            TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Miss);
-            #endregion
-            #region 踊り子
-            TJAPlayer3.t安全にDisposeする(ref Dancer);
-            #endregion
-            #region モブ
-            TJAPlayer3.t安全にDisposeする(ref Mob);
-            #endregion
-            #region フッター
-            TJAPlayer3.t安全にDisposeする(ref Mob_Footer);
-            #endregion
-            #region 背景
-            TJAPlayer3.t安全にDisposeする(ref Background);
-            TJAPlayer3.t安全にDisposeする(ref Background_Up);
-            TJAPlayer3.t安全にDisposeする(ref Background_Up_Clear);
-            TJAPlayer3.t安全にDisposeする(ref Background_Down);
-            TJAPlayer3.t安全にDisposeする(ref Background_Down_Clear);
-            TJAPlayer3.t安全にDisposeする(ref Background_Down_Scroll);
-
-            #endregion
-            #region 太鼓
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Background);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Frame);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_PlayerNumber);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_NamePlate);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Base);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Don_Left);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Don_Right);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Ka_Left);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Ka_Right);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_LevelUp);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_LevelDown);
-            TJAPlayer3.t安全にDisposeする(ref Course_Symbol);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Score);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Combo);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Combo_Effect);
-            TJAPlayer3.t安全にDisposeする(ref Taiko_Combo_Text);
-            #endregion
-            #region ゲージ
-            TJAPlayer3.t安全にDisposeする(ref Gauge);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Hard);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_ExHard);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Base);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Base_Hard);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Base_ExHard);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Line);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Line_Hard);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Rainbow);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Soul);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Soul_Fire);
-            TJAPlayer3.t安全にDisposeする(ref Gauge_Soul_Explosion);
-            #endregion
-            #region 吹き出し
-            TJAPlayer3.t安全にDisposeする(ref Balloon_Combo);
-            TJAPlayer3.t安全にDisposeする(ref Balloon_Roll);
-            TJAPlayer3.t安全にDisposeする(ref Balloon_Balloon);
-            TJAPlayer3.t安全にDisposeする(ref Balloon_Number_Roll);
-            TJAPlayer3.t安全にDisposeする(ref Balloon_Number_Combo);
-            TJAPlayer3.t安全にDisposeする(ref Balloon_Breaking);
-            #endregion
-            #region エフェクト
-            TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Explosion);
-            TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Explosion_Big);
-            TJAPlayer3.t安全にDisposeする(ref Effects_Hit_FireWorks);
-
-            TJAPlayer3.t安全にDisposeする(ref Effects_Fire);
-            TJAPlayer3.t安全にDisposeする(ref Effects_Rainbow);
-
-            TJAPlayer3.t安全にDisposeする(ref Effects_GoGoSplash);
-
-            TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Good);
-            TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Good_Big);
-            TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Great);
-            TJAPlayer3.t安全にDisposeする(ref Effects_Hit_Great_Big);
-
-            TJAPlayer3.t安全にDisposeする(ref Effects_Roll);
-            #endregion
-            #region レーン
-            TJAPlayer3.t安全にDisposeする(ref Lane_Base);
-            TJAPlayer3.t安全にDisposeする(ref Lane_Text);
-            TJAPlayer3.t安全にDisposeする(ref Lane_Red);
-            TJAPlayer3.t安全にDisposeする(ref Lane_Blue);
-            TJAPlayer3.t安全にDisposeする(ref Lane_Yellow);
-            TJAPlayer3.t安全にDisposeする(ref Lane_Background_Main);
-            TJAPlayer3.t安全にDisposeする(ref Lane_Background_Sub);
-            TJAPlayer3.t安全にDisposeする(ref Lane_Background_GoGo);
-
-            #endregion
-            #region 終了演出
-            TJAPlayer3.t安全にDisposeする(ref End_Clear_L);
-            TJAPlayer3.t安全にDisposeする(ref End_Clear_R);
-            TJAPlayer3.t安全にDisposeする(ref End_Clear_Text);
-            TJAPlayer3.t安全にDisposeする(ref End_Clear_Text_Effect);
-            #endregion
-            #region ゲームモード
-            TJAPlayer3.t安全にDisposeする(ref GameMode_Timer_Tick);
-            TJAPlayer3.t安全にDisposeする(ref GameMode_Timer_Frame);
-            #endregion
-            #region ステージ失敗
-            TJAPlayer3.t安全にDisposeする(ref Failed_Game);
-            TJAPlayer3.t安全にDisposeする(ref Failed_Stage);
-            #endregion
-            #region ランナー
-            TJAPlayer3.t安全にDisposeする(ref Runner);
-            #endregion
-            #region DanC
-            TJAPlayer3.t安全にDisposeする(ref DanC_Background);
-            TJAPlayer3.t安全にDisposeする(ref DanC_Gauge);
-            TJAPlayer3.t安全にDisposeする(ref DanC_Base);
-            TJAPlayer3.t安全にDisposeする(ref DanC_Failed);
-            TJAPlayer3.t安全にDisposeする(ref DanC_Number);
-            TJAPlayer3.t安全にDisposeする(ref DanC_ExamRange);
-            TJAPlayer3.t安全にDisposeする(ref DanC_ExamUnit);
-            TJAPlayer3.t安全にDisposeする(ref DanC_ExamType);
-            TJAPlayer3.t安全にDisposeする(ref DanC_Screen);
-            #endregion
-            #region PuchiChara
-            TJAPlayer3.t安全にDisposeする(ref PuchiChara);
-            #endregion
-            #endregion
-
-            #region 6_結果発表
-            TJAPlayer3.t安全にDisposeする(ref Result_Background);
-            TJAPlayer3.t安全にDisposeする(ref Result_FadeIn);
-            TJAPlayer3.t安全にDisposeする(ref Result_Gauge);
-            TJAPlayer3.t安全にDisposeする(ref Result_Gauge_Base);
-            TJAPlayer3.t安全にDisposeする(ref Result_Gauge_Hard);
-            TJAPlayer3.t安全にDisposeする(ref Result_Gauge_ExHard);
-            TJAPlayer3.t安全にDisposeする(ref Result_Gauge_Base_Hard);
-            TJAPlayer3.t安全にDisposeする(ref Result_Gauge_Base_ExHard);
-            TJAPlayer3.t安全にDisposeする(ref Result_Judge);
-            TJAPlayer3.t安全にDisposeする(ref Result_Header);
-            TJAPlayer3.t安全にDisposeする(ref Result_Number);
-            TJAPlayer3.t安全にDisposeする(ref Result_Panel);
-            TJAPlayer3.t安全にDisposeする(ref Result_Score_Text);
-            TJAPlayer3.t安全にDisposeする(ref Result_Score_Number);
-            TJAPlayer3.t安全にDisposeする(ref Result_Dan);
-            #endregion
-
-            #region 7_終了画面
-            TJAPlayer3.t安全にDisposeする(ref Exit_Background);
-            #endregion
-
+            foreach (var trackedTexture in _trackedTextures)
+            {
+                trackedTexture.Dispose();
+            }
+            _trackedTextures.Clear();
         }
 
         #region 共通

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -674,12 +674,7 @@ namespace TJAPlayer3
             TJAPlayer3.t安全にDisposeする(ref Chara_Balloon_Miss);
             #endregion
             #region 踊り子
-            for (int i = 0; i < Dancer.Length; i++)
-            {
-                TJAPlayer3.t安全にDisposeする(Dancer[i]);
-            }
-            Dancer = null;
-
+            TJAPlayer3.t安全にDisposeする(ref Dancer);
             #endregion
             #region モブ
             TJAPlayer3.t安全にDisposeする(Mob);

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -111,29 +111,34 @@ namespace TJAPlayer3
             SongSelect_Cursor_Left = TxC(SONGSELECT + @"Cursor_Left.png");
             SongSelect_Cursor_Right = TxC(SONGSELECT + @"Cursor_Right.png");
 
-            SongSelect_Bar_Genre = new CTexture[9];
-            for (int i = 0; i < SongSelect_Bar_Genre.Length; i++)
+            var songSelect_Bar_Genre = new CTexture[9];
+            for (int i = 0; i < songSelect_Bar_Genre.Length; i++)
             {
-                SongSelect_Bar_Genre[i] = TxC(string.Format(SONGSELECT + "Bar_Genre_{0}.png", i));
+                songSelect_Bar_Genre[i] = TxC(string.Format(SONGSELECT + "Bar_Genre_{0}.png", i));
             }
+            SongSelect_Bar_Genre = songSelect_Bar_Genre;
 
-            SongSelect_Frame_Box = new CTexture[9];
-            for (int i = 0; i < SongSelect_Frame_Box.Length; i++)
+            var songSelect_Frame_Box = new CTexture[9];
+            for (int i = 0; i < songSelect_Frame_Box.Length; i++)
             {
-                SongSelect_Frame_Box[i] = TxC(string.Format(SONGSELECT + "Frame_Box_{0}.png", i));
+                songSelect_Frame_Box[i] = TxC(string.Format(SONGSELECT + "Frame_Box_{0}.png", i));
             }
+            SongSelect_Frame_Box = songSelect_Frame_Box;
 
-            SongSelect_ScoreWindow = new CTexture[(int) Difficulty.Total];
-            for (int i = 0; i < SongSelect_ScoreWindow.Length; i++)
+            var songSelect_ScoreWindow = new CTexture[(int) Difficulty.Total];
+            for (int i = 0; i < songSelect_ScoreWindow.Length; i++)
             {
-                SongSelect_ScoreWindow[i] = TxC(string.Format(SONGSELECT + "ScoreWindow_{0}.png", i));
+                songSelect_ScoreWindow[i] = TxC(string.Format(SONGSELECT + "ScoreWindow_{0}.png", i));
             }
+            SongSelect_ScoreWindow = songSelect_ScoreWindow;
 
-            SongSelect_GenreBack = new CTexture[9];
-            for (int i = 0; i < SongSelect_GenreBack.Length; i++)
+            var songSelect_GenreBack = new CTexture[9];
+            for (int i = 0; i < songSelect_GenreBack.Length; i++)
             {
-                SongSelect_GenreBack[i] = TxC(string.Format(SONGSELECT + "GenreBackground_{0}.png", i));
+                songSelect_GenreBack[i] = TxC(string.Format(SONGSELECT + "GenreBackground_{0}.png", i));
             }
+            SongSelect_GenreBack = songSelect_GenreBack;
+
             SongSelect_ScoreWindow_Text = TxC(SONGSELECT + @"ScoreWindow_Text.png");
             SongSelect_Rating = TxC(SONGSELECT + @"Rating.png");
             #endregion
@@ -161,128 +166,142 @@ namespace TJAPlayer3
             TJAPlayer3.Skin.Game_Chara_Ptn_Normal = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Normal\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Normal != 0)
             {
-                Chara_Normal = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Normal];
-                for (int i = 0; i < Chara_Normal.Length; i++)
+                var chara_Normal = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Normal];
+                for (int i = 0; i < chara_Normal.Length; i++)
                 {
-                    Chara_Normal[i] = TxC(string.Format(GAME + CHARA + @"Normal\{0}.png", i));
+                    chara_Normal[i] = TxC(string.Format(GAME + CHARA + @"Normal\{0}.png", i));
                 }
+                Chara_Normal = chara_Normal;
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Clear = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Clear\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
             {
-                Chara_Normal_Cleared = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Clear];
-                for (int i = 0; i < Chara_Normal_Cleared.Length; i++)
+                var chara_Normal_Cleared = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Clear];
+                for (int i = 0; i < chara_Normal_Cleared.Length; i++)
                 {
-                    Chara_Normal_Cleared[i] = TxC(string.Format(GAME + CHARA + @"Clear\{0}.png", i));
+                    chara_Normal_Cleared[i] = TxC(string.Format(GAME + CHARA + @"Clear\{0}.png", i));
                 }
+                Chara_Normal_Cleared = chara_Normal_Cleared;
             }
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
             {
-                Chara_Normal_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Clear];
-                for (int i = 0; i < Chara_Normal_Maxed.Length; i++)
+                var chara_Normal_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Clear];
+                for (int i = 0; i < chara_Normal_Maxed.Length; i++)
                 {
-                    Chara_Normal_Maxed[i] = TxC(string.Format(GAME + CHARA + @"Clear_Max\{0}.png", i));
+                    chara_Normal_Maxed[i] = TxC(string.Format(GAME + CHARA + @"Clear_Max\{0}.png", i));
                 }
+                Chara_Normal_Maxed = chara_Normal_Maxed;
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGo\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
             {
-                Chara_GoGoTime = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGo];
-                for (int i = 0; i < Chara_GoGoTime.Length; i++)
+                var chara_GoGoTime = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGo];
+                for (int i = 0; i < chara_GoGoTime.Length; i++)
                 {
-                    Chara_GoGoTime[i] = TxC(string.Format(GAME + CHARA + @"GoGo\{0}.png", i));
+                    chara_GoGoTime[i] = TxC(string.Format(GAME + CHARA + @"GoGo\{0}.png", i));
                 }
+                Chara_GoGoTime = chara_GoGoTime;
             }
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
             {
-                Chara_GoGoTime_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGo];
-                for (int i = 0; i < Chara_GoGoTime_Maxed.Length; i++)
+                var chara_GoGoTime_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGo];
+                for (int i = 0; i < chara_GoGoTime_Maxed.Length; i++)
                 {
-                    Chara_GoGoTime_Maxed[i] = TxC(string.Format(GAME + CHARA + @"GoGo_Max\{0}.png", i));
+                    chara_GoGoTime_Maxed[i] = TxC(string.Format(GAME + CHARA + @"GoGo_Max\{0}.png", i));
                 }
+                Chara_GoGoTime_Maxed = chara_GoGoTime_Maxed;
             }
 
             TJAPlayer3.Skin.Game_Chara_Ptn_10combo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"10combo\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo != 0)
             {
-                Chara_10Combo = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_10combo];
-                for (int i = 0; i < Chara_10Combo.Length; i++)
+                var chara_10Combo = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_10combo];
+                for (int i = 0; i < chara_10Combo.Length; i++)
                 {
-                    Chara_10Combo[i] = TxC(string.Format(GAME + CHARA + @"10combo\{0}.png", i));
+                    chara_10Combo[i] = TxC(string.Format(GAME + CHARA + @"10combo\{0}.png", i));
                 }
+                Chara_10Combo = chara_10Combo;
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"10combo_Max\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max != 0)
             {
-                Chara_10Combo_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max];
-                for (int i = 0; i < Chara_10Combo_Maxed.Length; i++)
+                var chara_10Combo_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max];
+                for (int i = 0; i < chara_10Combo_Maxed.Length; i++)
                 {
-                    Chara_10Combo_Maxed[i] = TxC(string.Format(GAME + CHARA + @"10combo_Max\{0}.png", i));
+                    chara_10Combo_Maxed[i] = TxC(string.Format(GAME + CHARA + @"10combo_Max\{0}.png", i));
                 }
+                Chara_10Combo_Maxed = chara_10Combo_Maxed;
             }
 
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGoStart\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart != 0)
             {
-                Chara_GoGoStart = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart];
-                for (int i = 0; i < Chara_GoGoStart.Length; i++)
+                var chara_GoGoStart = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart];
+                for (int i = 0; i < chara_GoGoStart.Length; i++)
                 {
-                    Chara_GoGoStart[i] = TxC(string.Format(GAME + CHARA + @"GoGoStart\{0}.png", i));
+                    chara_GoGoStart[i] = TxC(string.Format(GAME + CHARA + @"GoGoStart\{0}.png", i));
                 }
+                Chara_GoGoStart = chara_GoGoStart;
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGoStart_Max\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max != 0)
             {
-                Chara_GoGoStart_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max];
-                for (int i = 0; i < Chara_GoGoStart_Maxed.Length; i++)
+                var chara_GoGoStart_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max];
+                for (int i = 0; i < chara_GoGoStart_Maxed.Length; i++)
                 {
-                    Chara_GoGoStart_Maxed[i] = TxC(string.Format(GAME + CHARA + @"GoGoStart_Max\{0}.png", i));
+                    chara_GoGoStart_Maxed[i] = TxC(string.Format(GAME + CHARA + @"GoGoStart_Max\{0}.png", i));
                 }
+                Chara_GoGoStart_Maxed = chara_GoGoStart_Maxed;
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"ClearIn\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn != 0)
             {
-                Chara_Become_Cleared = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn];
-                for (int i = 0; i < Chara_Become_Cleared.Length; i++)
+                var chara_Become_Cleared = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn];
+                for (int i = 0; i < chara_Become_Cleared.Length; i++)
                 {
-                    Chara_Become_Cleared[i] = TxC(string.Format(GAME + CHARA + @"ClearIn\{0}.png", i));
+                    chara_Become_Cleared[i] = TxC(string.Format(GAME + CHARA + @"ClearIn\{0}.png", i));
                 }
+                Chara_Become_Cleared = chara_Become_Cleared;
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"SoulIn\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn != 0)
             {
-                Chara_Become_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn];
-                for (int i = 0; i < Chara_Become_Maxed.Length; i++)
+                var chara_Become_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn];
+                for (int i = 0; i < chara_Become_Maxed.Length; i++)
                 {
-                    Chara_Become_Maxed[i] = TxC(string.Format(GAME + CHARA + @"SoulIn\{0}.png", i));
+                    chara_Become_Maxed[i] = TxC(string.Format(GAME + CHARA + @"SoulIn\{0}.png", i));
                 }
+                Chara_Become_Maxed = chara_Become_Maxed;
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Breaking\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking != 0)
             {
-                Chara_Balloon_Breaking = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking];
-                for (int i = 0; i < Chara_Balloon_Breaking.Length; i++)
+                var chara_Balloon_Breaking = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking];
+                for (int i = 0; i < chara_Balloon_Breaking.Length; i++)
                 {
-                    Chara_Balloon_Breaking[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Breaking\{0}.png", i));
+                    chara_Balloon_Breaking[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Breaking\{0}.png", i));
                 }
+                Chara_Balloon_Breaking = chara_Balloon_Breaking;
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Broke\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke != 0)
             {
-                Chara_Balloon_Broke = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke];
-                for (int i = 0; i < Chara_Balloon_Broke.Length; i++)
+                var chara_Balloon_Broke = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke];
+                for (int i = 0; i < chara_Balloon_Broke.Length; i++)
                 {
-                    Chara_Balloon_Broke[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Broke\{0}.png", i));
+                    chara_Balloon_Broke[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Broke\{0}.png", i));
                 }
+                Chara_Balloon_Broke = chara_Balloon_Broke;
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Miss\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss != 0)
             {
-                Chara_Balloon_Miss = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss];
-                for (int i = 0; i < Chara_Balloon_Miss.Length; i++)
+                var chara_Balloon_Miss = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss];
+                for (int i = 0; i < chara_Balloon_Miss.Length; i++)
                 {
-                    Chara_Balloon_Miss[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Miss\{0}.png", i));
+                    chara_Balloon_Miss[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Miss\{0}.png", i));
                 }
+                Chara_Balloon_Miss = chara_Balloon_Miss;
             }
             #endregion
             #region 踊り子
@@ -302,11 +321,13 @@ namespace TJAPlayer3
             #endregion
             #region モブ
             TJAPlayer3.Skin.Game_Mob_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + MOB));
-            Mob = new CTexture[TJAPlayer3.Skin.Game_Mob_Ptn];
-            for (int i = 0; i < Mob.Length; i++)
+            var mob = new CTexture[TJAPlayer3.Skin.Game_Mob_Ptn];
+            for (int i = 0; i < mob.Length; i++)
             {
-                Mob[i] = TxC(string.Format(GAME + MOB + "{0}.png", i));
+                mob[i] = TxC(string.Format(GAME + MOB + "{0}.png", i));
             }
+            Mob = mob;
+
             #endregion
             #region フッター
             Mob_Footer = TxC(GAME + FOOTER + @"0.png");
@@ -352,11 +373,12 @@ namespace TJAPlayer3
             Taiko_LevelUp = TxC(GAME + TAIKO + @"LevelUp.png");
             Taiko_LevelDown = TxC(GAME + TAIKO + @"LevelDown.png");
 
-            Course_Symbol = new CTexture[Course_Symbols.Length];
-            for (int i = 0; i < Course_Symbol.Length; i++)
+            var course_Symbol = new CTexture[Course_Symbols.Length];
+            for (int i = 0; i < course_Symbol.Length; i++)
             {
-                Course_Symbol[i] = TxC(GAME + COURSESYMBOL + Course_Symbols[i] + ".png");
+                course_Symbol[i] = TxC(GAME + COURSESYMBOL + Course_Symbols[i] + ".png");
             }
+            Course_Symbol = course_Symbol;
 
             Taiko_Score = new CTexture[3];
             Taiko_Score[0] = TxC(GAME + TAIKO + @"Score.png");
@@ -407,11 +429,12 @@ namespace TJAPlayer3
             TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + GAUGE + @"Rainbow\"));
             if (TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn != 0)
             {
-                Gauge_Rainbow = new CTexture[TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn];
+                var gauge_Rainbow = new CTexture[TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn];
                 for (int i = 0; i < TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn; i++)
                 {
-                    Gauge_Rainbow[i] = TxC(string.Format(GAME + GAUGE + @"Rainbow\{0}.png", i));
+                    gauge_Rainbow[i] = TxC(string.Format(GAME + GAUGE + @"Rainbow\{0}.png", i));
                 }
+                Gauge_Rainbow = gauge_Rainbow;
             }
             Gauge_Soul = TxC(GAME + GAUGE + @"Soul.png");
             Gauge_Soul_Fire = TxC(GAME + GAUGE + @"Fire.png");
@@ -431,11 +454,13 @@ namespace TJAPlayer3
             Balloon_Number_Roll = TxC(GAME + BALLOON + @"Number_Roll.png");
             Balloon_Number_Combo = TxC(GAME + BALLOON + @"Number_Combo.png");
 
-            Balloon_Breaking = new CTexture[6];
-            for (int i = 0; i < Balloon_Breaking.Length; i++)
+            var balloon_Breaking = new CTexture[6];
+            for (int i = 0; i < balloon_Breaking.Length; i++)
             {
-                Balloon_Breaking[i] = TxC(string.Format(GAME + BALLOON + @"Breaking_{0}.png", i));
+                balloon_Breaking[i] = TxC(string.Format(GAME + BALLOON + @"Breaking_{0}.png", i));
             }
+            Balloon_Breaking = balloon_Breaking;
+
             #endregion
             #region エフェクト
             Effects_Hit_Explosion = TxCAf(GAME + EFFECTS + @"Hit\Explosion.png");
@@ -454,49 +479,58 @@ namespace TJAPlayer3
             Effects_GoGoSplash = TxC(GAME + EFFECTS + @"GoGoSplash.png");
             if (Effects_GoGoSplash != null) Effects_GoGoSplash.b加算合成 = TJAPlayer3.Skin.Game_Effect_GoGoSplash_AddBlend;
 
-            Effects_Hit_Good = new CTexture[15];
-            for (int i = 0; i < Effects_Hit_Good.Length; i++)
+            var effects_Hit_Good = new CTexture[15];
+            for (int i = 0; i < effects_Hit_Good.Length; i++)
             {
-                Effects_Hit_Good[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Good\{0}.png", i));
+                effects_Hit_Good[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Good\{0}.png", i));
             }
+            Effects_Hit_Good = effects_Hit_Good;
 
-            Effects_Hit_Good_Big = new CTexture[15];
-            for (int i = 0; i < Effects_Hit_Good_Big.Length; i++)
+            var effects_Hit_Good_Big = new CTexture[15];
+            for (int i = 0; i < effects_Hit_Good_Big.Length; i++)
             {
-                Effects_Hit_Good_Big[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Good_Big\{0}.png", i));
+                effects_Hit_Good_Big[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Good_Big\{0}.png", i));
             }
+            Effects_Hit_Good_Big = effects_Hit_Good_Big;
 
-            Effects_Hit_Great = new CTexture[15];
-            for (int i = 0; i < Effects_Hit_Great.Length; i++)
+            var effects_Hit_Great = new CTexture[15];
+            for (int i = 0; i < effects_Hit_Great.Length; i++)
             {
-                Effects_Hit_Great[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Great\{0}.png", i));
+                effects_Hit_Great[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Great\{0}.png", i));
             }
+            Effects_Hit_Great = effects_Hit_Great;
 
-            Effects_Hit_Great_Big = new CTexture[15];
-            for (int i = 0; i < Effects_Hit_Great_Big.Length; i++)
+            var effects_Hit_Great_Big = new CTexture[15];
+            for (int i = 0; i < effects_Hit_Great_Big.Length; i++)
             {
-                Effects_Hit_Great_Big[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Great_Big\{0}.png", i));
+                effects_Hit_Great_Big[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Great_Big\{0}.png", i));
             }
+            Effects_Hit_Great_Big = effects_Hit_Great_Big;
 
             TJAPlayer3.Skin.Game_Effect_Roll_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + EFFECTS + @"Roll\"));
-            Effects_Roll = new CTexture[TJAPlayer3.Skin.Game_Effect_Roll_Ptn];
+            var effects_Roll = new CTexture[TJAPlayer3.Skin.Game_Effect_Roll_Ptn];
             for (int i = 0; i < TJAPlayer3.Skin.Game_Effect_Roll_Ptn; i++)
             {
-                Effects_Roll[i] = TxC(string.Format(GAME + EFFECTS + @"Roll\{0}.png", i));
+                effects_Roll[i] = TxC(string.Format(GAME + EFFECTS + @"Roll\{0}.png", i));
             }
+            Effects_Roll = effects_Roll;
+
             #endregion
             #region レーン
             var lanes = new[] { "Normal", "Expert", "Master" };
-            Lane_Base = new CTexture[lanes.Length];
-            for (int i = 0; i < Lane_Base.Length; i++)
+            var lane_Base = new CTexture[lanes.Length];
+            for (int i = 0; i < lane_Base.Length; i++)
             {
-                Lane_Base[i] = TxC(GAME + LANE + "Base_" + lanes[i] + ".png");
+                lane_Base[i] = TxC(GAME + LANE + "Base_" + lanes[i] + ".png");
             }
-            Lane_Text = new CTexture[lanes.Length];
-            for (int i = 0; i < Lane_Text.Length; i++)
+            Lane_Base = lane_Base;
+
+            var lane_Text = new CTexture[lanes.Length];
+            for (int i = 0; i < lane_Text.Length; i++)
             {
-                Lane_Text[i] = TxC(GAME + LANE + "Text_" + lanes[i] + ".png");
+                lane_Text[i] = TxC(GAME + LANE + "Text_" + lanes[i] + ".png");
             }
+            Lane_Text = lane_Text;
 
             Lane_Red = TxC(GAME + LANE + @"Red.png");
             Lane_Blue = TxC(GAME + LANE + @"Blue.png");
@@ -508,16 +542,19 @@ namespace TJAPlayer3
             #endregion
             #region 終了演出
 
-            End_Clear_L = new CTexture[5];
-            for (int i = 0; i < End_Clear_L.Length; i++)
+            var end_Clear_L = new CTexture[5];
+            for (int i = 0; i < end_Clear_L.Length; i++)
             {
-                End_Clear_L[i] = TxC(string.Format(GAME + END + @"Clear_L_{0}.png", i));
+                end_Clear_L[i] = TxC(string.Format(GAME + END + @"Clear_L_{0}.png", i));
             }
-            End_Clear_R = new CTexture[5];
-            for (int i = 0; i < End_Clear_R.Length; i++)
+            End_Clear_L = end_Clear_L;
+
+            var end_Clear_R = new CTexture[5];
+            for (int i = 0; i < end_Clear_R.Length; i++)
             {
-                End_Clear_R[i] = TxC(string.Format(GAME + END + @"Clear_R_{0}.png", i));
+                end_Clear_R[i] = TxC(string.Format(GAME + END + @"Clear_R_{0}.png", i));
             }
+            End_Clear_R = end_Clear_R;
 
             End_Clear_Text = TxC(GAME + END + @"Clear_Text.png");
             End_Clear_Text_Effect = TxC(GAME + END + @"Clear_Text_Effect.png");
@@ -537,12 +574,13 @@ namespace TJAPlayer3
             #region DanC
             DanC_Background = TxC(GAME + DANC + @"Background.png");
 
-            DanC_Gauge = new CTexture[4];
+            var danC_Gauge = new CTexture[4];
             var type = new string[] { "Normal", "Reach", "Clear", "Flush" };
-            for (int i = 0; i < DanC_Gauge.Length; i++)
+            for (int i = 0; i < danC_Gauge.Length; i++)
             {
-                DanC_Gauge[i] = TxC(GAME + DANC + @"Gauge_" + type[i] + ".png");
+                danC_Gauge[i] = TxC(GAME + DANC + @"Gauge_" + type[i] + ".png");
             }
+            DanC_Gauge = danC_Gauge;
 
             DanC_Base = TxC(GAME + DANC + @"Base.png");
             DanC_Failed = TxC(GAME + DANC + @"Failed.png");

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -48,6 +48,30 @@ namespace TJAPlayer3
 
         }
 
+        private CTexture[] TxC(int count, string format)
+        {
+            var array = new CTexture[count];
+
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = TxC(string.Format(format, i));
+            }
+
+            return array;
+        }
+
+        private CTexture[] TxC(string[] parts, string format)
+        {
+            var array = new CTexture[parts.Length];
+
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = TxC(string.Format(format, parts[i]));
+            }
+
+            return array;
+        }
+
         internal CTexture TxC(string FileName)
         {
             return TJAPlayer3.tテクスチャの生成(CSkin.Path(BASE + FileName));
@@ -110,35 +134,10 @@ namespace TJAPlayer3
             SongSelect_GenreText = TxC(SONGSELECT + @"GenreText.png");
             SongSelect_Cursor_Left = TxC(SONGSELECT + @"Cursor_Left.png");
             SongSelect_Cursor_Right = TxC(SONGSELECT + @"Cursor_Right.png");
-
-            var songSelect_Bar_Genre = new CTexture[9];
-            for (int i = 0; i < songSelect_Bar_Genre.Length; i++)
-            {
-                songSelect_Bar_Genre[i] = TxC(string.Format(SONGSELECT + "Bar_Genre_{0}.png", i));
-            }
-            SongSelect_Bar_Genre = songSelect_Bar_Genre;
-
-            var songSelect_Frame_Box = new CTexture[9];
-            for (int i = 0; i < songSelect_Frame_Box.Length; i++)
-            {
-                songSelect_Frame_Box[i] = TxC(string.Format(SONGSELECT + "Frame_Box_{0}.png", i));
-            }
-            SongSelect_Frame_Box = songSelect_Frame_Box;
-
-            var songSelect_ScoreWindow = new CTexture[(int) Difficulty.Total];
-            for (int i = 0; i < songSelect_ScoreWindow.Length; i++)
-            {
-                songSelect_ScoreWindow[i] = TxC(string.Format(SONGSELECT + "ScoreWindow_{0}.png", i));
-            }
-            SongSelect_ScoreWindow = songSelect_ScoreWindow;
-
-            var songSelect_GenreBack = new CTexture[9];
-            for (int i = 0; i < songSelect_GenreBack.Length; i++)
-            {
-                songSelect_GenreBack[i] = TxC(string.Format(SONGSELECT + "GenreBackground_{0}.png", i));
-            }
-            SongSelect_GenreBack = songSelect_GenreBack;
-
+            SongSelect_Bar_Genre = TxC(9, SONGSELECT + "Bar_Genre_{0}.png");
+            SongSelect_Frame_Box = TxC(9, SONGSELECT + "Frame_Box_{0}.png");
+            SongSelect_ScoreWindow = TxC((int) Difficulty.Total, SONGSELECT + "ScoreWindow_{0}.png");
+            SongSelect_GenreBack = TxC(9, SONGSELECT + "GenreBackground_{0}.png");
             SongSelect_ScoreWindow_Text = TxC(SONGSELECT + @"ScoreWindow_Text.png");
             SongSelect_Rating = TxC(SONGSELECT + @"Rating.png");
             #endregion
@@ -166,142 +165,72 @@ namespace TJAPlayer3
             TJAPlayer3.Skin.Game_Chara_Ptn_Normal = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Normal\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Normal != 0)
             {
-                var chara_Normal = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Normal];
-                for (int i = 0; i < chara_Normal.Length; i++)
-                {
-                    chara_Normal[i] = TxC(string.Format(GAME + CHARA + @"Normal\{0}.png", i));
-                }
-                Chara_Normal = chara_Normal;
+                Chara_Normal = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Normal, GAME + CHARA + @"Normal\{0}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Clear = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Clear\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
             {
-                var chara_Normal_Cleared = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Clear];
-                for (int i = 0; i < chara_Normal_Cleared.Length; i++)
-                {
-                    chara_Normal_Cleared[i] = TxC(string.Format(GAME + CHARA + @"Clear\{0}.png", i));
-                }
-                Chara_Normal_Cleared = chara_Normal_Cleared;
+                Chara_Normal_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, GAME + CHARA + @"Clear\{0}.png");
             }
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
             {
-                var chara_Normal_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Clear];
-                for (int i = 0; i < chara_Normal_Maxed.Length; i++)
-                {
-                    chara_Normal_Maxed[i] = TxC(string.Format(GAME + CHARA + @"Clear_Max\{0}.png", i));
-                }
-                Chara_Normal_Maxed = chara_Normal_Maxed;
+                Chara_Normal_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, GAME + CHARA + @"Clear_Max\{0}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGo\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
             {
-                var chara_GoGoTime = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGo];
-                for (int i = 0; i < chara_GoGoTime.Length; i++)
-                {
-                    chara_GoGoTime[i] = TxC(string.Format(GAME + CHARA + @"GoGo\{0}.png", i));
-                }
-                Chara_GoGoTime = chara_GoGoTime;
+                Chara_GoGoTime = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, GAME + CHARA + @"GoGo\{0}.png");
             }
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
             {
-                var chara_GoGoTime_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGo];
-                for (int i = 0; i < chara_GoGoTime_Maxed.Length; i++)
-                {
-                    chara_GoGoTime_Maxed[i] = TxC(string.Format(GAME + CHARA + @"GoGo_Max\{0}.png", i));
-                }
-                Chara_GoGoTime_Maxed = chara_GoGoTime_Maxed;
+                Chara_GoGoTime_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, GAME + CHARA + @"GoGo_Max\{0}.png");
             }
 
             TJAPlayer3.Skin.Game_Chara_Ptn_10combo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"10combo\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo != 0)
             {
-                var chara_10Combo = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_10combo];
-                for (int i = 0; i < chara_10Combo.Length; i++)
-                {
-                    chara_10Combo[i] = TxC(string.Format(GAME + CHARA + @"10combo\{0}.png", i));
-                }
-                Chara_10Combo = chara_10Combo;
+                Chara_10Combo = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo, GAME + CHARA + @"10combo\{0}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"10combo_Max\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max != 0)
             {
-                var chara_10Combo_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max];
-                for (int i = 0; i < chara_10Combo_Maxed.Length; i++)
-                {
-                    chara_10Combo_Maxed[i] = TxC(string.Format(GAME + CHARA + @"10combo_Max\{0}.png", i));
-                }
-                Chara_10Combo_Maxed = chara_10Combo_Maxed;
+                Chara_10Combo_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max, GAME + CHARA + @"10combo_Max\{0}.png");
             }
 
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGoStart\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart != 0)
             {
-                var chara_GoGoStart = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart];
-                for (int i = 0; i < chara_GoGoStart.Length; i++)
-                {
-                    chara_GoGoStart[i] = TxC(string.Format(GAME + CHARA + @"GoGoStart\{0}.png", i));
-                }
-                Chara_GoGoStart = chara_GoGoStart;
+                Chara_GoGoStart = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart, GAME + CHARA + @"GoGoStart\{0}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"GoGoStart_Max\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max != 0)
             {
-                var chara_GoGoStart_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max];
-                for (int i = 0; i < chara_GoGoStart_Maxed.Length; i++)
-                {
-                    chara_GoGoStart_Maxed[i] = TxC(string.Format(GAME + CHARA + @"GoGoStart_Max\{0}.png", i));
-                }
-                Chara_GoGoStart_Maxed = chara_GoGoStart_Maxed;
+                Chara_GoGoStart_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max, GAME + CHARA + @"GoGoStart_Max\{0}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"ClearIn\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn != 0)
             {
-                var chara_Become_Cleared = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn];
-                for (int i = 0; i < chara_Become_Cleared.Length; i++)
-                {
-                    chara_Become_Cleared[i] = TxC(string.Format(GAME + CHARA + @"ClearIn\{0}.png", i));
-                }
-                Chara_Become_Cleared = chara_Become_Cleared;
+                Chara_Become_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn, GAME + CHARA + @"ClearIn\{0}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"SoulIn\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn != 0)
             {
-                var chara_Become_Maxed = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn];
-                for (int i = 0; i < chara_Become_Maxed.Length; i++)
-                {
-                    chara_Become_Maxed[i] = TxC(string.Format(GAME + CHARA + @"SoulIn\{0}.png", i));
-                }
-                Chara_Become_Maxed = chara_Become_Maxed;
+                Chara_Become_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn, GAME + CHARA + @"SoulIn\{0}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Breaking\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking != 0)
             {
-                var chara_Balloon_Breaking = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking];
-                for (int i = 0; i < chara_Balloon_Breaking.Length; i++)
-                {
-                    chara_Balloon_Breaking[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Breaking\{0}.png", i));
-                }
-                Chara_Balloon_Breaking = chara_Balloon_Breaking;
+                Chara_Balloon_Breaking = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking, GAME + CHARA + @"Balloon_Breaking\{0}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Broke\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke != 0)
             {
-                var chara_Balloon_Broke = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke];
-                for (int i = 0; i < chara_Balloon_Broke.Length; i++)
-                {
-                    chara_Balloon_Broke[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Broke\{0}.png", i));
-                }
-                Chara_Balloon_Broke = chara_Balloon_Broke;
+                Chara_Balloon_Broke = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke, GAME + CHARA + @"Balloon_Broke\{0}.png");
             }
             TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + CHARA + @"Balloon_Miss\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss != 0)
             {
-                var chara_Balloon_Miss = new CTexture[TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss];
-                for (int i = 0; i < chara_Balloon_Miss.Length; i++)
-                {
-                    chara_Balloon_Miss[i] = TxC(string.Format(GAME + CHARA + @"Balloon_Miss\{0}.png", i));
-                }
-                Chara_Balloon_Miss = chara_Balloon_Miss;
+                Chara_Balloon_Miss = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss, GAME + CHARA + @"Balloon_Miss\{0}.png");
             }
             #endregion
             #region 踊り子
@@ -321,12 +250,7 @@ namespace TJAPlayer3
             #endregion
             #region モブ
             TJAPlayer3.Skin.Game_Mob_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + MOB));
-            var mob = new CTexture[TJAPlayer3.Skin.Game_Mob_Ptn];
-            for (int i = 0; i < mob.Length; i++)
-            {
-                mob[i] = TxC(string.Format(GAME + MOB + "{0}.png", i));
-            }
-            Mob = mob;
+            Mob = TxC(TJAPlayer3.Skin.Game_Mob_Ptn, GAME + MOB + "{0}.png");
 
             #endregion
             #region フッター
@@ -373,12 +297,7 @@ namespace TJAPlayer3
             Taiko_LevelUp = TxC(GAME + TAIKO + @"LevelUp.png");
             Taiko_LevelDown = TxC(GAME + TAIKO + @"LevelDown.png");
 
-            var course_Symbol = new CTexture[Course_Symbols.Length];
-            for (int i = 0; i < course_Symbol.Length; i++)
-            {
-                course_Symbol[i] = TxC(GAME + COURSESYMBOL + Course_Symbols[i] + ".png");
-            }
-            Course_Symbol = course_Symbol;
+            Course_Symbol = TxC(Course_Symbols, GAME + COURSESYMBOL + "{0}.png");
 
             Taiko_Score = new CTexture[3];
             Taiko_Score[0] = TxC(GAME + TAIKO + @"Score.png");
@@ -429,12 +348,7 @@ namespace TJAPlayer3
             TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + GAUGE + @"Rainbow\"));
             if (TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn != 0)
             {
-                var gauge_Rainbow = new CTexture[TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn];
-                for (int i = 0; i < TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn; i++)
-                {
-                    gauge_Rainbow[i] = TxC(string.Format(GAME + GAUGE + @"Rainbow\{0}.png", i));
-                }
-                Gauge_Rainbow = gauge_Rainbow;
+                Gauge_Rainbow = TxC(TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn, GAME + GAUGE + @"Rainbow\{0}.png");
             }
             Gauge_Soul = TxC(GAME + GAUGE + @"Soul.png");
             Gauge_Soul_Fire = TxC(GAME + GAUGE + @"Fire.png");
@@ -454,12 +368,7 @@ namespace TJAPlayer3
             Balloon_Number_Roll = TxC(GAME + BALLOON + @"Number_Roll.png");
             Balloon_Number_Combo = TxC(GAME + BALLOON + @"Number_Combo.png");
 
-            var balloon_Breaking = new CTexture[6];
-            for (int i = 0; i < balloon_Breaking.Length; i++)
-            {
-                balloon_Breaking[i] = TxC(string.Format(GAME + BALLOON + @"Breaking_{0}.png", i));
-            }
-            Balloon_Breaking = balloon_Breaking;
+            Balloon_Breaking = TxC(6, GAME + BALLOON + @"Breaking_{0}.png");
 
             #endregion
             #region エフェクト
@@ -479,58 +388,19 @@ namespace TJAPlayer3
             Effects_GoGoSplash = TxC(GAME + EFFECTS + @"GoGoSplash.png");
             if (Effects_GoGoSplash != null) Effects_GoGoSplash.b加算合成 = TJAPlayer3.Skin.Game_Effect_GoGoSplash_AddBlend;
 
-            var effects_Hit_Good = new CTexture[15];
-            for (int i = 0; i < effects_Hit_Good.Length; i++)
-            {
-                effects_Hit_Good[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Good\{0}.png", i));
-            }
-            Effects_Hit_Good = effects_Hit_Good;
-
-            var effects_Hit_Good_Big = new CTexture[15];
-            for (int i = 0; i < effects_Hit_Good_Big.Length; i++)
-            {
-                effects_Hit_Good_Big[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Good_Big\{0}.png", i));
-            }
-            Effects_Hit_Good_Big = effects_Hit_Good_Big;
-
-            var effects_Hit_Great = new CTexture[15];
-            for (int i = 0; i < effects_Hit_Great.Length; i++)
-            {
-                effects_Hit_Great[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Great\{0}.png", i));
-            }
-            Effects_Hit_Great = effects_Hit_Great;
-
-            var effects_Hit_Great_Big = new CTexture[15];
-            for (int i = 0; i < effects_Hit_Great_Big.Length; i++)
-            {
-                effects_Hit_Great_Big[i] = TxC(string.Format(GAME + EFFECTS + @"Hit\" + @"Great_Big\{0}.png", i));
-            }
-            Effects_Hit_Great_Big = effects_Hit_Great_Big;
+            Effects_Hit_Good = TxC(15, GAME + EFFECTS + @"Hit\" + @"Good\{0}.png");
+            Effects_Hit_Good_Big = TxC(15, GAME + EFFECTS + @"Hit\" + @"Good_Big\{0}.png");
+            Effects_Hit_Great = TxC(15, GAME + EFFECTS + @"Hit\" + @"Great\{0}.png");
+            Effects_Hit_Great_Big = TxC(15, GAME + EFFECTS + @"Hit\" + @"Great_Big\{0}.png");
 
             TJAPlayer3.Skin.Game_Effect_Roll_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + EFFECTS + @"Roll\"));
-            var effects_Roll = new CTexture[TJAPlayer3.Skin.Game_Effect_Roll_Ptn];
-            for (int i = 0; i < TJAPlayer3.Skin.Game_Effect_Roll_Ptn; i++)
-            {
-                effects_Roll[i] = TxC(string.Format(GAME + EFFECTS + @"Roll\{0}.png", i));
-            }
-            Effects_Roll = effects_Roll;
+            Effects_Roll = TxC(TJAPlayer3.Skin.Game_Effect_Roll_Ptn, GAME + EFFECTS + @"Roll\{0}.png");
 
             #endregion
             #region レーン
             var lanes = new[] { "Normal", "Expert", "Master" };
-            var lane_Base = new CTexture[lanes.Length];
-            for (int i = 0; i < lane_Base.Length; i++)
-            {
-                lane_Base[i] = TxC(GAME + LANE + "Base_" + lanes[i] + ".png");
-            }
-            Lane_Base = lane_Base;
-
-            var lane_Text = new CTexture[lanes.Length];
-            for (int i = 0; i < lane_Text.Length; i++)
-            {
-                lane_Text[i] = TxC(GAME + LANE + "Text_" + lanes[i] + ".png");
-            }
-            Lane_Text = lane_Text;
+            Lane_Base = TxC(lanes, GAME + LANE + "Base_{0}.png");
+            Lane_Text = TxC(lanes, GAME + LANE + "Text_{0}.png");
 
             Lane_Red = TxC(GAME + LANE + @"Red.png");
             Lane_Blue = TxC(GAME + LANE + @"Blue.png");
@@ -542,19 +412,8 @@ namespace TJAPlayer3
             #endregion
             #region 終了演出
 
-            var end_Clear_L = new CTexture[5];
-            for (int i = 0; i < end_Clear_L.Length; i++)
-            {
-                end_Clear_L[i] = TxC(string.Format(GAME + END + @"Clear_L_{0}.png", i));
-            }
-            End_Clear_L = end_Clear_L;
-
-            var end_Clear_R = new CTexture[5];
-            for (int i = 0; i < end_Clear_R.Length; i++)
-            {
-                end_Clear_R[i] = TxC(string.Format(GAME + END + @"Clear_R_{0}.png", i));
-            }
-            End_Clear_R = end_Clear_R;
+            End_Clear_L = TxC(5, GAME + END + @"Clear_L_{0}.png");
+            End_Clear_R = TxC(5, GAME + END + @"Clear_R_{0}.png");
 
             End_Clear_Text = TxC(GAME + END + @"Clear_Text.png");
             End_Clear_Text_Effect = TxC(GAME + END + @"Clear_Text_Effect.png");
@@ -574,13 +433,8 @@ namespace TJAPlayer3
             #region DanC
             DanC_Background = TxC(GAME + DANC + @"Background.png");
 
-            var danC_Gauge = new CTexture[4];
             var type = new string[] { "Normal", "Reach", "Clear", "Flush" };
-            for (int i = 0; i < danC_Gauge.Length; i++)
-            {
-                danC_Gauge[i] = TxC(GAME + DANC + @"Gauge_" + type[i] + ".png");
-            }
-            DanC_Gauge = danC_Gauge;
+            DanC_Gauge = TxC(type, GAME + DANC + "Gauge_{0}.png");
 
             DanC_Base = TxC(GAME + DANC + @"Base.png");
             DanC_Failed = TxC(GAME + DANC + @"Failed.png");

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -233,7 +233,7 @@ namespace TJAPlayer3
             Mob_Footer = TxC($"{GAME}{FOOTER}0.png");
             #endregion
             #region 背景
-            Background = TxC($@"{GAME}{Background}0\Background.png");
+            Background = TxC($@"{GAME}{BACKGROUND}0\Background.png");
             Background_Up = TxC(2, $@"{GAME}{BACKGROUND}0\{{0}}P_Up.png", 1);
             Background_Up_Clear = TxC(2, $@"{GAME}{BACKGROUND}0\{{0}}P_Up_Clear.png", 1);
             Background_Down = TxC($@"{GAME}{BACKGROUND}0\Down.png");

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -45,6 +45,13 @@ namespace TJAPlayer3
 
         private readonly List<CTexture> _trackedTextures = new List<CTexture>();
 
+        private (int skinGameCharaPtnNormal, CTexture[] charaNormal) TxCFolder(string folder)
+        {
+            var count = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + folder));
+            var texture = count == 0 ? null : TxC(count, folder + "{0}.png");
+            return (count, texture);
+        }
+
         private CTexture[] TxC(int count, string format, int start = 0)
         {
             return TxC(format, Enumerable.Range(start, count).Select(o => o.ToString()).ToArray());
@@ -166,89 +173,26 @@ namespace TJAPlayer3
             #endregion
             #region キャラクター
 
-            var s = $@"{GAME}{CHARA}Normal\";
-            var skinGameCharaPtnNormal = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s));
-            var charaNormal = skinGameCharaPtnNormal != 0 ? TxC(skinGameCharaPtnNormal, s + "{0}.png") : null;
-            Chara_Normal = charaNormal;
-            TJAPlayer3.Skin.Game_Chara_Ptn_Normal = skinGameCharaPtnNormal;
+            (TJAPlayer3.Skin.Game_Chara_Ptn_Normal, Chara_Normal) = TxCFolder($@"{GAME}{CHARA}Normal\");
+            (TJAPlayer3.Skin.Game_Chara_Ptn_Clear, Chara_Normal_Cleared) = TxCFolder($@"{GAME}{CHARA}Clear\");
+            (_, Chara_Normal_Maxed) = TxCFolder($@"{GAME}{CHARA}Clear_Max\");
 
-            var s1 = $@"{GAME}{CHARA}Clear\";
-            var skinGameCharaPtnClear = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s1));
-            var charaNormalCleared = skinGameCharaPtnClear != 0 ? TxC(skinGameCharaPtnClear, s1 + "{0}.png") : null;
-            Chara_Normal_Cleared = charaNormalCleared;
-            TJAPlayer3.Skin.Game_Chara_Ptn_Clear = skinGameCharaPtnClear;
+            (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, Chara_GoGoTime) = TxCFolder($@"{GAME}{CHARA}GoGo\");
+            (_, Chara_GoGoTime_Maxed) = TxCFolder($@"{GAME}{CHARA}GoGo_Max\");
 
-            var s2 = $@"{GAME}{CHARA}Clear_Max\";
-            var skinGameCharaPtnClearMax = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s2));
-            var charaNormalMaxed = skinGameCharaPtnClearMax != 0 ? TxC(skinGameCharaPtnClearMax, s2 + "{0}.png") : null;
-            Chara_Normal_Maxed = charaNormalMaxed;
-            // no assignment
+            (TJAPlayer3.Skin.Game_Chara_Ptn_10combo, Chara_10Combo) = TxCFolder($@"{GAME}{CHARA}10combo\");
+            (TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max, Chara_10Combo_Maxed) = TxCFolder($@"{GAME}{CHARA}10combo_Max\");
 
-            var s3 = $@"{GAME}{CHARA}GoGo\";
-            var skinGameCharaPtnGoGo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s3));
-            var charaGoGoTime = skinGameCharaPtnGoGo != 0 ? TxC(skinGameCharaPtnGoGo, s3 + "{0}.png") : null;
-            Chara_GoGoTime = charaGoGoTime;
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGo = skinGameCharaPtnGoGo;
+            (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart, Chara_GoGoStart) = TxCFolder($@"{GAME}{CHARA}GoGoStart\");
+            (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max, Chara_GoGoStart_Maxed) = TxCFolder($@"{GAME}{CHARA}GoGoStart_Max\");
 
-            var s4 = $@"{GAME}{CHARA}GoGo_Max\";
-            var skinGameCharaPtnGoGoMax = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s4));
-            var charaGoGoTimeMaxed = skinGameCharaPtnGoGoMax != 0 ? TxC(skinGameCharaPtnGoGoMax, s4 + "{0}.png") : null;
-            Chara_GoGoTime_Maxed = charaGoGoTimeMaxed;
-            // no assignment
+            (TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn, Chara_Become_Cleared) = TxCFolder($@"{GAME}{CHARA}ClearIn\");
 
-            var s5 = $@"{GAME}{CHARA}10combo\";
-            var skinGameCharaPtn10Combo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s5));
-            var chara10Combo = skinGameCharaPtn10Combo != 0 ? TxC(skinGameCharaPtn10Combo, s5 + "{0}.png") : null;
-            Chara_10Combo = chara10Combo;
-            TJAPlayer3.Skin.Game_Chara_Ptn_10combo = skinGameCharaPtn10Combo;
+            (TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn, Chara_Become_Maxed) = TxCFolder($@"{GAME}{CHARA}SoulIn\");
 
-            var s6 = $@"{GAME}{CHARA}10combo_Max\";
-            var skinGameCharaPtn10ComboMax = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s6));
-            var chara10ComboMaxed = skinGameCharaPtn10ComboMax != 0 ? TxC(skinGameCharaPtn10ComboMax, s6 + "{0}.png") : null;
-            Chara_10Combo_Maxed = chara10ComboMaxed;
-            TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = skinGameCharaPtn10ComboMax;
-
-            var s7 = $@"{GAME}{CHARA}GoGoStart\";
-            var skinGameCharaPtnGoGoStart = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s7));
-            var charaGoGoStart = skinGameCharaPtnGoGoStart != 0 ? TxC(skinGameCharaPtnGoGoStart, s7 + "{0}.png") : null;
-            Chara_GoGoStart = charaGoGoStart;
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart = skinGameCharaPtnGoGoStart;
-
-            var s8 = $@"{GAME}{CHARA}GoGoStart_Max\";
-            var skinGameCharaPtnGoGoStartMax = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s8));
-            var charaGoGoStartMaxed = skinGameCharaPtnGoGoStartMax != 0 ? TxC(skinGameCharaPtnGoGoStartMax, s8 + "{0}.png") : null;
-            Chara_GoGoStart_Maxed = charaGoGoStartMaxed;
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = skinGameCharaPtnGoGoStartMax;
-
-            var s9 = $@"{GAME}{CHARA}ClearIn\";
-            var skinGameCharaPtnClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s9));
-            var charaBecomeCleared = skinGameCharaPtnClearIn != 0 ? TxC(skinGameCharaPtnClearIn, s9 + "{0}.png") : null;
-            Chara_Become_Cleared = charaBecomeCleared;
-            TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = skinGameCharaPtnClearIn;
-
-            var s10 = $@"{GAME}{CHARA}SoulIn\";
-            var skinGameCharaPtnSoulIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s10));
-            var charaBecomeMaxed = skinGameCharaPtnSoulIn != 0 ? TxC(skinGameCharaPtnSoulIn, s10 + "{0}.png") : null;
-            Chara_Become_Maxed = charaBecomeMaxed;
-            TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn = skinGameCharaPtnSoulIn;
-
-            var s11 = $@"{GAME}{CHARA}Balloon_Breaking\";
-            var skinGameCharaPtnBalloonBreaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s11));
-            var charaBalloonBreaking = skinGameCharaPtnBalloonBreaking != 0 ? TxC(skinGameCharaPtnBalloonBreaking, s11 + "{0}.png") : null;
-            Chara_Balloon_Breaking = charaBalloonBreaking;
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = skinGameCharaPtnBalloonBreaking;
-
-            var s12 = $@"{GAME}{CHARA}Balloon_Broke\";
-            var skinGameCharaPtnBalloonBroke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s12));
-            var charaBalloonBroke = skinGameCharaPtnBalloonBroke != 0 ? TxC(skinGameCharaPtnBalloonBroke, s12 + "{0}.png") : null;
-            Chara_Balloon_Broke = charaBalloonBroke;
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = skinGameCharaPtnBalloonBroke;
-
-            var s13 = $@"{GAME}{CHARA}Balloon_Miss\";
-            var skinGameCharaPtnBalloonMiss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s13));
-            var charaBalloonMiss = skinGameCharaPtnBalloonMiss != 0 ? TxC(skinGameCharaPtnBalloonMiss, s13 + "{0}.png") : null;
-            Chara_Balloon_Miss = charaBalloonMiss;
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = skinGameCharaPtnBalloonMiss;
+            (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking, Chara_Balloon_Breaking) = TxCFolder($@"{GAME}{CHARA}Balloon_Breaking\");
+            (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke, Chara_Balloon_Broke) = TxCFolder($@"{GAME}{CHARA}Balloon_Broke\");
+            (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss, Chara_Balloon_Miss) = TxCFolder($@"{GAME}{CHARA}Balloon_Miss\");
 
             #endregion
             #region 踊り子
@@ -271,11 +215,7 @@ namespace TJAPlayer3
             #endregion
             #region モブ
 
-            var s14 = $"{GAME}{MOB}";
-            var skinGameMobPtn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s14));
-            var mob = skinGameMobPtn != 0 ? TxC(skinGameMobPtn, s14 + "{0}.png") : null;
-            Mob = mob;
-            TJAPlayer3.Skin.Game_Mob_Ptn = skinGameMobPtn;
+            (TJAPlayer3.Skin.Game_Mob_Ptn, Mob) = TxCFolder($"{GAME}{MOB}");
 
             #endregion
             #region フッター
@@ -326,11 +266,7 @@ namespace TJAPlayer3
             Gauge_Line = TxC(2, $"{GAME}{GAUGE}{{0}}P_Line.png", 1);
             Gauge_Line_Hard = TxC(2, $"{GAME}{GAUGE}{{0}}P_Line_Hard.png", 1);
 
-            var s15 = $@"{GAME}{GAUGE}Rainbow\";
-            var skinGameGaugeRainbowPtn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s15));
-            var gaugeRainbow = skinGameGaugeRainbowPtn != 0 ? TxC(skinGameGaugeRainbowPtn, s15 + "{0}.png") : null;
-            Gauge_Rainbow = gaugeRainbow;
-            TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn = skinGameGaugeRainbowPtn;
+            (TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn, Gauge_Rainbow) = TxCFolder($@"{GAME}{GAUGE}Rainbow\");
 
             Gauge_Soul = TxC($"{GAME}{GAUGE}Soul.png");
             Gauge_Soul_Fire = TxC($"{GAME}{GAUGE}Fire.png");
@@ -369,11 +305,7 @@ namespace TJAPlayer3
             Effects_Hit_Great = TxC(15, $@"{GAME}{EFFECTS}Hit\Great\{{0}}.png");
             Effects_Hit_Great_Big = TxC(15, $@"{GAME}{EFFECTS}Hit\Great_Big\{{0}}.png");
 
-            var s16 = $@"{GAME}{EFFECTS}Roll\";
-            var skinGameEffectRollPtn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + s16));
-            var effectsRoll = skinGameEffectRollPtn != 0 ? TxC(skinGameEffectRollPtn, s16 + "{0}.png") : null;
-            Effects_Roll = effectsRoll;
-            TJAPlayer3.Skin.Game_Effect_Roll_Ptn = skinGameEffectRollPtn;
+            (TJAPlayer3.Skin.Game_Effect_Roll_Ptn, Effects_Roll) = TxCFolder($@"{GAME}{EFFECTS}Roll\");
 
             #endregion
             #region レーン

--- a/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
+++ b/TJAPlayer3/Stages/01.StartUp/TextureLoader.cs
@@ -165,76 +165,86 @@ namespace TJAPlayer3
 
             #endregion
             #region キャラクター
-            TJAPlayer3.Skin.Game_Chara_Ptn_Normal = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Normal\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_Normal = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}Normal\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Normal != 0)
             {
-                Chara_Normal = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Normal, $@"{GAME}{CHARA}Normal\{{0}}.png");
-            }
-            TJAPlayer3.Skin.Game_Chara_Ptn_Clear = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Clear\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
-            {
-                Chara_Normal_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, $@"{GAME}{CHARA}Clear\{{0}}.png");
-            }
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
-            {
-                Chara_Normal_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, $@"{GAME}{CHARA}Clear_Max\{{0}}.png");
-            }
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}GoGo\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
-            {
-                Chara_GoGoTime = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, $@"{GAME}{CHARA}GoGo\{{0}}.png");
-            }
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
-            {
-                Chara_GoGoTime_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, $@"{GAME}{CHARA}GoGo_Max\{{0}}.png");
+                Chara_Normal = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Normal, $@"{GAME}{CHARA}Normal\" + "{0}.png");
             }
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_10combo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}10combo\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_Clear = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}Clear\"));
+            if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
+            {
+                Chara_Normal_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, $@"{GAME}{CHARA}Clear\" + "{0}.png");
+            }
+            if (TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
+            {
+                Chara_Normal_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Clear, $@"{GAME}{CHARA}Clear_Max\" + "{0}.png");
+            }
+
+            TJAPlayer3.Skin.Game_Chara_Ptn_GoGo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}GoGo\"));
+            if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
+            {
+                Chara_GoGoTime = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, $@"{GAME}{CHARA}GoGo\" + "{0}.png");
+            }
+            if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
+            {
+                Chara_GoGoTime_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo, $@"{GAME}{CHARA}GoGo_Max\" + "{0}.png");
+            }
+
+            TJAPlayer3.Skin.Game_Chara_Ptn_10combo = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}10combo\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo != 0)
             {
-                Chara_10Combo = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo, $@"{GAME}{CHARA}10combo\{{0}}.png");
-            }
-            TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}10combo_Max\"));
-            if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max != 0)
-            {
-                Chara_10Combo_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max, $@"{GAME}{CHARA}10combo_Max\{{0}}.png");
+                Chara_10Combo = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo, $@"{GAME}{CHARA}10combo\" + "{0}.png");
             }
 
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}GoGoStart\"));
+            TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}10combo_Max\"));
+            if (TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max != 0)
+            {
+                Chara_10Combo_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_10combo_Max, $@"{GAME}{CHARA}10combo_Max\" + "{0}.png");
+            }
+
+            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}GoGoStart\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart != 0)
             {
-                Chara_GoGoStart = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart, $@"{GAME}{CHARA}GoGoStart\{{0}}.png");
+                Chara_GoGoStart = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart, $@"{GAME}{CHARA}GoGoStart\" + "{0}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}GoGoStart_Max\"));
+
+            TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}GoGoStart_Max\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max != 0)
             {
-                Chara_GoGoStart_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max, $@"{GAME}{CHARA}GoGoStart_Max\{{0}}.png");
+                Chara_GoGoStart_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max, $@"{GAME}{CHARA}GoGoStart_Max\" + "{0}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}ClearIn\"));
+
+            TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}ClearIn\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn != 0)
             {
-                Chara_Become_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn, $@"{GAME}{CHARA}ClearIn\{{0}}.png");
+                Chara_Become_Cleared = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn, $@"{GAME}{CHARA}ClearIn\" + "{0}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}SoulIn\"));
+
+            TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}SoulIn\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn != 0)
             {
-                Chara_Become_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn, $@"{GAME}{CHARA}SoulIn\{{0}}.png");
+                Chara_Become_Maxed = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn, $@"{GAME}{CHARA}SoulIn\" + "{0}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Balloon_Breaking\"));
+
+            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}Balloon_Breaking\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking != 0)
             {
-                Chara_Balloon_Breaking = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking, $@"{GAME}{CHARA}Balloon_Breaking\{{0}}.png");
+                Chara_Balloon_Breaking = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking, $@"{GAME}{CHARA}Balloon_Breaking\" + "{0}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Balloon_Broke\"));
+
+            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}Balloon_Broke\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke != 0)
             {
-                Chara_Balloon_Broke = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke, $@"{GAME}{CHARA}Balloon_Broke\{{0}}.png");
+                Chara_Balloon_Broke = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Broke, $@"{GAME}{CHARA}Balloon_Broke\" + "{0}.png");
             }
-            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{CHARA}Balloon_Miss\"));
+
+            TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{CHARA}Balloon_Miss\"));
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss != 0)
             {
-                Chara_Balloon_Miss = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss, $@"{GAME}{CHARA}Balloon_Miss\{{0}}.png");
+                Chara_Balloon_Miss = TxC(TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss, $@"{GAME}{CHARA}Balloon_Miss\" + "{0}.png");
             }
+
             #endregion
             #region 踊り子
             TJAPlayer3.Skin.Game_Dancer_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{DANCER}1\"));
@@ -252,8 +262,11 @@ namespace TJAPlayer3
             }
             #endregion
             #region モブ
-            TJAPlayer3.Skin.Game_Mob_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + GAME + MOB));
-            Mob = TxC(TJAPlayer3.Skin.Game_Mob_Ptn, $"{GAME}{MOB}{{0}}.png");
+            TJAPlayer3.Skin.Game_Mob_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $"{GAME}{MOB}"));
+            if (TJAPlayer3.Skin.Game_Mob_Ptn != 0)
+            {
+                Mob = TxC(TJAPlayer3.Skin.Game_Mob_Ptn, $"{GAME}{MOB}" + "{0}.png");
+            }
 
             #endregion
             #region フッター
@@ -304,10 +317,10 @@ namespace TJAPlayer3
             Gauge_Line = TxC(2, $"{GAME}{GAUGE}{{0}}P_Line.png", 1);
             Gauge_Line_Hard = TxC(2, $"{GAME}{GAUGE}{{0}}P_Line_Hard.png", 1);
 
-            TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{GAUGE}Rainbow\"));
+            TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{GAUGE}Rainbow\"));
             if (TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn != 0)
             {
-                Gauge_Rainbow = TxC(TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn, $@"{GAME}{GAUGE}Rainbow\{{0}}.png");
+                Gauge_Rainbow = TxC(TJAPlayer3.Skin.Game_Gauge_Rainbow_Ptn, $@"{GAME}{GAUGE}Rainbow\" + "{0}.png");
             }
 
             Gauge_Soul = TxC($"{GAME}{GAUGE}Soul.png");
@@ -347,8 +360,11 @@ namespace TJAPlayer3
             Effects_Hit_Great = TxC(15, $@"{GAME}{EFFECTS}Hit\Great\{{0}}.png");
             Effects_Hit_Great_Big = TxC(15, $@"{GAME}{EFFECTS}Hit\Great_Big\{{0}}.png");
 
-            TJAPlayer3.Skin.Game_Effect_Roll_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path($@"{BASE}{GAME}{EFFECTS}Roll\"));
-            Effects_Roll = TxC(TJAPlayer3.Skin.Game_Effect_Roll_Ptn, $@"{GAME}{EFFECTS}Roll\{{0}}.png");
+            TJAPlayer3.Skin.Game_Effect_Roll_Ptn = TJAPlayer3.t連番画像の枚数を数える(CSkin.Path(BASE + $@"{GAME}{EFFECTS}Roll\"));
+            if (TJAPlayer3.Skin.Game_Effect_Roll_Ptn != 0)
+            {
+                Effects_Roll = TxC(TJAPlayer3.Skin.Game_Effect_Roll_Ptn, $@"{GAME}{EFFECTS}Roll\" + "{0}.png");
+            }
 
             #endregion
             #region レーン

--- a/TJAPlayer3/Stages/02.Title/CStageタイトル.cs
+++ b/TJAPlayer3/Stages/02.Title/CStageタイトル.cs
@@ -180,8 +180,7 @@ namespace TJAPlayer3
 
                 // 描画
 
-                if (TJAPlayer3.Tx.Title_Background != null )
-                    TJAPlayer3.Tx.Title_Background.t2D描画( TJAPlayer3.app.Device, 0, 0 );
+                TJAPlayer3.Tx.Title_Background?.t2D描画( TJAPlayer3.app.Device, 0, 0 );
 
                 #region[ バージョン表示 ]
                 const string repositoryUrl = "https://github.com/twopointzero/TJAPlayer3";

--- a/TJAPlayer3/Stages/04.Config/CActConfigKeyAssign.cs
+++ b/TJAPlayer3/Stages/04.Config/CActConfigKeyAssign.cs
@@ -185,9 +185,9 @@ namespace TJAPlayer3
 				y += num5;
 				TJAPlayer3.stageコンフィグ.actFont.t文字列描画( x + 20, y, "<< Returnto List", this.n現在の選択行 == 0x11, 0.75f );
 				y += num5;
-				if( this.bキー入力待ち && ( TJAPlayer3.Tx.Config_KeyAssign != null ) )
+				if( this.bキー入力待ち )
 				{
-                    TJAPlayer3.Tx.Config_KeyAssign.t2D描画( TJAPlayer3.app.Device, 0x185, 0xd7 );
+                    TJAPlayer3.Tx.Config_KeyAssign?.t2D描画( TJAPlayer3.app.Device, 0x185, 0xd7 );
 				}
 			}
 			return 0;

--- a/TJAPlayer3/Stages/04.Config/CActConfigList.cs
+++ b/TJAPlayer3/Stages/04.Config/CActConfigList.cs
@@ -1754,8 +1754,7 @@ namespace TJAPlayer3
 				{
 					case CItemBase.Eパネル種別.通常:
                     case CItemBase.Eパネル種別.その他:
-                        if ( TJAPlayer3.Tx.Config_ItemBox != null )
-                            TJAPlayer3.Tx.Config_ItemBox.t2D描画( TJAPlayer3.app.Device, x, y );
+                        TJAPlayer3.Tx.Config_ItemBox?.t2D描画( TJAPlayer3.app.Device, x, y );
 						break;
 				}
 				//-----------------

--- a/TJAPlayer3/Stages/04.Config/CStageコンフィグ.cs
+++ b/TJAPlayer3/Stages/04.Config/CStageコンフィグ.cs
@@ -180,8 +180,7 @@ namespace TJAPlayer3
 
 			#region [ 背景 ]
 			//---------------------
-			if(TJAPlayer3.Tx.Config_Background != null )
-                TJAPlayer3.Tx.Config_Background.t2D描画( TJAPlayer3.app.Device, 0, 0 );
+            TJAPlayer3.Tx.Config_Background?.t2D描画( TJAPlayer3.app.Device, 0, 0 );
 			//---------------------
 			#endregion
 			#region [ メニューカーソル ]

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelectPopupMenu.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelectPopupMenu.cs
@@ -313,11 +313,10 @@ namespace TJAPlayer3
 					#endregion
 				}
 				#region [ ポップアップメニュー 背景描画 ]
-				if ( TJAPlayer3.Tx.Menu_Title != null )
-				{
-                    TJAPlayer3.Tx.Menu_Title.t2D描画( TJAPlayer3.app.Device, 160, 40 );
-				}
-				#endregion
+
+                TJAPlayer3.Tx.Menu_Title?.t2D描画(TJAPlayer3.app.Device, 160, 40);
+
+                #endregion
 				#region [ ソートメニュータイトル描画 ]
 				int x = 240, y = 44;
 				stqMenuTitle.txName.t2D描画( TJAPlayer3.app.Device, x, y );

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -1226,7 +1226,7 @@ namespace TJAPlayer3
 							int y = this.ptバーの基本座標[ i ].Y;
                             this.tジャンル別選択されていない曲バーの描画( this.ptバーの座標[ nパネル番号 ].X, TJAPlayer3.Skin.SongSelect_Overall_Y, this.stバー情報[ nパネル番号 ].strジャンル );
                             if( this.stバー情報[ nパネル番号 ].b分岐[ TJAPlayer3.stage選曲.n現在選択中の曲の難易度 ] == true && i != 5 )
-                                TJAPlayer3.Tx.SongSelect_Branch.t2D描画( TJAPlayer3.app.Device, this.ptバーの座標[ nパネル番号 ].X + 66, TJAPlayer3.Skin.SongSelect_Overall_Y-5);
+                                TJAPlayer3.Tx.SongSelect_Branch?.t2D描画( TJAPlayer3.app.Device, this.ptバーの座標[ nパネル番号 ].X + 66, TJAPlayer3.Skin.SongSelect_Overall_Y-5);
                             if( this.stバー情報[ nパネル番号 ].ar難易度 != null )
                             {
                                 int nX補正 = 0;
@@ -1278,7 +1278,7 @@ namespace TJAPlayer3
                         else if (n見た目の行番号 != 5)
                             this.tジャンル別選択されていない曲バーの描画(xAnime, TJAPlayer3.Skin.SongSelect_Overall_Y, this.stバー情報[nパネル番号].strジャンル);
                         if (this.stバー情報[nパネル番号].b分岐[TJAPlayer3.stage選曲.n現在選択中の曲の難易度] == true && n見た目の行番号 != 5)
-                            TJAPlayer3.Tx.SongSelect_Branch.t2D描画(TJAPlayer3.app.Device, xAnime + 66, TJAPlayer3.Skin.SongSelect_Overall_Y - 5);
+                            TJAPlayer3.Tx.SongSelect_Branch?.t2D描画(TJAPlayer3.app.Device, xAnime + 66, TJAPlayer3.Skin.SongSelect_Overall_Y - 5);
                         //-----------------
                         #endregion
 

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -1051,8 +1051,8 @@ namespace TJAPlayer3
 			{
                 if( this.n現在のスクロールカウンタ == 0 )
                 {
-                    if( TJAPlayer3.Tx.SongSelect_Bar_Center != null )
-                        TJAPlayer3.Tx.SongSelect_Bar_Center.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.SongSelect_Bar_Center_X, TJAPlayer3.Skin.SongSelect_Overall_Y);
+                    TJAPlayer3.Tx.SongSelect_Bar_Center?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.SongSelect_Bar_Center_X, TJAPlayer3.Skin.SongSelect_Overall_Y);
+
                     switch (r現在選択中の曲.eノード種別)
                     {
                         case C曲リストノード.Eノード種別.SCORE:
@@ -1156,13 +1156,11 @@ namespace TJAPlayer3
                             break;
 
                         case C曲リストノード.Eノード種別.BACKBOX:
-                            if (TJAPlayer3.Tx.SongSelect_Frame_BackBox != null)
-                                TJAPlayer3.Tx.SongSelect_Frame_BackBox.t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
+                            TJAPlayer3.Tx.SongSelect_Frame_BackBox?.t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
                             break;
 
                         case C曲リストノード.Eノード種別.RANDOM:
-                            if (TJAPlayer3.Tx.SongSelect_Frame_Random != null)
-                                TJAPlayer3.Tx.SongSelect_Frame_Random.t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
+                            TJAPlayer3.Tx.SongSelect_Frame_Random?.t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
                             break;
                             //case C曲リストノード.Eノード種別.DANI:
                             //    if (CDTXMania.Tx.SongSelect_Frame_Dani != null)
@@ -1310,8 +1308,8 @@ namespace TJAPlayer3
 
                 if( this.n現在のスクロールカウンタ == 0 )
                 {
-                    if( TJAPlayer3.Tx.SongSelect_Bar_Center != null )
-                        TJAPlayer3.Tx.SongSelect_Bar_Center.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.SongSelect_Bar_Center_X, TJAPlayer3.Skin.SongSelect_Overall_Y);
+                    TJAPlayer3.Tx.SongSelect_Bar_Center?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.SongSelect_Bar_Center_X, TJAPlayer3.Skin.SongSelect_Overall_Y);
+
                     switch (r現在選択中の曲.eノード種別)
                     {
                         case C曲リストノード.Eノード種別.SCORE:
@@ -1429,13 +1427,11 @@ namespace TJAPlayer3
                             break;
 
                         case C曲リストノード.Eノード種別.BACKBOX:
-                            if (TJAPlayer3.Tx.SongSelect_Frame_BackBox != null)
-                                TJAPlayer3.Tx.SongSelect_Frame_BackBox.t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
+                            TJAPlayer3.Tx.SongSelect_Frame_BackBox?.t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
                             break;
 
                         case C曲リストノード.Eノード種別.RANDOM:
-                            if (TJAPlayer3.Tx.SongSelect_Frame_Random != null)
-                                TJAPlayer3.Tx.SongSelect_Frame_Random.t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
+                            TJAPlayer3.Tx.SongSelect_Frame_Random?.t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
                             break;
                             //case C曲リストノード.Eノード種別.DANI:
                             //    if (CDTXMania.Tx.SongSelect_Frame_Dani != null)
@@ -1556,8 +1552,7 @@ namespace TJAPlayer3
 
             if( this.e曲のバー種別を返す( this.r現在選択中の曲 ) == Eバー種別.Score && CStrジャンルtoNum.ForGenreTextIndex( this.r現在選択中の曲.strジャンル ) != 8 )
             {
-                if( TJAPlayer3.Tx.SongSelect_GenreText != null )
-                    TJAPlayer3.Tx.SongSelect_GenreText.t2D描画( TJAPlayer3.app.Device, 496, TJAPlayer3.Skin.SongSelect_Overall_Y-64, new Rectangle( 0, 60 * CStrジャンルtoNum.ForGenreTextIndex( this.r現在選択中の曲.strジャンル ), 288, 60 ) );
+                TJAPlayer3.Tx.SongSelect_GenreText?.t2D描画( TJAPlayer3.app.Device, 496, TJAPlayer3.Skin.SongSelect_Overall_Y-64, new Rectangle( 0, 60 * CStrジャンルtoNum.ForGenreTextIndex( this.r現在選択中の曲.strジャンル ), 288, 60 ) );
             }
 
 

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect演奏履歴パネル.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect演奏履歴パネル.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using SlimDX;
@@ -158,11 +155,10 @@ namespace TJAPlayer3
                 int y = 350;
                 if (TJAPlayer3.stage選曲.r現在選択中のスコア != null && this.ct登場アニメ用.n現在の値 >= 2000 && TJAPlayer3.stage選曲.r現在選択中の曲.eノード種別 == C曲リストノード.Eノード種別.SCORE)
                 {
-                    //CDTXMania.Tx.SongSelect_ScoreWindow_Text.n透明度 = ct登場アニメ用.n現在の値 - 1745;
-                    if (TJAPlayer3.Tx.SongSelect_ScoreWindow[TJAPlayer3.stage選曲.n現在選択中の曲の難易度] != null)
+                    var scoreWindowTexture = TJAPlayer3.Tx.SongSelect_ScoreWindow[TJAPlayer3.stage選曲.n現在選択中の曲の難易度];
+                    if (scoreWindowTexture != null)
                     {
-                        //CDTXMania.Tx.SongSelect_ScoreWindow[CDTXMania.stage選曲.n現在選択中の曲の難易度].n透明度 = ct登場アニメ用.n現在の値 - 1745;
-                        TJAPlayer3.Tx.SongSelect_ScoreWindow[TJAPlayer3.stage選曲.n現在選択中の曲の難易度].t2D描画(TJAPlayer3.app.Device, x, y);
+                        scoreWindowTexture.t2D描画(TJAPlayer3.app.Device, x, y);
                         this.t小文字表示(x + 56, y + 160, string.Format("{0,7:######0}", TJAPlayer3.stage選曲.r現在選択中のスコア.譜面情報.nハイスコア[TJAPlayer3.stage選曲.n現在選択中の曲の難易度].ToString()));
                         TJAPlayer3.Tx.SongSelect_ScoreWindow_Text?.t2D描画(TJAPlayer3.app.Device, x + 236, y + 166, new Rectangle(0, 36, 32, 30));
                     }

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect演奏履歴パネル.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect演奏履歴パネル.cs
@@ -164,7 +164,7 @@ namespace TJAPlayer3
                         //CDTXMania.Tx.SongSelect_ScoreWindow[CDTXMania.stage選曲.n現在選択中の曲の難易度].n透明度 = ct登場アニメ用.n現在の値 - 1745;
                         TJAPlayer3.Tx.SongSelect_ScoreWindow[TJAPlayer3.stage選曲.n現在選択中の曲の難易度].t2D描画(TJAPlayer3.app.Device, x, y);
                         this.t小文字表示(x + 56, y + 160, string.Format("{0,7:######0}", TJAPlayer3.stage選曲.r現在選択中のスコア.譜面情報.nハイスコア[TJAPlayer3.stage選曲.n現在選択中の曲の難易度].ToString()));
-                        TJAPlayer3.Tx.SongSelect_ScoreWindow_Text.t2D描画(TJAPlayer3.app.Device, x + 236, y + 166, new Rectangle(0, 36, 32, 30));
+                        TJAPlayer3.Tx.SongSelect_ScoreWindow_Text?.t2D描画(TJAPlayer3.app.Device, x + 236, y + 166, new Rectangle(0, 36, 32, 30));
                     }
                 }
 			}
@@ -203,10 +203,7 @@ namespace TJAPlayer3
                     if (this.st小文字位置[i].ch == ch)
                     {
                         Rectangle rectangle = new Rectangle( this.st小文字位置[i].pt.X, this.st小文字位置[i].pt.Y, 26, 36 );
-                        if (TJAPlayer3.Tx.SongSelect_ScoreWindow_Text != null)
-                        {
-                            TJAPlayer3.Tx.SongSelect_ScoreWindow_Text.t2D描画(TJAPlayer3.app.Device, x, y, rectangle);
-                        }
+                        TJAPlayer3.Tx.SongSelect_ScoreWindow_Text?.t2D描画(TJAPlayer3.app.Device, x, y, rectangle);
                         break;
                     }
                 }

--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -342,7 +342,7 @@ namespace TJAPlayer3
 				this.actShowCurrentPosition.On進行描画();								// #27648 2011.3.28 yyagi
 
                 //CDTXMania.act文字コンソール.tPrint( 0, 0, C文字コンソール.Eフォント種別.白, this.n現在選択中の曲の難易度.ToString() );
-                TJAPlayer3.Tx.SongSelect_Difficulty.t2D描画( TJAPlayer3.app.Device, 980, 30, new Rectangle( 0, 70 * this.n現在選択中の曲の難易度, 260, 70 ) );
+                TJAPlayer3.Tx.SongSelect_Difficulty?.t2D描画( TJAPlayer3.app.Device, 980, 30, new Rectangle( 0, 70 * this.n現在選択中の曲の難易度, 260, 70 ) );
 
 				if( !this.bBGM再生済み && ( base.eフェーズID == CStage.Eフェーズ.共通_通常状態 ) )
 				{

--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -288,8 +288,8 @@ namespace TJAPlayer3
                 TJAPlayer3.Tx.SongSelect_Header?.t2D描画( TJAPlayer3.app.Device, 0, 0 );
 
 				this.actInformation.On進行描画();
-				if( TJAPlayer3.Tx.SongSelect_Footer != null )
-                    TJAPlayer3.Tx.SongSelect_Footer.t2D描画( TJAPlayer3.app.Device, 0, 720 - TJAPlayer3.Tx.SongSelect_Footer.sz画像サイズ.Height );
+
+                TJAPlayer3.Tx.SongSelect_Footer?.t2D描画( TJAPlayer3.app.Device, 0, 720 - TJAPlayer3.Tx.SongSelect_Footer.sz画像サイズ.Height );
 
                 #region ネームプレート
                 for (int i = 0; i < Math.Min(TJAPlayer3.ConfigIni.nPlayerCount, TJAPlayer3.Tx.NamePlate.Length); i++)

--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -284,15 +284,8 @@ namespace TJAPlayer3
 			//	this.bIsEnumeratingSongs = !this.actPreimageパネル.bIsPlayingPremovie;				// #27060 2011.3.2 yyagi: #PREMOVIE再生中は曲検索を中断する
 
 				this.act曲リスト.On進行描画();
-				int y = 0;
-				if( this.ct登場時アニメ用共通.b進行中 )
-				{
-					double db登場割合 = ( (double) this.ct登場時アニメ用共通.n現在の値 ) / 100.0;	// 100が最終値
-					double dbY表示割合 = Math.Sin( Math.PI / 2 * db登場割合 );
-					y = ( (int) (TJAPlayer3.Tx.SongSelect_Header.sz画像サイズ.Height * dbY表示割合 ) ) - TJAPlayer3.Tx.SongSelect_Header.sz画像サイズ.Height;
-				}
-				if( TJAPlayer3.Tx.SongSelect_Header != null )
-                    TJAPlayer3.Tx.SongSelect_Header.t2D描画( TJAPlayer3.app.Device, 0, 0 );
+
+                TJAPlayer3.Tx.SongSelect_Header?.t2D描画( TJAPlayer3.app.Device, 0, 0 );
 
 				this.actInformation.On進行描画();
 				if( TJAPlayer3.Tx.SongSelect_Footer != null )

--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -209,7 +209,7 @@ namespace TJAPlayer3
                 //this.tx難易度別背景[3] = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\5_background_Master.png" ) );
                 //this.tx難易度別背景[4] = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\5_background_Edit.png" ) );
                 //this.tx下部テキスト = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\5_footer text.png" ) );
-                this.ct背景スクロール用タイマー = new CCounter(0, TJAPlayer3.Tx.SongSelect_Background.szテクスチャサイズ.Width, 30, TJAPlayer3.Timer);
+                this.ct背景スクロール用タイマー = new CCounter(0, TJAPlayer3.Tx.SongSelect_Background?.szテクスチャサイズ.Width ?? 1280, 30, TJAPlayer3.Timer);
 				base.OnManagedリソースの作成();
 			}
 		}

--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -299,7 +299,7 @@ namespace TJAPlayer3
                     TJAPlayer3.Tx.SongSelect_Footer.t2D描画( TJAPlayer3.app.Device, 0, 720 - TJAPlayer3.Tx.SongSelect_Footer.sz画像サイズ.Height );
 
                 #region ネームプレート
-                for (int i = 0; i < TJAPlayer3.ConfigIni.nPlayerCount; i++)
+                for (int i = 0; i < Math.Min(TJAPlayer3.ConfigIni.nPlayerCount, TJAPlayer3.Tx.NamePlate.Length); i++)
                 {
                     TJAPlayer3.Tx.NamePlate[i]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.SongSelect_NamePlate_X[i], TJAPlayer3.Skin.SongSelect_NamePlate_Y[i]);
                 }

--- a/TJAPlayer3/Stages/07.Game/CAct演奏ステージ失敗.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏ステージ失敗.cs
@@ -142,8 +142,7 @@ namespace TJAPlayer3
                 }
                 if (this.ct進行.n現在の値 > 1500)
                 {
-                    if (TJAPlayer3.Tx.Failed_Game != null)
-                        TJAPlayer3.Tx.Failed_Game.t2D描画(TJAPlayer3.app.Device, 0, 0);
+                    TJAPlayer3.Tx.Failed_Game?.t2D描画(TJAPlayer3.app.Device, 0, 0);
 
                     int num = (TJAPlayer3.DTX.listChip.Count > 0) ? TJAPlayer3.DTX.listChip[TJAPlayer3.DTX.listChip.Count - 1].n発声時刻ms : 0;
                     this.t文字表示(640, 520, (((this.dbFailedTime) / 1000.0) / (((double)num) / 1000.0) * 100).ToString("##0") + "%");
@@ -167,18 +166,13 @@ namespace TJAPlayer3
                 }
                 else
                 {
-                    if (TJAPlayer3.Tx.Failed_Stage != null)
-                    {
-                        TJAPlayer3.Tx.Failed_Stage.t2D描画(TJAPlayer3.app.Device, 0, 0);
-                    }
+                    TJAPlayer3.Tx.Failed_Stage?.t2D描画(TJAPlayer3.app.Device, 0, 0);
+
                     if (this.ct進行.n現在の値 <= 250)
                     {
                         int num2 = TJAPlayer3.Random.Next(5) - 2;
                         int y = TJAPlayer3.Random.Next(5) - 2;
-                        if (TJAPlayer3.Tx.Failed_Stage != null)
-                        {
-                            TJAPlayer3.Tx.Failed_Stage.t2D描画(TJAPlayer3.app.Device, num2, y);
-                        }
+                        TJAPlayer3.Tx.Failed_Stage?.t2D描画(TJAPlayer3.app.Device, num2, y);
                     }
                     if (!this.b効果音再生済み)
                     {

--- a/TJAPlayer3/Stages/07.Game/CAct演奏ステージ失敗.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏ステージ失敗.cs
@@ -231,10 +231,8 @@ namespace TJAPlayer3
                         {
                             rectangle.Width = 80;
                         }
-						if(TJAPlayer3.Tx.Balloon_Number_Roll != null )
-						{
-                            TJAPlayer3.Tx.Balloon_Number_Roll.t2D描画( TJAPlayer3.app.Device, x - ( 62 * str.Length / 2 ), y, rectangle );
-						}
+
+                        TJAPlayer3.Tx.Balloon_Number_Roll?.t2D描画( TJAPlayer3.app.Device, x - ( 62 * str.Length / 2 ), y, rectangle );
 						break;
 					}
 				}

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -89,9 +89,8 @@ namespace TJAPlayer3
 					}
 				}
 
-			    this.txGENRE?.Dispose();
                 var genreTextureFileName = CStrジャンルtoStr.ForTextureFileName( genreName );
-			    this.txGENRE = genreTextureFileName == null ? null : TJAPlayer3.Tx.TxCGenreUntracked(genreTextureFileName);
+			    this.txGENRE = genreTextureFileName == null ? null : TJAPlayer3.Tx.TxCGenre(genreTextureFileName);
 
 			    this.ct進行用 = new CCounter( 0, 2000, 2, TJAPlayer3.Timer );
 			}
@@ -144,7 +143,7 @@ namespace TJAPlayer3
             {
                 TJAPlayer3.t安全にDisposeする(ref txPanel);
                 TJAPlayer3.t安全にDisposeする(ref txMusicName);
-                TJAPlayer3.t安全にDisposeする(ref txGENRE);
+                txGENRE = null;
                 TJAPlayer3.t安全にDisposeする(ref txPanel);
                 TJAPlayer3.t安全にDisposeする(ref tx歌詞テクスチャ);
                 TJAPlayer3.t安全にDisposeする(ref pfMusicName);
@@ -177,11 +176,11 @@ namespace TJAPlayer3
                 {
                     this.ct進行用.n現在の値 = 300;
                 }
-                if( this.txGENRE != null )
-                    this.txGENRE.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Genre_XY[0], TJAPlayer3.Skin.Game_Genre_XY[1] );
 
                 if( TJAPlayer3.Skin.b現在のステージ数を表示しない )
                 {
+                    txGENRE?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Genre_XY[0], TJAPlayer3.Skin.Game_Genre_XY[1]);
+
                     if( this.txMusicName != null )
                     {
                         float fRate = 660.0f / this.txMusicName.szテクスチャサイズ.Width;
@@ -218,14 +217,14 @@ namespace TJAPlayer3
                         opacity = ct進行用.n現在の値 - 1745;
                     }
 
-                    if (txMusicName != null)
-                    {
-                        txMusicName.Opacity = opacity;
-                    }
-
                     if (txGENRE != null)
                     {
                         txGENRE.Opacity = opacity;
+                    }
+
+                    if (txMusicName != null)
+                    {
+                        txMusicName.Opacity = opacity;
                     }
 
                     if (tx難易度とステージ数 != null)
@@ -234,6 +233,8 @@ namespace TJAPlayer3
                     }
 
                     #endregion
+
+                    txGENRE?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Genre_XY[0], TJAPlayer3.Skin.Game_Genre_XY[1]);
 
                     txMusicName?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_MusicName_XY[0], TJAPlayer3.Skin.Game_MusicName_XY[1], TJAPlayer3.Skin.GameMusicNameHorizontalReferencePoint);
 

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -91,7 +91,7 @@ namespace TJAPlayer3
 
 			    this.txGENRE?.Dispose();
                 var genreTextureFileName = CStrジャンルtoStr.ForTextureFileName( genreName );
-			    this.txGENRE = genreTextureFileName == null ? null : TJAPlayer3.Tx.TxCGen(genreTextureFileName);
+			    this.txGENRE = genreTextureFileName == null ? null : TJAPlayer3.Tx.TxCGenreUntracked(genreTextureFileName);
 
 			    this.ct進行用 = new CCounter( 0, 2000, 2, TJAPlayer3.Timer );
 			}

--- a/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
+++ b/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
@@ -2609,11 +2609,6 @@ namespace TJAPlayer3
 
 			var n現在時刻ms = CSound管理.rc演奏用タイマ.n現在時刻ms;
 
-			if( this.r指定時刻に一番近い未ヒットChip( (long)n現在時刻ms, 0x50, 0, 1000000, nPlayer ) == null )
-            {
-                this.actChara.b演奏中 = false;
-            }
-
 			var db現在の譜面スクロール速度 = this.act譜面スクロール速度.db現在の譜面スクロール速度;
 
 			//double speed = 264.0;	// BPM150の時の1小節の長さ[dot]
@@ -2908,7 +2903,6 @@ namespace TJAPlayer3
 						{
                             if ( !pChip.bHit && ( pChip.nバーからの距離dot.Taiko < 0 ) )
 						    {
-                                this.actChara.b演奏中 = true;
                                 if( this.actPlayInfo.NowMeasure[nPlayer] == 0 )
                                 {
                                     for (int i = 0; i < 2; i++)

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsFooter.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsFooter.cs
@@ -14,10 +14,7 @@ namespace TJAPlayer3
 
         public override int On進行描画()
         {
-            if (TJAPlayer3.Tx.Mob_Footer != null)
-            {
-                TJAPlayer3.Tx.Mob_Footer.t2D描画(TJAPlayer3.app.Device, 0, 720 - TJAPlayer3.Tx.Mob_Footer.szテクスチャサイズ.Height);
-            }
+            TJAPlayer3.Tx.Mob_Footer?.t2D描画(TJAPlayer3.app.Device, 0, 720 - TJAPlayer3.Tx.Mob_Footer.szテクスチャサイズ.Height);
 
             return base.On進行描画();
         }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMob.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMob.cs
@@ -55,7 +55,7 @@ namespace TJAPlayer3
                 {
                     if (TJAPlayer3.stage演奏ドラム画面.actGauge.db現在のゲージ値[0] >= 100)
                     {
-                        TJAPlayer3.Tx.Mob[(int)ctMobPtn.db現在の値]?.t2D描画(TJAPlayer3.app.Device, 0, (720 - (TJAPlayer3.Tx.Mob[0].szテクスチャサイズ.Height - 70)) + -((float)Math.Sin((float)this.ctMob.db現在の値 * (Math.PI / 180)) * 70));
+                        TJAPlayer3.Tx.Mob?[(int)ctMobPtn.db現在の値]?.t2D描画(TJAPlayer3.app.Device, 0, (720 - (TJAPlayer3.Tx.Mob[0].szテクスチャサイズ.Height - 70)) + -((float)Math.Sin((float)this.ctMob.db現在の値 * (Math.PI / 180)) * 70));
                     }
 
                 }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMob.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMob.cs
@@ -55,7 +55,7 @@ namespace TJAPlayer3
                 {
                     if (TJAPlayer3.stage演奏ドラム画面.actGauge.db現在のゲージ値[0] >= 100)
                     {
-                        TJAPlayer3.Tx.Mob?[(int)ctMobPtn.db現在の値]?.t2D描画(TJAPlayer3.app.Device, 0, (720 - (TJAPlayer3.Tx.Mob[0].szテクスチャサイズ.Height - 70)) + -((float)Math.Sin((float)this.ctMob.db現在の値 * (Math.PI / 180)) * 70));
+                        TJAPlayer3.Tx.Mob[(int)ctMobPtn.db現在の値]?.t2D描画(TJAPlayer3.app.Device, 0, (720 - (TJAPlayer3.Tx.Mob[0].szテクスチャサイズ.Height - 70)) + -((float)Math.Sin((float)this.ctMob.db現在の値 * (Math.PI / 180)) * 70));
                     }
 
                 }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
@@ -187,17 +187,21 @@ namespace TJAPlayer3
 
             for( int i = 0; i < TJAPlayer3.ConfigIni.nPlayerCount; i++ )
             {
-                TJAPlayer3.Tx.Course_Symbol[TJAPlayer3.stage選曲.n確定された曲の難易度]?.t2D描画(TJAPlayer3.app.Device,
-                    TJAPlayer3.Skin.Game_CourseSymbol_X[i],
-                    TJAPlayer3.Skin.Game_CourseSymbol_Y[i]
-                    );
 
-                if (TJAPlayer3.ConfigIni.ShinuchiMode)
+                if (TJAPlayer3.Tx.Course_Symbol.Length > TJAPlayer3.stage選曲.n確定された曲の難易度)
                 {
-                    TJAPlayer3.Tx.Course_Symbol[(int)Difficulty.Total]?.t2D描画(TJAPlayer3.app.Device,
+                    TJAPlayer3.Tx.Course_Symbol[TJAPlayer3.stage選曲.n確定された曲の難易度]?.t2D描画(TJAPlayer3.app.Device,
                         TJAPlayer3.Skin.Game_CourseSymbol_X[i],
                         TJAPlayer3.Skin.Game_CourseSymbol_Y[i]
-                        );
+                    );
+                }
+
+                if (TJAPlayer3.ConfigIni.ShinuchiMode && TJAPlayer3.Tx.Course_Symbol.Length > (int)Difficulty.Total)
+                {
+                    TJAPlayer3.Tx.Course_Symbol[(int) Difficulty.Total]?.t2D描画(TJAPlayer3.app.Device,
+                        TJAPlayer3.Skin.Game_CourseSymbol_X[i],
+                        TJAPlayer3.Skin.Game_CourseSymbol_Y[i]
+                    );
                 }
             }
 

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
@@ -6,20 +6,8 @@ namespace TJAPlayer3
 {
     internal class CAct演奏DrumsMtaiko : CActivity
     {
-        /// <summary>
-        /// mtaiko部分を描画するクラス。左側だけ。
-        /// 
-        /// </summary>
         public CAct演奏DrumsMtaiko()
         {
-            //this.strCourseSymbolFileName = new string[]{
-            //    @"Graphics\CourseSymbol\easy.png",
-            //    @"Graphics\CourseSymbol\normal.png",
-            //    @"Graphics\CourseSymbol\hard.png",
-            //    @"Graphics\CourseSymbol\oni.png",
-            //    @"Graphics\CourseSymbol\edit.png",
-            //    @"Graphics\CourseSymbol\sinuchi.png",
-            //};
             base.b活性化してない = true;
         }
 
@@ -34,81 +22,21 @@ namespace TJAPlayer3
             base.On活性化();
         }
 
-        public override void On非活性化()
-        {
-            base.On非活性化();
-        }
-
         public override void OnManagedリソースの作成()
         {
-            //this.txMtaiko枠 = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_mtaiko_A.png" ) );
-            //this.txMtaiko下敷き[ 0 ] = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_mtaiko_C.png" ) );
-            //if (CDTXMania.stage演奏ドラム画面.bDoublePlay)
-            //    this.txMtaiko下敷き[ 1 ] = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_mtaiko_C_2P.png" ) );
-
-            //this.txオプションパネル_HS = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_HiSpeed.png" ) );
-            //this.txオプションパネル_RANMIR = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_RANMIR.png" ) );
-            //this.txオプションパネル_特殊 = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_SpecialOption.png" ) );
-            
-            //this.tx太鼓_土台 = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_mtaiko_main.png" ) );
-            //this.tx太鼓_面L = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_mtaiko_red.png" ) );
-            //this.tx太鼓_ふちL = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_mtaiko_blue.png" ) );
-            //this.tx太鼓_面R = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_mtaiko_red.png" ) );
-            //this.tx太鼓_ふちR = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_mtaiko_blue.png" ) );
-
-            //this.txレベルアップ = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_LevelUp.png" ) );
-            //this.txレベルダウン = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_LevelDown.png" ) );
-
-            //this.txネームプレート = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_NamePlate.png" ) );
-            //if (CDTXMania.stage演奏ドラム画面.bDoublePlay)
-            //    this.txネームプレート = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_NamePlate2P.png" ) );
-            
-            //for( int i = 0; i < 6; i++ )
-            //{
-            //    this.txコースシンボル[ i ] = CDTXMania.tテクスチャの生成( CSkin.Path( this.strCourseSymbolFileName[ i ] ) );
-            //}
             this.ctレベルアップダウン = new CCounter[ 4 ];
             this.After = new int[ 4 ];
             this.Before = new int[ 4 ];
             for( int i = 0; i < 4; i++ )
             {
-                //this.ctレベルアップダウン = new CCounter( 0, 1000, 1, CDTXMania.Timer );
                 this.ctレベルアップダウン[ i ] = new CCounter();
             }
-
 
             base.OnManagedリソースの作成();
         }
 
         public override void OnManagedリソースの解放()
         {
-      //      CDTXMania.tテクスチャの解放( ref this.txMtaiko枠 );
-      //      CDTXMania.tテクスチャの解放( ref this.txMtaiko下敷き[ 0 ] );
-      //      if (CDTXMania.stage演奏ドラム画面.bDoublePlay)
-      //          CDTXMania.tテクスチャの解放( ref this.txMtaiko下敷き[ 1 ] );
-            
-		    //CDTXMania.tテクスチャの解放( ref this.tx太鼓_土台 );
-      //      CDTXMania.tテクスチャの解放( ref this.txオプションパネル_HS );
-      //      CDTXMania.tテクスチャの解放( ref this.txオプションパネル_RANMIR );
-      //      CDTXMania.tテクスチャの解放( ref this.txオプションパネル_特殊 );
-
-      //      CDTXMania.tテクスチャの解放( ref this.tx太鼓_面L );
-      //      CDTXMania.tテクスチャの解放( ref this.tx太鼓_面R );
-		    //CDTXMania.tテクスチャの解放( ref this.tx太鼓_ふちL );
-      //      CDTXMania.tテクスチャの解放( ref this.tx太鼓_ふちR );
-
-		    //CDTXMania.tテクスチャの解放( ref this.txレベルアップ );
-      //      CDTXMania.tテクスチャの解放( ref this.txレベルダウン );
-
-      //      CDTXMania.tテクスチャの解放( ref this.txネームプレート );
-      //      if (CDTXMania.stage演奏ドラム画面.bDoublePlay)
-      //          CDTXMania.tテクスチャの解放( ref this.txネームプレート2P );
-
-      //      for( int i = 0; i < 6; i++ )
-      //      {
-      //          CDTXMania.tテクスチャの解放( ref this.txコースシンボル[ i ] );
-      //      }
-
             this.ctレベルアップダウン = null;
 
             base.OnManagedリソースの解放();
@@ -139,17 +67,10 @@ namespace TJAPlayer3
 				this.nフラッシュ制御タイマ += 20;
 		    }
 
-
-            this.nHS = TJAPlayer3.ConfigIni.n譜面スクロール速度.Drums < 8 ? TJAPlayer3.ConfigIni.n譜面スクロール速度.Drums : 7;
-
-            //if(CDTXMania.Tx.Taiko_Frame[ 0 ] != null )
-               // CDTXMania.Tx.Taiko_Frame[ 0 ].t2D描画( CDTXMania.app.Device, 0, 184 );
             TJAPlayer3.Tx.Taiko_Background[0]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Background_X[0], TJAPlayer3.Skin.Game_Taiko_Background_Y[0] );
 
             if ( TJAPlayer3.stage演奏ドラム画面.bDoublePlay )
             {
-                //if(CDTXMania.Tx.Taiko_Frame[ 1 ] != null )
-                    //CDTXMania.Tx.Taiko_Frame[ 1 ].t2D描画( CDTXMania.app.Device, 0, 360 );
                 TJAPlayer3.Tx.Taiko_Background[1]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Background_X[1], TJAPlayer3.Skin.Game_Taiko_Background_Y[1]);
             }
             
@@ -196,8 +117,6 @@ namespace TJAPlayer3
                 TJAPlayer3.Tx.Taiko_Don_Right.t2D描画( TJAPlayer3.app.Device, p2RightX, p2Y, rightDrawingArea );
             }
 
-            int[] nLVUPY = new int[] { 127, 127, 0, 0 };
-
             for ( int i = 0; i < TJAPlayer3.ConfigIni.nPlayerCount; i++ )
             {
                 if( !this.ctレベルアップダウン[ i ].b停止中 )
@@ -209,8 +128,6 @@ namespace TJAPlayer3
                 }
                 if( ( this.ctレベルアップダウン[ i ].b進行中 && ( TJAPlayer3.Tx.Taiko_LevelUp != null && TJAPlayer3.Tx.Taiko_LevelDown != null ) ) && !TJAPlayer3.ConfigIni.bNoInfo )
                 {
-                    //this.ctレベルアップダウン[ i ].n現在の値 = 110;
-
                     //2017.08.21 kairera0467 t3D描画に変更。
                     float fScale = 1.0f;
                     int nAlpha = 255;
@@ -270,35 +187,6 @@ namespace TJAPlayer3
 
             for( int i = 0; i < TJAPlayer3.ConfigIni.nPlayerCount; i++ )
             {
-                // 2018/7/1 一時的にオプション画像の廃止。オプション画像については後日作り直します。(AioiLight)
-                //if( !CDTXMania.ConfigIni.bNoInfo && CDTXMania.Skin.eDiffDispMode != E難易度表示タイプ.mtaikoに画像で表示 )
-                //{
-                //    this.txオプションパネル_HS.t2D描画( CDTXMania.app.Device, 0, 230, new Rectangle( 0, this.nHS * 44, 162, 44 ) );
-                //    switch( CDTXMania.ConfigIni.eRandom.Taiko )
-                //    {
-                //        case Eランダムモード.RANDOM:
-                //            if( this.txオプションパネル_RANMIR != null )
-                //                this.txオプションパネル_RANMIR.t2D描画( CDTXMania.app.Device, 0, 264, new Rectangle( 0, 0, 162, 44 ) );
-                //            break;
-                //        case Eランダムモード.HYPERRANDOM:
-                //            if( this.txオプションパネル_RANMIR != null )
-                //                this.txオプションパネル_RANMIR.t2D描画( CDTXMania.app.Device, 0, 264, new Rectangle( 0, 88, 162, 44 ) );
-                //            break;
-                //        case Eランダムモード.SUPERRANDOM:
-                //            if( this.txオプションパネル_RANMIR != null )
-                //                this.txオプションパネル_RANMIR.t2D描画( CDTXMania.app.Device, 0, 264, new Rectangle( 0, 132, 162, 44 ) );
-                //            break;
-                //        case Eランダムモード.MIRROR:
-                //            if( this.txオプションパネル_RANMIR != null )
-                //                this.txオプションパネル_RANMIR.t2D描画( CDTXMania.app.Device, 0, 264, new Rectangle( 0, 44, 162, 44 ) );
-                //            break;
-                //    }
-
-                //    if( CDTXMania.ConfigIni.eSTEALTH == Eステルスモード.STEALTH )
-                //        this.txオプションパネル_特殊.t2D描画( CDTXMania.app.Device, 0, 300, new Rectangle( 0, 0, 162, 44 ) );
-                //    else if( CDTXMania.ConfigIni.eSTEALTH == Eステルスモード.DORON )
-                //        this.txオプションパネル_特殊.t2D描画( CDTXMania.app.Device, 0, 300, new Rectangle( 0, 44, 162, 44 ) );
-                //}
                 TJAPlayer3.Tx.Course_Symbol[TJAPlayer3.stage選曲.n確定された曲の難易度]?.t2D描画(TJAPlayer3.app.Device,
                     TJAPlayer3.Skin.Game_CourseSymbol_X[i],
                     TJAPlayer3.Skin.Game_CourseSymbol_Y[i]
@@ -324,25 +212,6 @@ namespace TJAPlayer3
             {
                 TJAPlayer3.Tx.Taiko_PlayerNumber[1]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_PlayerNumber_X[1], TJAPlayer3.Skin.Game_Taiko_PlayerNumber_Y[1]);
             }
-
-            //if (CDTXMania.Input管理.Keyboard.bキーが押された((int)SlimDX.DirectInput.Key.V))
-            //{
-            //    this.tMtaikoEvent( 0x11, 0, 1 );
-            //}
-            //if (CDTXMania.Input管理.Keyboard.bキーが押された((int)SlimDX.DirectInput.Key.N))
-            //{
-            //    this.tMtaikoEvent( 0x11, 1, 1 );
-            //}
-            //if (CDTXMania.Input管理.Keyboard.bキーが押された((int)SlimDX.DirectInput.Key.C))
-            //{
-            //    this.tMtaikoEvent( 0x12, 0, 1 );
-            //}
-            //if (CDTXMania.Input管理.Keyboard.bキーが押された((int)SlimDX.DirectInput.Key.M))
-            //{
-            //    this.tMtaikoEvent( 0x12, 1, 1 );
-            //}
-
-
 
             return base.On進行描画();
         }
@@ -427,38 +296,14 @@ namespace TJAPlayer3
             public int n明るさ;
         }
 
-        //太鼓
-        //private CTexture txMtaiko枠;
-        //private CTexture[] txMtaiko下敷き = new CTexture[ 4 ];
+        private readonly STパッド状態[] stパッド状態 = new STパッド状態[ 4 * 4 ];
 
-        //private CTexture tx太鼓_土台;
-        //private CTexture tx太鼓_面L;
-        //private CTexture tx太鼓_ふちL;
-        //private CTexture tx太鼓_面R;
-        //private CTexture tx太鼓_ふちR;
-
-        private STパッド状態[] stパッド状態 = new STパッド状態[ 4 * 4 ];
         private long nフラッシュ制御タイマ;
-
-        //private CTexture[] txコースシンボル = new CTexture[ 6 ];
-        private string[] strCourseSymbolFileName;
-
-        //オプション
-        private CTexture txオプションパネル_HS;
-        private CTexture txオプションパネル_RANMIR;
-        private CTexture txオプションパネル_特殊;
-        private int nHS;
-
-        //ネームプレート
-        //private CTexture txネームプレート;
-        //private CTexture txネームプレート2P;
 
         //譜面分岐
         private CCounter[] ctレベルアップダウン;
         private int[] After;
         private int[] Before;
-        //private CTexture txレベルアップ;
-        //private CTexture txレベルダウン;
         //-----------------
         #endregion
 

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using FDK;
@@ -162,30 +159,41 @@ namespace TJAPlayer3
                 if( TJAPlayer3.stage演奏ドラム画面.bDoublePlay )
                     TJAPlayer3.Tx.Taiko_Base.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_X[1], TJAPlayer3.Skin.Game_Taiko_Y[1]);
             }
+
             if( TJAPlayer3.Tx.Taiko_Don_Left != null && TJAPlayer3.Tx.Taiko_Don_Right != null && TJAPlayer3.Tx.Taiko_Ka_Left != null && TJAPlayer3.Tx.Taiko_Ka_Right != null )
             {
+                var taikoKaRightTextureSize = TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ;
+                var halfWidth = taikoKaRightTextureSize.Width / 2;
+                var leftDrawingArea = new Rectangle( 0, 0, halfWidth, taikoKaRightTextureSize.Height);
+                var rightDrawingArea = new Rectangle(halfWidth, 0, halfWidth, taikoKaRightTextureSize.Height);
+
                 TJAPlayer3.Tx.Taiko_Ka_Left.Opacity = this.stパッド状態[0].n明るさ * 73;
                 TJAPlayer3.Tx.Taiko_Ka_Right.Opacity = this.stパッド状態[1].n明るさ * 73;
                 TJAPlayer3.Tx.Taiko_Don_Left.Opacity = this.stパッド状態[2].n明るさ * 73;
                 TJAPlayer3.Tx.Taiko_Don_Right.Opacity = this.stパッド状態[3].n明るさ * 73;
-            
-                TJAPlayer3.Tx.Taiko_Ka_Left.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_X[0], TJAPlayer3.Skin.Game_Taiko_Y[0], new Rectangle( 0, 0, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Height) );
-                TJAPlayer3.Tx.Taiko_Ka_Right.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_X[0] + TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Taiko_Y[0], new Rectangle(TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Height) );
-                TJAPlayer3.Tx.Taiko_Don_Left.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_X[0], TJAPlayer3.Skin.Game_Taiko_Y[0], new Rectangle( 0, 0, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Height) );
-                TJAPlayer3.Tx.Taiko_Don_Right.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_X[0] + TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Taiko_Y[0], new Rectangle(TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Height));
-            }
 
-            if( TJAPlayer3.Tx.Taiko_Don_Left != null && TJAPlayer3.Tx.Taiko_Don_Right != null && TJAPlayer3.Tx.Taiko_Ka_Left != null && TJAPlayer3.Tx.Taiko_Ka_Right != null )
-            {
+                var p1LeftX = TJAPlayer3.Skin.Game_Taiko_X[0];
+                var p1RightX = p1LeftX + halfWidth;
+                var p1Y = TJAPlayer3.Skin.Game_Taiko_Y[0];
+
+                TJAPlayer3.Tx.Taiko_Ka_Left.t2D描画( TJAPlayer3.app.Device, p1LeftX, p1Y, leftDrawingArea );
+                TJAPlayer3.Tx.Taiko_Ka_Right.t2D描画( TJAPlayer3.app.Device, p1RightX, p1Y, rightDrawingArea );
+                TJAPlayer3.Tx.Taiko_Don_Left.t2D描画( TJAPlayer3.app.Device, p1LeftX, p1Y, leftDrawingArea );
+                TJAPlayer3.Tx.Taiko_Don_Right.t2D描画( TJAPlayer3.app.Device, p1RightX, p1Y, rightDrawingArea );
+
                 TJAPlayer3.Tx.Taiko_Ka_Left.Opacity = this.stパッド状態[4].n明るさ * 73;
                 TJAPlayer3.Tx.Taiko_Ka_Right.Opacity = this.stパッド状態[5].n明るさ * 73;
                 TJAPlayer3.Tx.Taiko_Don_Left.Opacity = this.stパッド状態[6].n明るさ * 73;
                 TJAPlayer3.Tx.Taiko_Don_Right.Opacity = this.stパッド状態[7].n明るさ * 73;
-            
-                TJAPlayer3.Tx.Taiko_Ka_Left.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_X[1], TJAPlayer3.Skin.Game_Taiko_Y[1], new Rectangle( 0, 0, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Height) );
-                TJAPlayer3.Tx.Taiko_Ka_Right.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_X[1] + TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Taiko_Y[1], new Rectangle(TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Height) );
-                TJAPlayer3.Tx.Taiko_Don_Left.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_X[1], TJAPlayer3.Skin.Game_Taiko_Y[1], new Rectangle( 0, 0, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Height) );
-                TJAPlayer3.Tx.Taiko_Don_Right.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_X[1] + TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Taiko_Y[1], new Rectangle(TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.Taiko_Ka_Right.szテクスチャサイズ.Height) );
+
+                var p2LeftX = TJAPlayer3.Skin.Game_Taiko_X[1];
+                var p2RightX = p2LeftX + halfWidth;
+                var p2Y = TJAPlayer3.Skin.Game_Taiko_Y[1];
+
+                TJAPlayer3.Tx.Taiko_Ka_Left.t2D描画( TJAPlayer3.app.Device, p2LeftX, p2Y, leftDrawingArea );
+                TJAPlayer3.Tx.Taiko_Ka_Right.t2D描画( TJAPlayer3.app.Device, p2RightX, p2Y, rightDrawingArea );
+                TJAPlayer3.Tx.Taiko_Don_Left.t2D描画( TJAPlayer3.app.Device, p2LeftX, p2Y, leftDrawingArea );
+                TJAPlayer3.Tx.Taiko_Don_Right.t2D描画( TJAPlayer3.app.Device, p2RightX, p2Y, rightDrawingArea );
             }
 
             int[] nLVUPY = new int[] { 127, 127, 0, 0 };

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
@@ -235,9 +235,9 @@ namespace TJAPlayer3
 
                 if (this.ctキャラクターアクション_魂MAX.b進行中db)
                 {
-                    if (TJAPlayer3.Tx.Chara_Become_Maxed[0] != null && TJAPlayer3.Skin.Game_Chara_Ptn_SoulIn != 0)
+                    if (TJAPlayer3.Tx.Chara_Become_Maxed?[0] != null)
                     {
-                        TJAPlayer3.Tx.Chara_Become_Maxed[(int)this.ctキャラクターアクション_魂MAX.db現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
+                        TJAPlayer3.Tx.Chara_Become_Maxed[(int)this.ctキャラクターアクション_魂MAX.db現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
                     }
                     if (this.ctキャラクターアクション_魂MAX.b終了値に達したdb)
                     {

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
@@ -144,7 +144,7 @@ namespace TJAPlayer3
 
                 if (this.ctキャラクターアクション_10コンボ.b進行中db)
                 {
-                    if (TJAPlayer3.Tx.Chara_10Combo?[0] != null)
+                    if (TJAPlayer3.Tx.Chara_10Combo.Length > (int)this.ctキャラクターアクション_10コンボ.db現在の値)
                     {
                         TJAPlayer3.Tx.Chara_10Combo[(int)this.ctキャラクターアクション_10コンボ.db現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
                     }
@@ -159,7 +159,7 @@ namespace TJAPlayer3
 
                 if (this.ctキャラクターアクション_10コンボMAX.b進行中db)
                 {
-                    if (TJAPlayer3.Tx.Chara_10Combo_Maxed?[0] != null)
+                    if (TJAPlayer3.Tx.Chara_10Combo_Maxed.Length > (int)this.ctキャラクターアクション_10コンボMAX.db現在の値)
                     {
                         TJAPlayer3.Tx.Chara_10Combo_Maxed[(int)this.ctキャラクターアクション_10コンボMAX.db現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
                     }
@@ -174,7 +174,7 @@ namespace TJAPlayer3
 
                 if (this.ctキャラクターアクション_ゴーゴースタート.b進行中db)
                 {
-                    if (TJAPlayer3.Tx.Chara_GoGoStart?[0] != null)
+                    if (TJAPlayer3.Tx.Chara_GoGoStart.Length > (int)this.ctキャラクターアクション_ゴーゴースタート.db現在の値)
                     {
                         TJAPlayer3.Tx.Chara_GoGoStart[(int)this.ctキャラクターアクション_ゴーゴースタート.db現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
                     }
@@ -189,7 +189,7 @@ namespace TJAPlayer3
 
                 if (this.ctキャラクターアクション_ゴーゴースタートMAX.b進行中db)
                 {
-                    if (TJAPlayer3.Tx.Chara_GoGoStart_Maxed?[0] != null)
+                    if (TJAPlayer3.Tx.Chara_GoGoStart_Maxed.Length > (int)this.ctキャラクターアクション_ゴーゴースタートMAX.db現在の値)
                     {
                         TJAPlayer3.Tx.Chara_GoGoStart_Maxed[(int)this.ctキャラクターアクション_ゴーゴースタートMAX.db現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
                     }
@@ -204,7 +204,7 @@ namespace TJAPlayer3
 
                 if (this.ctキャラクターアクション_ノルマ.b進行中db)
                 {
-                    if (TJAPlayer3.Tx.Chara_Become_Cleared?[0] != null)
+                    if (TJAPlayer3.Tx.Chara_Become_Cleared.Length > (int)this.ctキャラクターアクション_ノルマ.db現在の値)
                     {
                         TJAPlayer3.Tx.Chara_Become_Cleared[(int)this.ctキャラクターアクション_ノルマ.db現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
                     }
@@ -218,7 +218,7 @@ namespace TJAPlayer3
 
                 if (this.ctキャラクターアクション_魂MAX.b進行中db)
                 {
-                    if (TJAPlayer3.Tx.Chara_Become_Maxed?[0] != null)
+                    if (TJAPlayer3.Tx.Chara_Become_Maxed.Length > (int)this.ctキャラクターアクション_魂MAX.db現在の値)
                     {
                         TJAPlayer3.Tx.Chara_Become_Maxed[(int)this.ctキャラクターアクション_魂MAX.db現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
                     }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
@@ -12,11 +12,6 @@ namespace TJAPlayer3
     //
     internal class CAct演奏Drumsキャラクター : CActivity
     {
-        public CAct演奏Drumsキャラクター()
-        {
-
-        }
-
         public override void On活性化()
         {
             ctChara_Normal = new CCounter();
@@ -36,7 +31,6 @@ namespace TJAPlayer3
             CharaAction_Balloon_Delay = new CCounter();
 
             this.b風船連打中 = false;
-            this.b演奏中 = false;
 
 
             CharaAction_Balloon_FadeOut = new Animations.FadeOut(TJAPlayer3.Skin.Game_Chara_Balloon_FadeOut);
@@ -91,11 +85,6 @@ namespace TJAPlayer3
             base.OnManagedリソースの作成();
         }
 
-        public override void OnManagedリソースの解放()
-        {
-            base.OnManagedリソースの解放();
-        }
-
         public override int On進行描画()
         {
             if (ctChara_Normal != null || TJAPlayer3.Skin.Game_Chara_Ptn_Normal != 0) ctChara_Normal.t進行LoopDb();
@@ -123,15 +112,11 @@ namespace TJAPlayer3
                 {
                     if( TJAPlayer3.stage演奏ドラム画面.actGauge.db現在のゲージ値[ 0 ] >= 100.0 && TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0 && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.Hard && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.ExHard)
                     {
-                        if(TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
-                            TJAPlayer3.Tx.Chara_Normal_Maxed?[ this.arクリアモーション番号[(int)this.ctChara_Clear.db現在の値] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
+                        TJAPlayer3.Tx.Chara_Normal_Maxed?[ this.arクリアモーション番号[(int)this.ctChara_Clear.db現在の値] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
                     }
                     else if( TJAPlayer3.stage演奏ドラム画面.actGauge.db現在のゲージ値[ 0 ] >= 80.0 && TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0 && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.Hard && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.ExHard)
                     {
-                        if(TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0)
-                        {
-                            TJAPlayer3.Tx.Chara_Normal_Cleared?[ this.arクリアモーション番号[ (int)this.ctChara_Clear.db現在の値 ] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
-                        }
+                        TJAPlayer3.Tx.Chara_Normal_Cleared?[ this.arクリアモーション番号[ (int)this.ctChara_Clear.db現在の値 ] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
                     }
                     else
                     {
@@ -141,17 +126,15 @@ namespace TJAPlayer3
                         }
                     }
                 }
-                else
+                else if(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
                 {
-                    if( TJAPlayer3.stage演奏ドラム画面.actGauge.db現在のゲージ値[ 0 ] >= 100.0 && TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0 && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.Hard && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.ExHard)
+                    if( TJAPlayer3.stage演奏ドラム画面.actGauge.db現在のゲージ値[ 0 ] >= 100.0 && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.Hard && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.ExHard)
                     {
-                        if(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
-                            TJAPlayer3.Tx.Chara_GoGoTime_Maxed?[this.arゴーゴーモーション番号[(int)this.ctChara_GoGo.db現在の値] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
+                        TJAPlayer3.Tx.Chara_GoGoTime_Maxed?[this.arゴーゴーモーション番号[(int)this.ctChara_GoGo.db現在の値] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
                     }
                     else
                     {
-                        if(TJAPlayer3.Skin.Game_Chara_Ptn_GoGo != 0)
-                            TJAPlayer3.Tx.Chara_GoGoTime?[ this.arゴーゴーモーション番号[ (int)this.ctChara_GoGo.db現在の値 ] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
+                        TJAPlayer3.Tx.Chara_GoGoTime?[ this.arゴーゴーモーション番号[ (int)this.ctChara_GoGo.db現在の値 ] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
                     }
                 }
             }
@@ -262,11 +245,6 @@ namespace TJAPlayer3
             if (TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Miss != 0) CharaAction_Balloon_Miss?.t進行();
             CharaAction_Balloon_FadeOut.Tick();
 
-            //CharaAction_Balloon_Delay?.t進行();
-            //CDTXMania.act文字コンソール.tPrint(0, 0, C文字コンソール.Eフォント種別.白, CharaAction_Balloon_Broke?.b進行中.ToString());
-            //CDTXMania.act文字コンソール.tPrint(0, 20, C文字コンソール.Eフォント種別.白, CharaAction_Balloon_Miss?.b進行中.ToString());
-            //CDTXMania.act文字コンソール.tPrint(0, 40, C文字コンソール.Eフォント種別.白, CharaAction_Balloon_Breaking?.b進行中.ToString());
-
             if (bマイどんアクション中)
             {
                 var nowOpacity = CharaAction_Balloon_FadeOut.Counter.b進行中 ? (int)CharaAction_Balloon_FadeOut.GetAnimation() : 255;
@@ -313,14 +291,6 @@ namespace TJAPlayer3
                     TJAPlayer3.Tx.Chara_Balloon_Breaking?[CharaAction_Balloon_Breaking.n現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_Balloon_X[0], TJAPlayer3.Skin.Game_Chara_Balloon_Y[0]);
                     TJAPlayer3.stage演奏ドラム画面.PuchiChara.On進行描画(TJAPlayer3.Skin.Game_PuchiChara_BalloonX[0], TJAPlayer3.Skin.Game_PuchiChara_BalloonY[0], false, 255, true);
                 }
-
-                //if (CDTXMania.stage演奏ドラム画面.actChara.CharaAction_Balloon_Breaking?.b終了値に達した == true)
-                //{
-                //    CDTXMania.stage演奏ドラム画面.actChara.bマイどんアクション中 = false;
-                //    CDTXMania.stage演奏ドラム画面.actChara.CharaAction_Balloon_Breaking.t停止();
-                //    CDTXMania.stage演奏ドラム画面.actChara.CharaAction_Balloon_Breaking.n現在の値 = 0;
-                //}
-
             }
         }
 
@@ -341,11 +311,9 @@ namespace TJAPlayer3
             CharaAction_Balloon_Breaking?.t停止();
             CharaAction_Balloon_Broke?.t停止();
             CharaAction_Balloon_Miss?.t停止();
-            //CharaAction_Balloon_Delay?.t停止();
             CharaAction_Balloon_Breaking.n現在の値 = 0;
             CharaAction_Balloon_Broke.n現在の値 = 0;
             CharaAction_Balloon_Miss.n現在の値 = 0;
-            //CharaAction_Balloon_Delay.n現在の値 = 0;
         }
 
         public int[] arモーション番号;
@@ -373,6 +341,5 @@ namespace TJAPlayer3
         public bool bマイどんアクション中;
 
         public bool b風船連打中;
-        public bool b演奏中;
     }
 }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
@@ -276,7 +276,7 @@ namespace TJAPlayer3
                     {
                         CharaAction_Balloon_FadeOut.Start();
                     }
-                    if(TJAPlayer3.Tx.Chara_Balloon_Broke[CharaAction_Balloon_Broke.n現在の値] != null)
+                    if(TJAPlayer3.Tx.Chara_Balloon_Broke?[CharaAction_Balloon_Broke.n現在の値] != null)
                     {
                         TJAPlayer3.Tx.Chara_Balloon_Broke[CharaAction_Balloon_Broke.n現在の値].Opacity = nowOpacity;
                         TJAPlayer3.Tx.Chara_Balloon_Broke[CharaAction_Balloon_Broke.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_Balloon_X[0], TJAPlayer3.Skin.Game_Chara_Balloon_Y[0]);

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
@@ -310,7 +310,7 @@ namespace TJAPlayer3
                 }
                 else if (CharaAction_Balloon_Breaking?.b進行中 == true && TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking != 0)
                 {
-                    TJAPlayer3.Tx.Chara_Balloon_Breaking[CharaAction_Balloon_Breaking.n現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_Balloon_X[0], TJAPlayer3.Skin.Game_Chara_Balloon_Y[0]);
+                    TJAPlayer3.Tx.Chara_Balloon_Breaking?[CharaAction_Balloon_Breaking.n現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_Balloon_X[0], TJAPlayer3.Skin.Game_Chara_Balloon_Y[0]);
                     TJAPlayer3.stage演奏ドラム画面.PuchiChara.On進行描画(TJAPlayer3.Skin.Game_PuchiChara_BalloonX[0], TJAPlayer3.Skin.Game_PuchiChara_BalloonY[0], false, 255, true);
                 }
 

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
@@ -221,9 +221,9 @@ namespace TJAPlayer3
 
                 if (this.ctキャラクターアクション_ノルマ.b進行中db)
                 {
-                    if (TJAPlayer3.Tx.Chara_Become_Cleared[0] != null && TJAPlayer3.Skin.Game_Chara_Ptn_ClearIn != 0)
+                    if (TJAPlayer3.Tx.Chara_Become_Cleared?[0] != null)
                     {
-                        TJAPlayer3.Tx.Chara_Become_Cleared[(int)this.ctキャラクターアクション_ノルマ.db現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
+                        TJAPlayer3.Tx.Chara_Become_Cleared[(int)this.ctキャラクターアクション_ノルマ.db現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
                     }
                     if (this.ctキャラクターアクション_ノルマ.b終了値に達したdb)
                     {

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
@@ -191,9 +191,9 @@ namespace TJAPlayer3
 
                 if (this.ctキャラクターアクション_ゴーゴースタート.b進行中db)
                 {
-                    if (TJAPlayer3.Tx.Chara_GoGoStart[0] != null && TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart != 0)
+                    if (TJAPlayer3.Tx.Chara_GoGoStart?[0] != null)
                     {
-                        TJAPlayer3.Tx.Chara_GoGoStart[(int)this.ctキャラクターアクション_ゴーゴースタート.db現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
+                        TJAPlayer3.Tx.Chara_GoGoStart[(int)this.ctキャラクターアクション_ゴーゴースタート.db現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
                     }
                     if (this.ctキャラクターアクション_ゴーゴースタート.b終了値に達したdb)
                     {

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
@@ -295,7 +295,7 @@ namespace TJAPlayer3
                     {
                         CharaAction_Balloon_FadeOut.Start();
                     }
-                    if(TJAPlayer3.Tx.Chara_Balloon_Miss[CharaAction_Balloon_Miss.n現在の値] != null)
+                    if(TJAPlayer3.Tx.Chara_Balloon_Miss?[CharaAction_Balloon_Miss.n現在の値] != null)
                     {
                         TJAPlayer3.Tx.Chara_Balloon_Miss[CharaAction_Balloon_Miss.n現在の値].Opacity = nowOpacity;
                         TJAPlayer3.Tx.Chara_Balloon_Miss[CharaAction_Balloon_Miss.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_Balloon_X[0], TJAPlayer3.Skin.Game_Chara_Balloon_Y[0]);

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
@@ -112,17 +112,17 @@ namespace TJAPlayer3
                 {
                     if( TJAPlayer3.stage演奏ドラム画面.actGauge.db現在のゲージ値[ 0 ] >= 100.0 && TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0 && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.Hard && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.ExHard)
                     {
-                        TJAPlayer3.Tx.Chara_Normal_Maxed?[ this.arクリアモーション番号[(int)this.ctChara_Clear.db現在の値] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
+                        TJAPlayer3.Tx.Chara_Normal_Maxed[ this.arクリアモーション番号[(int)this.ctChara_Clear.db現在の値] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
                     }
                     else if( TJAPlayer3.stage演奏ドラム画面.actGauge.db現在のゲージ値[ 0 ] >= 80.0 && TJAPlayer3.Skin.Game_Chara_Ptn_Clear != 0 && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.Hard && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.ExHard)
                     {
-                        TJAPlayer3.Tx.Chara_Normal_Cleared?[ this.arクリアモーション番号[ (int)this.ctChara_Clear.db現在の値 ] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
+                        TJAPlayer3.Tx.Chara_Normal_Cleared[ this.arクリアモーション番号[ (int)this.ctChara_Clear.db現在の値 ] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
                     }
                     else
                     {
                         if (TJAPlayer3.Skin.Game_Chara_Ptn_Normal != 0)
                         {
-                            TJAPlayer3.Tx.Chara_Normal?[ this.arモーション番号[ (int)this.ctChara_Normal.db現在の値 ] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
+                            TJAPlayer3.Tx.Chara_Normal[ this.arモーション番号[ (int)this.ctChara_Normal.db現在の値 ] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
                         }
                     }
                 }
@@ -130,11 +130,11 @@ namespace TJAPlayer3
                 {
                     if( TJAPlayer3.stage演奏ドラム画面.actGauge.db現在のゲージ値[ 0 ] >= 100.0 && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.Hard && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.ExHard)
                     {
-                        TJAPlayer3.Tx.Chara_GoGoTime_Maxed?[this.arゴーゴーモーション番号[(int)this.ctChara_GoGo.db現在の値] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
+                        TJAPlayer3.Tx.Chara_GoGoTime_Maxed[this.arゴーゴーモーション番号[(int)this.ctChara_GoGo.db現在の値] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
                     }
                     else
                     {
-                        TJAPlayer3.Tx.Chara_GoGoTime?[ this.arゴーゴーモーション番号[ (int)this.ctChara_GoGo.db現在の値 ] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
+                        TJAPlayer3.Tx.Chara_GoGoTime[ this.arゴーゴーモーション番号[ (int)this.ctChara_GoGo.db現在の値 ] ]?.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0] );
                     }
                 }
             }
@@ -254,7 +254,7 @@ namespace TJAPlayer3
                     {
                         CharaAction_Balloon_FadeOut.Start();
                     }
-                    if(TJAPlayer3.Tx.Chara_Balloon_Broke?[CharaAction_Balloon_Broke.n現在の値] != null)
+                    if(TJAPlayer3.Tx.Chara_Balloon_Broke[CharaAction_Balloon_Broke.n現在の値] != null)
                     {
                         TJAPlayer3.Tx.Chara_Balloon_Broke[CharaAction_Balloon_Broke.n現在の値].Opacity = nowOpacity;
                         TJAPlayer3.Tx.Chara_Balloon_Broke[CharaAction_Balloon_Broke.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_Balloon_X[0], TJAPlayer3.Skin.Game_Chara_Balloon_Y[0]);
@@ -273,7 +273,7 @@ namespace TJAPlayer3
                     {
                         CharaAction_Balloon_FadeOut.Start();
                     }
-                    if(TJAPlayer3.Tx.Chara_Balloon_Miss?[CharaAction_Balloon_Miss.n現在の値] != null)
+                    if(TJAPlayer3.Tx.Chara_Balloon_Miss[CharaAction_Balloon_Miss.n現在の値] != null)
                     {
                         TJAPlayer3.Tx.Chara_Balloon_Miss[CharaAction_Balloon_Miss.n現在の値].Opacity = nowOpacity;
                         TJAPlayer3.Tx.Chara_Balloon_Miss[CharaAction_Balloon_Miss.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_Balloon_X[0], TJAPlayer3.Skin.Game_Chara_Balloon_Y[0]);
@@ -288,7 +288,7 @@ namespace TJAPlayer3
                 }
                 else if (CharaAction_Balloon_Breaking?.b進行中 == true && TJAPlayer3.Skin.Game_Chara_Ptn_Balloon_Breaking != 0)
                 {
-                    TJAPlayer3.Tx.Chara_Balloon_Breaking?[CharaAction_Balloon_Breaking.n現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_Balloon_X[0], TJAPlayer3.Skin.Game_Chara_Balloon_Y[0]);
+                    TJAPlayer3.Tx.Chara_Balloon_Breaking[CharaAction_Balloon_Breaking.n現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_Balloon_X[0], TJAPlayer3.Skin.Game_Chara_Balloon_Y[0]);
                     TJAPlayer3.stage演奏ドラム画面.PuchiChara.On進行描画(TJAPlayer3.Skin.Game_PuchiChara_BalloonX[0], TJAPlayer3.Skin.Game_PuchiChara_BalloonY[0], false, 255, true);
                 }
             }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsキャラクター.cs
@@ -206,9 +206,9 @@ namespace TJAPlayer3
 
                 if (this.ctキャラクターアクション_ゴーゴースタートMAX.b進行中db)
                 {
-                    if (TJAPlayer3.Tx.Chara_GoGoStart_Maxed[0] != null && TJAPlayer3.Skin.Game_Chara_Ptn_GoGoStart_Max != 0)
+                    if (TJAPlayer3.Tx.Chara_GoGoStart_Maxed?[0] != null)
                     {
-                        TJAPlayer3.Tx.Chara_GoGoStart_Maxed[(int)this.ctキャラクターアクション_ゴーゴースタートMAX.db現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
+                        TJAPlayer3.Tx.Chara_GoGoStart_Maxed[(int)this.ctキャラクターアクション_ゴーゴースタートMAX.db現在の値]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Chara_X[0], TJAPlayer3.Skin.Game_Chara_Y[0]);
                     }
                     if (this.ctキャラクターアクション_ゴーゴースタートMAX.b終了値に達したdb)
                     {

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲージ.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲージ.cs
@@ -398,22 +398,21 @@ namespace TJAPlayer3
                                 if (TJAPlayer3.Tx.Gauge[1] != null)
                                 {
                                     TJAPlayer3.Tx.Gauge[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1], new Rectangle(0, 0, nRectX2P, 44));
-                                    if (TJAPlayer3.Tx.Gauge[1] != null)
+
+                                    if (TJAPlayer3.ConfigIni.eGaugeMode == EGaugeMode.Normal && this.db現在のゲージ値[1] >= 100.0)
                                     {
-                                        if (TJAPlayer3.ConfigIni.eGaugeMode == EGaugeMode.Normal && this.db現在のゲージ値[1] >= 100.0)
+                                        this.ct虹アニメ.t進行Loop();
+                                        this.ct虹透明度.t進行Loop();
+                                        if (TJAPlayer3.Tx.Gauge_Rainbow[this.ct虹アニメ.n現在の値] != null)
                                         {
-                                            this.ct虹アニメ.t進行Loop();
-                                            this.ct虹透明度.t進行Loop();
-                                            if (TJAPlayer3.Tx.Gauge_Rainbow[this.ct虹アニメ.n現在の値] != null)
-                                            {
-                                                TJAPlayer3.Tx.Gauge_Rainbow[ct虹アニメ.n現在の値].Opacity = 255;
-                                                TJAPlayer3.Tx.Gauge_Rainbow[ct虹アニメ.n現在の値].t2D上下反転描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
-                                                TJAPlayer3.Tx.Gauge_Rainbow[虹ベース].Opacity = (ct虹透明度.n現在の値 * 255 / ct虹透明度.n終了値) / 1;
-                                                TJAPlayer3.Tx.Gauge_Rainbow[虹ベース].t2D上下反転描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
-                                            }
+                                            TJAPlayer3.Tx.Gauge_Rainbow[ct虹アニメ.n現在の値].Opacity = 255;
+                                            TJAPlayer3.Tx.Gauge_Rainbow[ct虹アニメ.n現在の値].t2D上下反転描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
+                                            TJAPlayer3.Tx.Gauge_Rainbow[虹ベース].Opacity = (ct虹透明度.n現在の値 * 255 / ct虹透明度.n終了値) / 1;
+                                            TJAPlayer3.Tx.Gauge_Rainbow[虹ベース].t2D上下反転描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
                                         }
-                                        TJAPlayer3.Tx.Gauge_Line[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
                                     }
+                                    TJAPlayer3.Tx.Gauge_Line[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
+
                                     #region[ 「クリア」文字 ]
                                     //1038 - 492 = 546
                                     //554 - 532 = 12

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲージ.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲージ.cs
@@ -351,12 +351,10 @@ namespace TJAPlayer3
                     default:
                         #region その他
                             #region ゲージベース
-                            if (TJAPlayer3.Tx.Gauge_Base[0] != null)
-                                TJAPlayer3.Tx.Gauge_Base[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[0], TJAPlayer3.Skin.Game_Gauge_Y[0], new Rectangle(0, 0, 700, 44));
+                            TJAPlayer3.Tx.Gauge_Base[0]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[0], TJAPlayer3.Skin.Game_Gauge_Y[0], new Rectangle(0, 0, 700, 44));
                             if (TJAPlayer3.stage演奏ドラム画面.bDoublePlay)
                             {
-                                if (TJAPlayer3.Tx.Gauge_Base[1] != null)
-                                    TJAPlayer3.Tx.Gauge_Base[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1], new Rectangle(0, 0, 700, 44));
+                                TJAPlayer3.Tx.Gauge_Base[1]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1], new Rectangle(0, 0, 700, 44));
                             }
                             #endregion
                             #region ゲージ1P

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲージ.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲージ.cs
@@ -409,7 +409,7 @@ namespace TJAPlayer3
                                             TJAPlayer3.Tx.Gauge_Rainbow[虹ベース].t2D上下反転描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
                                         }
                                     }
-                                    TJAPlayer3.Tx.Gauge_Line[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
+                                    TJAPlayer3.Tx.Gauge_Line[1]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
 
                                     #region[ 「クリア」文字 ]
                                     //1038 - 492 = 546

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
@@ -852,20 +852,22 @@ namespace TJAPlayer3
 				{
                     if (this.st小文字位置[i].ch == ch)
                     {
-                        Rectangle rectangle = new Rectangle(TJAPlayer3.Skin.Game_Taiko_Combo_Size[0] * i, 0, TJAPlayer3.Skin.Game_Taiko_Combo_Size[0], TJAPlayer3.Skin.Game_Taiko_Combo_Size[1]);
-						if(TJAPlayer3.Tx.Taiko_Combo[0]  != null )
-						{
+                        var taikoComboTexture = TJAPlayer3.Tx.Taiko_Combo[0];
+                        if(taikoComboTexture != null)
+                        {
+                            Rectangle rectangle = new Rectangle(TJAPlayer3.Skin.Game_Taiko_Combo_Size[0] * i, 0, TJAPlayer3.Skin.Game_Taiko_Combo_Size[0], TJAPlayer3.Skin.Game_Taiko_Combo_Size[1]);
+
                             if( this.st叩ききりまショー.bタイマー使用中 )
-                                TJAPlayer3.Tx.Taiko_Combo[0].Opacity = 255;
+                                taikoComboTexture.Opacity = 255;
                             else if( this.st叩ききりまショー.b最初のチップが叩かれた && !this.st叩ききりまショー.bタイマー使用中 )
-                                TJAPlayer3.Tx.Taiko_Combo[0].Opacity = 128;
+                                taikoComboTexture.Opacity = 128;
                             if (this.st叩ききりまショー.b加算アニメ中)
-                                TJAPlayer3.Tx.Taiko_Combo[0].Opacity = 0;
-                            TJAPlayer3.Tx.Taiko_Combo[0].vc拡大縮小倍率.Y = 1f;
-                            TJAPlayer3.Tx.Taiko_Combo[0].vc拡大縮小倍率.X = 1f;
-                            TJAPlayer3.Tx.Taiko_Combo[0].t2D中心基準描画( TJAPlayer3.app.Device, x, y, rectangle );
-						}
-						break;
+                                taikoComboTexture.Opacity = 0;
+                            taikoComboTexture.vc拡大縮小倍率.Y = 1f;
+                            taikoComboTexture.vc拡大縮小倍率.X = 1f;
+                            taikoComboTexture.t2D中心基準描画( TJAPlayer3.app.Device, x, y, rectangle );
+                        }
+                        break;
 					}
 				}
 				x += TJAPlayer3.Skin.Game_Taiko_Combo_Padding[0] * 2;

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
@@ -465,8 +465,7 @@ namespace TJAPlayer3
                 //CDTXMania.act文字コンソール.tPrint( 100, 16 * 7, C文字コンソール.Eフォント種別.白, this.st叩ききりまショー.ct加算審査中.n現在の値.ToString() );
 
                 #region[ 残り時間描画 ]
-                if (TJAPlayer3.Tx.GameMode_Timer_Frame != null)
-                    TJAPlayer3.Tx.GameMode_Timer_Frame.t2D描画( TJAPlayer3.app.Device, 230, 84 );
+                TJAPlayer3.Tx.GameMode_Timer_Frame?.t2D描画( TJAPlayer3.app.Device, 230, 84 );
                 this.st叩ききりまショー.ct針アニメ.t進行Loop();
 
                 int nCenterX = 230;
@@ -488,8 +487,11 @@ namespace TJAPlayer3
 
                 TJAPlayer3.Tx.GameMode_Timer_Tick.t3D描画( TJAPlayer3.app.Device, mat );
 
-                string str表示する残り時間 = ( this.st叩ききりまショー.ct残り時間.n現在の値 < 1000 ) ? "25" : ( ( 26000 - this.st叩ききりまショー.ct残り時間.n現在の値 ) / 1000 ).ToString();
-                this.t小文字表示( 230 + (str表示する残り時間.Length * TJAPlayer3.Skin.Game_Taiko_Combo_Size[0] / 4 ), 84 + TJAPlayer3.Tx.GameMode_Timer_Frame.szテクスチャサイズ.Height / 2 , string.Format("{0,2:#0}", str表示する残り時間 ));
+                if (TJAPlayer3.Tx.GameMode_Timer_Frame != null)
+                {
+                    string str表示する残り時間 = ( this.st叩ききりまショー.ct残り時間.n現在の値 < 1000 ) ? "25" : ( ( 26000 - this.st叩ききりまショー.ct残り時間.n現在の値 ) / 1000 ).ToString();
+                    this.t小文字表示( 230 + (str表示する残り時間.Length * TJAPlayer3.Skin.Game_Taiko_Combo_Size[0] / 4 ), 84 + TJAPlayer3.Tx.GameMode_Timer_Frame.szテクスチャサイズ.Height / 2 , string.Format("{0,2:#0}", str表示する残り時間 ));
+                }
 
                 if( !this.st叩ききりまショー.ct加算審査中.b停止中 )
                 {

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲームモード.cs
@@ -485,7 +485,7 @@ namespace TJAPlayer3
                     mat *= SlimDX.Matrix.Translation( 280 - 640, -( 134 - 360 ), 0 );
                 }
 
-                TJAPlayer3.Tx.GameMode_Timer_Tick.t3D描画( TJAPlayer3.app.Device, mat );
+                TJAPlayer3.Tx.GameMode_Timer_Tick?.t3D描画( TJAPlayer3.app.Device, mat );
 
                 if (TJAPlayer3.Tx.GameMode_Timer_Frame != null)
                 {

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsコンボ吹き出し.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsコンボ吹き出し.cs
@@ -86,7 +86,7 @@ namespace TJAPlayer3
                         }
                     }
 
-                    if( TJAPlayer3.Tx.Balloon_Combo[ i ] != null )
+                    if( TJAPlayer3.Tx.Balloon_Combo[ i ] != null && TJAPlayer3.Tx.Balloon_Number_Combo != null)
                     {
                         //半透明4f
                         if( this.ct進行[ i ].n現在の値 == 1 || this.ct進行[ i ].n現在の値 == 103 )
@@ -173,10 +173,7 @@ namespace TJAPlayer3
 					if( this.st小文字位置[ i ].ch == ch )
 					{
 						Rectangle rectangle = new Rectangle( this.st小文字位置[ i ].pt.X, this.st小文字位置[ i ].pt.Y, 44, 54 );
-						if(TJAPlayer3.Tx.Balloon_Number_Combo != null )
-						{
-                            TJAPlayer3.Tx.Balloon_Number_Combo.t2D描画( TJAPlayer3.app.Device, x, y, rectangle );
-						}
+                        TJAPlayer3.Tx.Balloon_Number_Combo?.t2D描画( TJAPlayer3.app.Device, x, y, rectangle );
 						break;
 					}
 				}

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
@@ -299,7 +299,6 @@ namespace TJAPlayer3
                                 TJAPlayer3.Tx.Lane_Text[2].Opacity = 255;
 
                                 TJAPlayer3.Tx.Lane_Text[0].Opacity = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 60));
-                                //CDTXMania.Tx.Lane_Text[1].n透明度 = this.ct分岐アニメ進行.n現在の値 > 100 ? 255 : ( ( ( this.ct分岐アニメ進行.n現在の値 * 0xff ) / 60 ) );
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
@@ -328,13 +327,6 @@ namespace TJAPlayer3
                                     TJAPlayer3.Tx.Lane_Text[0].Opacity = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
                                     TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 20) + this.stBranch[i].nY);
                                 }
-                                //if( this.stBranch[ i ].ct分岐アニメ進行.n現在の値 >= 5 && this.stBranch[ i ].ct分岐アニメ進行.n現在の値 < 60 )
-                                //{
-                                //    this.stBranch[ i ].nY = this.stBranch[ i ].ct分岐アニメ進行.n現在の値 / 2;
-                                //    this.tx普通譜面[ 1 ].t2D描画(CDTXMania.app.Device, 333, CDTXMania.Skin.Game_Lane_Field_Y[ i ] + this.stBranch[ i ].nY);
-                                //    this.tx普通譜面[ 1 ].n透明度 = this.stBranch[ i ].ct分岐アニメ進行.n現在の値 > 100 ? 0 : ( 255 - ( ( this.stBranch[ i ].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
-                                //    this.tx玄人譜面[ 1 ].t2D描画(CDTXMania.app.Device, 333, ( CDTXMania.Skin.Game_Lane_Field_Y[ i ] - 10 ) + this.stBranch[ i ].nY);
-                                //}
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 60 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 150)
                                 {
                                     this.stBranch[i].nY = 21;
@@ -621,68 +613,6 @@ namespace TJAPlayer3
                 if (TJAPlayer3.Tx.Lane_Background_GoGo != null) TJAPlayer3.Tx.Lane_Background_GoGo.Opacity = 255;
             }
 
-            //CDTXMania.act文字コンソール.tPrint(0, 0, C文字コンソール.Eフォント種別.白, this.nBranchレイヤー透明度.ToString());
-            //CDTXMania.act文字コンソール.tPrint(0, 16, C文字コンソール.Eフォント種別.白, this.ct分岐アニメ進行.n現在の値.ToString());
-            //CDTXMania.act文字コンソール.tPrint(0, 32, C文字コンソール.Eフォント種別.白, this.ct分岐アニメ進行.n終了値.ToString());
-
-            //CDTXMania.act文字コンソール.tPrint(0, 32, C文字コンソール.Eフォント種別.白, this.ctゴーゴースプラッシュ.n現在の値.ToString());
-
-            /*#region[ ゴーゴースプラッシュ ]
-            for (int i = 0; i < CDTXMania.ConfigIni.nPlayerCount; i++)
-            {
-                if (CDTXMania.stage演奏ドラム画面.bIsGOGOTIME[i])
-                {
-
-                    if (this.txゴーゴースプラッシュ != null)
-                    {
-                        this.txゴーゴースプラッシュ[(int)this.ctゴーゴースプラッシュ.db現在の値].t2D描画(CDTXMania.app.Device, 0, 260);
-                        this.ctゴーゴースプラッシュ.n現在の値++;
-                        if(this.ctゴーゴースプラッシュ.b終了値に達した)
-                        {
-                            this.ctゴーゴースプラッシュ.t停止();
-                            this.ctゴーゴースプラッシュ.n現在の値 = 0;
-                        }
-                    }
-                    
-         
-                    this.ctゴーゴースプラッシュ.t進行Loop();
-                if (this.txゴーゴースプラッシュ != null)
-                {
-                    if (this.ctゴーゴースプラッシュ.b終了値に達してない)
-                    {
-                        this.txゴーゴースプラッシュ[(int)this.ctゴーゴースプラッシュ.db現在の値].t2D描画(CDTXMania.app.Device, 0, 260);
-                    }
-
-                }
-                }
-            }
-            #endregion */
-            /*
-            for (int i = 0; i < CDTXMania.ConfigIni.nPlayerCount; i++)
-            {
-                #region[ ゴーゴースプラッシュ ]
-                if (this.txゴーゴースプラッシュ != null && CDTXMania.stage演奏ドラム画面.bIsGOGOTIME[i])
-                {
-                    if (!this.ctゴーゴースプラッシュ.b停止中)
-                    {
-                        this.ctゴーゴースプラッシュ.t進行();
-                    }
-                    if (this.ctゴーゴースプラッシュ.n現在の値 < 28)
-                    {
-                        for (int v = 0; v < 6; v++)
-                        {
-                            this.txゴーゴースプラッシュ[this.ctゴーゴースプラッシュ.n現在の値].t2D描画(CDTXMania.app.Device, 0 + (v * 213), 260);
-                        }
-
-                    }
-                    else
-                    {
-                        this.txゴーゴースプラッシュ[this.ctゴーゴースプラッシュ.n現在の値].n透明度 = 100;
-                    }
-
-                }
-                #endregion
-            } */
             return base.On進行描画();
         }
 
@@ -720,9 +650,6 @@ namespace TJAPlayer3
                         mat *= Matrix.Scaling(f倍率, f倍率, 1.0f);
                         mat *= Matrix.Translation(TJAPlayer3.Skin.Game_Lane_Field_X[i] - SampleFramework.GameWindowSize.Width / 2.0f, -(TJAPlayer3.Skin.Game_Lane_Field_Y[i] + (130 / 2) - SampleFramework.GameWindowSize.Height / 2.0f), 0f);
 
-                        //this.txゴーゴー炎.b加算合成 = true;
-
-                        //this.ctゴーゴー.n現在の値 = 6;
                         if (this.ctゴーゴー.b終了値に達した)
                         {
                             TJAPlayer3.Tx.Effects_Fire.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[i] - 180, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + (130 / 2) - (TJAPlayer3.Tx.Effects_Fire.szテクスチャサイズ.Height / 2), new Rectangle(360 * (this.ctゴーゴー炎.n現在の値), 0, 360, 370));
@@ -744,9 +671,7 @@ namespace TJAPlayer3
                     {
                         this.st状態[i].ct進行.t停止();
                     }
-                    //if( this.txアタックエフェクトLower != null )
                     {
-                        //this.txアタックエフェクトLower.b加算合成 = true;
                         int n = this.st状態[i].nIsBig == 1 ? 520 : 0;
 
                         switch (st状態[i].judge)
@@ -754,7 +679,6 @@ namespace TJAPlayer3
                             case E判定.Perfect:
                             case E判定.Great:
                             case E判定.Auto:
-                                //this.txアタックエフェクトLower.t2D描画( CDTXMania.app.Device, 285, 127, new Rectangle( this.st状態[ i ].ct進行.n現在の値 * 260, n, 260, 260 ) );
                                 if (this.st状態[i].nIsBig == 1 && TJAPlayer3.Tx.Effects_Hit_Great_Big[this.st状態[i].ct進行.n現在の値] != null)
                                     TJAPlayer3.Tx.Effects_Hit_Great_Big[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Great_Big[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + (130 / 2) - TJAPlayer3.Tx.Effects_Hit_Great_Big[0].szテクスチャサイズ.Width / 2);
                                 else if (TJAPlayer3.Tx.Effects_Hit_Great[this.st状態[i].ct進行.n現在の値] != null)
@@ -762,7 +686,6 @@ namespace TJAPlayer3
                                 break;
 
                             case E判定.Good:
-                                //this.txアタックエフェクトLower.t2D描画( CDTXMania.app.Device, 285, 127, new Rectangle( this.st状態[ i ].ct進行.n現在の値 * 260, n + 260, 260, 260 ) );
                                 if (this.st状態[i].nIsBig == 1 && TJAPlayer3.Tx.Effects_Hit_Good_Big[this.st状態[i].ct進行.n現在の値] != null)
                                     TJAPlayer3.Tx.Effects_Hit_Good_Big[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Good_Big[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + (130 / 2) - TJAPlayer3.Tx.Effects_Hit_Good_Big[0].szテクスチャサイズ.Width / 2);
                                 else if (TJAPlayer3.Tx.Effects_Hit_Good[this.st状態[i].ct進行.n現在の値] != null)
@@ -784,7 +707,6 @@ namespace TJAPlayer3
         {
             //2017.08.15 kairera0467 排他なので番地をそのまま各レーンの状態として扱う
 
-            //for( int n = 0; n < 1; n++ )
             {
                 this.st状態[nPlayer].ct進行 = new CCounter(0, 14, 20, TJAPlayer3.Timer);
                 this.st状態[nPlayer].judge = judge;
@@ -836,24 +758,6 @@ namespace TJAPlayer3
             TJAPlayer3.stage演奏ドラム画面.actLane.t分岐レイヤー_コース変化(n現在, n次回, nPlayer);
         }
 
-        //public void t判定枠移動(double db移動時間, int n移動px, int n移動方向)
-        //{
-        //    this.n移動開始時刻 = (int)CSound管理.rc演奏用タイマ.n現在時刻ms;
-        //    this.n移動開始X = TJAPlayer3.Skin.Game_Lane_Field_X[0];
-        //    this.n総移動時間 = (int)(db移動時間 * 1000);
-        //    this.n移動方向 = n移動方向;
-        //    this.n移動距離px = n移動px;
-        //}
-
-        //public void t判定枠移動2(double db移動時間, int n移動px, int n移動方向)
-        //{
-        //    this.n移動開始時刻2 = (int)CSound管理.rc演奏用タイマ.n現在時刻ms;
-        //    this.n移動開始X2 = TJAPlayer3.Skin.Game_Lane_Field_X[1];
-        //    this.n総移動時間2 = (int)(db移動時間 * 1000);
-        //    this.n移動方向2 = n移動方向;
-        //    this.n移動距離px2 = n移動px;
-        //}
-
         public void t判定枠移動XY(double db移動時間, int n移動px, int n移動Ypx, int n移動方向)
         {
             this.n移動開始時刻 = (int)CSound管理.rc演奏用タイマ.n現在時刻ms;
@@ -876,30 +780,8 @@ namespace TJAPlayer3
             this.n移動距離Ypx2 = n移動Ypx;
         }
         #region[ private ]
-        //-----------------
-        //private CTexture txLane;
-        //private CTexture txLaneB;
-        //private CTexture tx枠線;
-        //private CTexture tx判定枠;
-        //private CTexture txゴーゴー;
-        //private CTexture txゴーゴー炎;
-        //private CTexture[] txArゴーゴー炎;
-        //private CTexture[] txArアタックエフェクトLower_A;
-        //private CTexture[] txArアタックエフェクトLower_B;
-        //private CTexture[] txArアタックエフェクトLower_C;
-        //private CTexture[] txArアタックエフェクトLower_D;
-
-        //private CTexture[] txLaneFlush = new CTexture[3];
-
-        //private CTexture[] tx普通譜面 = new CTexture[2];
-        //private CTexture[] tx玄人譜面 = new CTexture[2];
-        //private CTexture[] tx達人譜面 = new CTexture[2];
-
-        //private CTextureAf txアタックエフェクトLower;
 
         protected STSTATUS[] st状態 = new STSTATUS[4];
-
-        //private CTexture[] txゴーゴースプラッシュ;
 
         [StructLayout(LayoutKind.Sequential)]
         protected struct STSTATUS

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
@@ -689,7 +689,7 @@ namespace TJAPlayer3
         public void ゴーゴー炎()
         {
             //判定枠
-            if (TJAPlayer3.Tx.Notes != null)
+            if (TJAPlayer3.Tx.Judge_Frame != null)
             {
                 int nJudgeX = TJAPlayer3.Skin.Game_Lane_Field_X[0] - (130 / 2); //元の値は349なんだけど...
                 int nJudgeY = TJAPlayer3.Skin.Game_Lane_Field_Y[0]; //元の値は349なんだけど...

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums判定文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums判定文字列.cs
@@ -101,13 +101,13 @@ namespace TJAPlayer3
 				{
 					if( !base.st状態[ j ].ct進行.b停止中 )
 					{
-						int baseX = 370;
-                        //int baseY = 135;
-                        int baseY = TJAPlayer3.Skin.Game_Lane_Field_Y[base.st状態[j].nPlayer] - 53;
-						int x = TJAPlayer3.Skin.Game_Lane_Field_X[ 0 ] - TJAPlayer3.Tx.Judge.szテクスチャサイズ.Width / 2;
-						int y = ( baseY + base.st状態[ j ].n相対Y座標 );
 						if( TJAPlayer3.Tx.Judge != null )
 						{
+                            int baseX = 370;
+                            //int baseY = 135;
+                            int baseY = TJAPlayer3.Skin.Game_Lane_Field_Y[base.st状態[j].nPlayer] - 53;
+                            int x = TJAPlayer3.Skin.Game_Lane_Field_X[ 0 ] - TJAPlayer3.Tx.Judge.szテクスチャサイズ.Width / 2;
+                            int y = ( baseY + base.st状態[ j ].n相対Y座標 );
                             TJAPlayer3.Tx.Judge.t2D描画( TJAPlayer3.app.Device, x, y, base.st判定文字列[ (int) base.st状態[ j ].judge ].rc );
 						}
 					}

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums演奏終了演出.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums演奏終了演出.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Runtime.InteropServices;
-using System.Drawing;
+﻿using System.Drawing;
 using FDK;
 
 namespace TJAPlayer3
@@ -245,12 +241,17 @@ namespace TJAPlayer3
                                 }
                                 else if (this.ct進行メイン.n現在の値 <= 46)
                                 {
+                                    //2016.07.16 kairera0467 またも原始的...
+                                    float[] fRet = { 1.0f, 0.99f, 0.98f, 0.97f, 0.96f, 0.95f, 0.96f, 0.97f, 0.98f, 0.99f, 1.0f };
+
                                     if (TJAPlayer3.Tx.End_Clear_L[0] != null)
                                     {
-                                        //2016.07.16 kairera0467 またも原始的...
-                                        float[] fRet = new float[] { 1.0f, 0.99f, 0.98f, 0.97f, 0.96f, 0.95f, 0.96f, 0.97f, 0.98f, 0.99f, 1.0f };
                                         TJAPlayer3.Tx.End_Clear_L[0].t2D描画(TJAPlayer3.app.Device, 466, y[i] - 30);
                                         TJAPlayer3.Tx.End_Clear_L[0].vc拡大縮小倍率 = new SlimDX.Vector3(fRet[this.ct進行メイン.n現在の値 - 36], 1.0f, 1.0f);
+                                    }
+
+                                    if (TJAPlayer3.Tx.End_Clear_R[0] != null)
+                                    {
                                         TJAPlayer3.Tx.End_Clear_R[0].t2D描画(TJAPlayer3.app.Device, 1136 - 180 * fRet[this.ct進行メイン.n現在の値 - 36], y[i] - 30);
                                         TJAPlayer3.Tx.End_Clear_R[0].vc拡大縮小倍率 = new SlimDX.Vector3(fRet[this.ct進行メイン.n現在の値 - 36], 1.0f, 1.0f);
                                     }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums演奏終了演出.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums演奏終了演出.cs
@@ -210,7 +210,7 @@ namespace TJAPlayer3
                                         TJAPlayer3.Tx.End_Clear_Text.t2D描画(TJAPlayer3.app.Device, 890, y[i] + 2, new Rectangle(360, 0, 90, 90));
                                     }
                                 }
-                                if (this.ct進行メイン.n現在の値 >= 50 && this.ct進行メイン.n現在の値 < 90)
+                                if (this.ct進行メイン.n現在の値 >= 50 && this.ct進行メイン.n現在の値 < 90 && TJAPlayer3.Tx.End_Clear_Text_Effect != null)
                                 {
                                     if (this.ct進行メイン.n現在の値 < 70)
                                     {

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums背景.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums背景.cs
@@ -119,10 +119,7 @@ namespace TJAPlayer3
             if( !TJAPlayer3.stage演奏ドラム画面.bDoublePlay )
             {
                 {
-                    if( TJAPlayer3.Tx.Background_Down != null )
-                    {
-                        TJAPlayer3.Tx.Background_Down.t2D描画( TJAPlayer3.app.Device, 0, 360 );
-                    }
+                    TJAPlayer3.Tx.Background_Down?.t2D描画(TJAPlayer3.app.Device, 0, 360);
                 }
                 if(TJAPlayer3.stage演奏ドラム画面.bIsAlreadyCleared[0] && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.Hard && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.ExHard)
                 {

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums背景.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums背景.cs
@@ -83,33 +83,36 @@ namespace TJAPlayer3
             #region 1P-2P-上背景
             for (int i = 0; i < 2; i++)
             {
-                if (this.ct上背景スクロール用タイマー[i] != null)
+                var backgroundUpTexture = TJAPlayer3.Tx.Background_Up[i];
+                if (backgroundUpTexture != null && this.ct上背景スクロール用タイマー[i] != null)
                 {
-                    double TexSize = 1280 / TJAPlayer3.Tx.Background_Up[i].szテクスチャサイズ.Width;
+                    double TexSize = 1280 / backgroundUpTexture.szテクスチャサイズ.Width;
                     // 1280をテクスチャサイズで割ったものを切り上げて、プラス+1足す。
                     int ForLoop = (int)Math.Ceiling(TexSize) + 1;
                     //int nループ幅 = 328;
-                    TJAPlayer3.Tx.Background_Up[i].t2D描画(TJAPlayer3.app.Device, 0 - this.ct上背景スクロール用タイマー[i].n現在の値, TJAPlayer3.Skin.Background_Scroll_Y[i]);
+                    backgroundUpTexture.t2D描画(TJAPlayer3.app.Device, 0 - this.ct上背景スクロール用タイマー[i].n現在の値, TJAPlayer3.Skin.Background_Scroll_Y[i]);
                     for (int l = 1; l < ForLoop + 1; l++)
                     {
-                        TJAPlayer3.Tx.Background_Up[i].t2D描画(TJAPlayer3.app.Device, +(l * TJAPlayer3.Tx.Background_Up[i].szテクスチャサイズ.Width) - this.ct上背景スクロール用タイマー[i].n現在の値, TJAPlayer3.Skin.Background_Scroll_Y[i]);
+                        backgroundUpTexture.t2D描画(TJAPlayer3.app.Device, +(l * backgroundUpTexture.szテクスチャサイズ.Width) - this.ct上背景スクロール用タイマー[i].n現在の値, TJAPlayer3.Skin.Background_Scroll_Y[i]);
                     }
                 }
-                if (this.ct上背景スクロール用タイマー[i] != null)
+
+                var backgroundUpClearTexture = TJAPlayer3.Tx.Background_Up_Clear[i];
+                if (backgroundUpClearTexture != null && this.ct上背景スクロール用タイマー[i] != null)
                 {
                     if (TJAPlayer3.stage演奏ドラム画面.bIsAlreadyCleared[i] && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.Hard && TJAPlayer3.ConfigIni.eGaugeMode != EGaugeMode.ExHard)
-                        TJAPlayer3.Tx.Background_Up_Clear[i].Opacity = ((this.ct上背景クリアインタイマー[i].n現在の値 * 0xff) / 100);
+                        backgroundUpClearTexture.Opacity = ((this.ct上背景クリアインタイマー[i].n現在の値 * 0xff) / 100);
                     else
-                        TJAPlayer3.Tx.Background_Up_Clear[i].Opacity = 0;
+                        backgroundUpClearTexture.Opacity = 0;
 
-                    double TexSize = 1280 / TJAPlayer3.Tx.Background_Up_Clear[i].szテクスチャサイズ.Width;
+                    double TexSize = 1280 / backgroundUpClearTexture.szテクスチャサイズ.Width;
                     // 1280をテクスチャサイズで割ったものを切り上げて、プラス+1足す。
                     int ForLoop = (int)Math.Ceiling(TexSize) + 1;
 
-                    TJAPlayer3.Tx.Background_Up_Clear[i].t2D描画(TJAPlayer3.app.Device, 0 - this.ct上背景スクロール用タイマー[i].n現在の値, TJAPlayer3.Skin.Background_Scroll_Y[i]);
+                    backgroundUpClearTexture.t2D描画(TJAPlayer3.app.Device, 0 - this.ct上背景スクロール用タイマー[i].n現在の値, TJAPlayer3.Skin.Background_Scroll_Y[i]);
                     for (int l = 1; l < ForLoop + 1; l++)
                     {
-                        TJAPlayer3.Tx.Background_Up_Clear[i].t2D描画(TJAPlayer3.app.Device, (l * TJAPlayer3.Tx.Background_Up_Clear[i].szテクスチャサイズ.Width) - this.ct上背景スクロール用タイマー[i].n現在の値, TJAPlayer3.Skin.Background_Scroll_Y[i]);
+                        backgroundUpClearTexture.t2D描画(TJAPlayer3.app.Device, (l * backgroundUpClearTexture.szテクスチャサイズ.Width) - this.ct上背景スクロール用タイマー[i].n現在の値, TJAPlayer3.Skin.Background_Scroll_Y[i]);
                     }
                 }
 

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums連打.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums連打.cs
@@ -127,11 +127,19 @@ namespace TJAPlayer3
                         FadeOut[player].Start();
                     }
                     var opacity = (int)FadeOut[player].GetAnimation();
-                    TJAPlayer3.Tx.Balloon_Roll.Opacity = opacity;
-                    TJAPlayer3.Tx.Balloon_Number_Roll.Opacity = opacity;
 
+                    if (TJAPlayer3.Tx.Balloon_Roll != null)
+                    {
+                        TJAPlayer3.Tx.Balloon_Roll.Opacity = opacity;
+                    }
 
-                    TJAPlayer3.Tx.Balloon_Roll.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Balloon_Roll_Frame_X[player], TJAPlayer3.Skin.Game_Balloon_Roll_Frame_Y[player]);
+                    if (TJAPlayer3.Tx.Balloon_Number_Roll != null)
+                    {
+                        TJAPlayer3.Tx.Balloon_Number_Roll.Opacity = opacity;
+                    }
+
+                    TJAPlayer3.Tx.Balloon_Roll?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Balloon_Roll_Frame_X[player], TJAPlayer3.Skin.Game_Balloon_Roll_Frame_Y[player]);
+
                     this.t文字表示(TJAPlayer3.Skin.Game_Balloon_Roll_Number_X[player], TJAPlayer3.Skin.Game_Balloon_Roll_Number_Y[player], n連打数.ToString(), n連打数, player);
                 }
             }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums風船.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums風船.cs
@@ -133,8 +133,7 @@ namespace TJAPlayer3
                     }
                 }
                 //1P:31 2P:329
-                if (TJAPlayer3.Tx.Balloon_Balloon != null)
-                    TJAPlayer3.Tx.Balloon_Balloon.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Balloon_Balloon_Frame_X[player], TJAPlayer3.Skin.Game_Balloon_Balloon_Frame_Y[player]);
+                TJAPlayer3.Tx.Balloon_Balloon?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Balloon_Balloon_Frame_X[player], TJAPlayer3.Skin.Game_Balloon_Balloon_Frame_Y[player]);
                 this.t文字表示(TJAPlayer3.Skin.Game_Balloon_Balloon_Number_X[player], TJAPlayer3.Skin.Game_Balloon_Balloon_Number_Y[player], n連打数.ToString(), n連打数, player);
                 //CDTXMania.act文字コンソール.tPrint( 0, 0, C文字コンソール.Eフォント種別.白, n連打数.ToString() );
             }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -1306,13 +1306,13 @@ namespace TJAPlayer3
                                     {
                                         if( nPlayer == 0 )
                                         {
-                                            TJAPlayer3.Tx.Notes_Arm.t2D上下反転描画( device, x + 25, ( y + 74 ) + nHand );
-                                            TJAPlayer3.Tx.Notes_Arm.t2D上下反転描画( device, x + 60, ( y + 104 ) - nHand );
+                                            TJAPlayer3.Tx.Notes_Arm?.t2D上下反転描画( device, x + 25, ( y + 74 ) + nHand );
+                                            TJAPlayer3.Tx.Notes_Arm?.t2D上下反転描画( device, x + 60, ( y + 104 ) - nHand );
                                         }
                                         else if( nPlayer == 1 )
                                         {
-                                            TJAPlayer3.Tx.Notes_Arm.t2D描画( device, x + 25, ( y - 44 ) + nHand );
-                                            TJAPlayer3.Tx.Notes_Arm.t2D描画( device, x + 60, ( y - 14 ) - nHand );
+                                            TJAPlayer3.Tx.Notes_Arm?.t2D描画( device, x + 25, ( y - 44 ) + nHand );
+                                            TJAPlayer3.Tx.Notes_Arm?.t2D描画( device, x + 60, ( y - 14 ) - nHand );
                                         }
 
                                         TJAPlayer3.Tx.Notes.t2D描画( device, x, y, new Rectangle( 1690, num9, 130, 130 ) );
@@ -1326,13 +1326,13 @@ namespace TJAPlayer3
                                     {
                                         if( nPlayer == 0 )
                                         {
-                                            TJAPlayer3.Tx.Notes_Arm.t2D上下反転描画( device, x + 25, ( y + 74 ) + nHand );
-                                            TJAPlayer3.Tx.Notes_Arm.t2D上下反転描画( device, x + 60, ( y + 104 ) - nHand );
+                                            TJAPlayer3.Tx.Notes_Arm?.t2D上下反転描画( device, x + 25, ( y + 74 ) + nHand );
+                                            TJAPlayer3.Tx.Notes_Arm?.t2D上下反転描画( device, x + 60, ( y + 104 ) - nHand );
                                         }
                                         else if( nPlayer == 1 )
                                         {
-                                            TJAPlayer3.Tx.Notes_Arm.t2D描画( device, x + 25, ( y - 44 ) + nHand );
-                                            TJAPlayer3.Tx.Notes_Arm.t2D描画( device, x + 60, ( y - 14 ) - nHand );
+                                            TJAPlayer3.Tx.Notes_Arm?.t2D描画( device, x + 25, ( y - 44 ) + nHand );
+                                            TJAPlayer3.Tx.Notes_Arm?.t2D描画( device, x + 60, ( y - 14 ) - nHand );
                                         }
 
                                         TJAPlayer3.Tx.Notes.t2D描画( device, x, y, new Rectangle( 1820, num9, 130, 130 ) );

--- a/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -1699,7 +1699,7 @@ namespace TJAPlayer3
 
                     if( pChip.bBranch )
                     {
-                        TJAPlayer3.Tx.Bar_Branch.t3D描画( TJAPlayer3.app.Device, mat, new Rectangle( 0, 0, TJAPlayer3.Skin.Game_Bar_Width, TJAPlayer3.Skin.Game_Bar_Height ) );
+                        TJAPlayer3.Tx.Bar_Branch?.t3D描画( TJAPlayer3.app.Device, mat, new Rectangle( 0, 0, TJAPlayer3.Skin.Game_Bar_Width, TJAPlayer3.Skin.Game_Bar_Height ) );
                     }
                     else
                     {
@@ -1868,8 +1868,7 @@ namespace TJAPlayer3
             {
                 //ボードの横幅は333px
                 //数字フォントの小さいほうはリザルトのものと同じ。
-                if( TJAPlayer3.Tx.Judge_Meter != null )
-                    TJAPlayer3.Tx.Judge_Meter.t2D描画( TJAPlayer3.app.Device, 0, 360 );
+                TJAPlayer3.Tx.Judge_Meter?.t2D描画( TJAPlayer3.app.Device, 0, 360 );
 
                 this.t小文字表示( 102, 494, string.Format( "{0,4:###0}", this.nヒット数_Auto含まない.Drums.Perfect.ToString() ), false );
                 this.t小文字表示( 102, 532, string.Format( "{0,4:###0}", this.nヒット数_Auto含まない.Drums.Great.ToString() ), false );

--- a/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -1909,12 +1909,9 @@ namespace TJAPlayer3
 
 					if( this.st小文字位置[ i ].ch == ch )
 					{
-						Rectangle rectangle = new Rectangle( this.st小文字位置[ i ].pt.X, this.st小文字位置[ i ].pt.Y, 32, 38 );
-						if( TJAPlayer3.Tx.Result_Number != null )
-						{
-                            TJAPlayer3.Tx.Result_Number.t2D描画( TJAPlayer3.app.Device, x, y, rectangle );
-						}
-						break;
+                        var rectangle = new Rectangle( this.st小文字位置[ i ].pt.X, this.st小文字位置[ i ].pt.Y, 32, 38 );
+                        TJAPlayer3.Tx.Result_Number?.t2D描画(TJAPlayer3.app.Device, x, y, rectangle);
+                        break;
 					}
 				}
 				x += 22;
@@ -1934,12 +1931,9 @@ namespace TJAPlayer3
 
 					if( this.st小文字位置[ i ].ch == ch )
 					{
-						Rectangle rectangle = new Rectangle( this.st小文字位置[ i ].pt.X, 38, 32, 42 );
-						if(TJAPlayer3.Tx.Result_Number != null )
-						{
-                            TJAPlayer3.Tx.Result_Number.t2D描画( TJAPlayer3.app.Device, x, y, rectangle );
-						}
-						break;
+                        var rectangle = new Rectangle( this.st小文字位置[ i ].pt.X, 38, 32, 42 );
+                        TJAPlayer3.Tx.Result_Number?.t2D描画(TJAPlayer3.app.Device, x, y, rectangle);
+                        break;
 					}
 				}
 				x += 28;

--- a/TJAPlayer3/Stages/07.Game/Taiko/Dan_Cert.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/Dan_Cert.cs
@@ -392,11 +392,8 @@ namespace TJAPlayer3
                         drawGaugeType = 0;
                 }
 
-                if (TJAPlayer3.Tx.DanC_Gauge != null)
-                {
-                    TJAPlayer3.Tx.DanC_Gauge[drawGaugeType]?.t2D拡大率考慮下基準描画(TJAPlayer3.app.Device,
-                        TJAPlayer3.Skin.Game_DanC_X[count - 1] + TJAPlayer3.Skin.Game_DanC_Offset[0], TJAPlayer3.Skin.Game_DanC_Y[count - 1] + TJAPlayer3.Skin.Game_DanC_Size[1] * (i + 1) + ((i + 1) * TJAPlayer3.Skin.Game_DanC_Padding) - TJAPlayer3.Skin.Game_DanC_Offset[1], new Rectangle(0, 0, (int)(dan_C[i].GetAmountToPercent() * (TJAPlayer3.Tx.DanC_Gauge[drawGaugeType].szテクスチャサイズ.Width / 100.0)), TJAPlayer3.Tx.DanC_Gauge[drawGaugeType].szテクスチャサイズ.Height));
-                }
+                TJAPlayer3.Tx.DanC_Gauge[drawGaugeType]?.t2D拡大率考慮下基準描画(TJAPlayer3.app.Device,
+                    TJAPlayer3.Skin.Game_DanC_X[count - 1] + TJAPlayer3.Skin.Game_DanC_Offset[0], TJAPlayer3.Skin.Game_DanC_Y[count - 1] + TJAPlayer3.Skin.Game_DanC_Size[1] * (i + 1) + ((i + 1) * TJAPlayer3.Skin.Game_DanC_Padding) - TJAPlayer3.Skin.Game_DanC_Offset[1], new Rectangle(0, 0, (int)(dan_C[i].GetAmountToPercent() * (TJAPlayer3.Tx.DanC_Gauge[drawGaugeType].szテクスチャサイズ.Width / 100.0)), TJAPlayer3.Tx.DanC_Gauge[drawGaugeType].szテクスチャサイズ.Height));
                 #endregion
 
                 #region 現在の値を描画する。

--- a/TJAPlayer3/Stages/07.Game/Taiko/LaneFlash.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/LaneFlash.cs
@@ -8,7 +8,7 @@ namespace TJAPlayer3
     public class LaneFlash : CActivity
     {
 
-        public LaneFlash(ref CTexture texture, int player)
+        public LaneFlash(CTexture texture, int player)
         {
             Texture = texture;
             Player = player;

--- a/TJAPlayer3/Stages/07.Game/Taiko/TaikoLaneFlash.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/TaikoLaneFlash.cs
@@ -61,13 +61,13 @@ namespace TJAPlayer3
                 switch (i)
                 {
                     case (int)FlashType.Red:
-                        Flash[i] = new LaneFlash(ref TJAPlayer3.Tx.Lane_Red, player);
+                        Flash[i] = new LaneFlash(TJAPlayer3.Tx.Lane_Red, player);
                         break;
                     case (int)FlashType.Blue:
-                        Flash[i] = new LaneFlash(ref TJAPlayer3.Tx.Lane_Blue, player);
+                        Flash[i] = new LaneFlash(TJAPlayer3.Tx.Lane_Blue, player);
                         break;
                     case (int)FlashType.Hit:
-                        Flash[i] = new LaneFlash(ref TJAPlayer3.Tx.Lane_Yellow, player);
+                        Flash[i] = new LaneFlash(TJAPlayer3.Tx.Lane_Yellow, player);
                         break;
                     default:
                         break;

--- a/TJAPlayer3/Stages/08.Result/CActResultParameterPanel.cs
+++ b/TJAPlayer3/Stages/08.Result/CActResultParameterPanel.cs
@@ -190,136 +190,136 @@ namespace TJAPlayer3
 
 
                 //ハード/EXハードゲージ用のBase
-                if (TJAPlayer3.ConfigIni.eGaugeMode == EGaugeMode.ExHard)
+                CTexture gaugeBase;
+                switch (TJAPlayer3.ConfigIni.eGaugeMode)
                 {
-                    if (TJAPlayer3.Tx.Result_Gauge_Base_ExHard != null)
-                        TJAPlayer3.Tx.Result_Gauge_Base_ExHard.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nResultGaugeBaseP1X, TJAPlayer3.Skin.nResultGaugeBaseP1Y, new Rectangle(0, 0, 691, 47));
-                    else if (TJAPlayer3.Tx.Result_Gauge_Base_Hard != null)
-                        TJAPlayer3.Tx.Result_Gauge_Base_Hard.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nResultGaugeBaseP1X, TJAPlayer3.Skin.nResultGaugeBaseP1Y, new Rectangle(0, 0, 691, 47));
-                    else
-                        TJAPlayer3.Tx.Result_Gauge_Base.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nResultGaugeBaseP1X, TJAPlayer3.Skin.nResultGaugeBaseP1Y, new Rectangle(0, 0, 691, 47));
+                    case EGaugeMode.ExHard:
+                        gaugeBase = TJAPlayer3.Tx.Result_Gauge_Base_ExHard ?? TJAPlayer3.Tx.Result_Gauge_Base_Hard ?? TJAPlayer3.Tx.Result_Gauge_Base;
+                        break;
+                    case EGaugeMode.Hard:
+                        gaugeBase = TJAPlayer3.Tx.Result_Gauge_Base_Hard ?? TJAPlayer3.Tx.Result_Gauge_Base;
+                        break;
+                    default:
+                        gaugeBase = TJAPlayer3.Tx.Result_Gauge_Base;
+                        break;
                 }
-                else if (TJAPlayer3.ConfigIni.eGaugeMode == EGaugeMode.Hard)
-                {
-                    if (TJAPlayer3.Tx.Result_Gauge_Base_Hard != null)
-                        TJAPlayer3.Tx.Result_Gauge_Base_Hard.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nResultGaugeBaseP1X, TJAPlayer3.Skin.nResultGaugeBaseP1Y, new Rectangle(0, 0, 691, 47));
-                    else
-                        TJAPlayer3.Tx.Result_Gauge_Base_Hard.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nResultGaugeBaseP1X, TJAPlayer3.Skin.nResultGaugeBaseP1Y, new Rectangle(0, 0, 691, 47));
-                }
-                else
-                        TJAPlayer3.Tx.Result_Gauge_Base.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nResultGaugeBaseP1X, TJAPlayer3.Skin.nResultGaugeBaseP1Y, new Rectangle(0, 0, 691, 47));
+                gaugeBase?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nResultGaugeBaseP1X, TJAPlayer3.Skin.nResultGaugeBaseP1Y, new Rectangle(0, 0, 691, 47));
 
                 #region[ ゲージ本体 ]
 
                 //ハードゲージ用のゲージ画像の分岐(ゲージ本体のコードを使いまわしたいので)
+                CTexture gauge;
                 if (TJAPlayer3.Tx.Result_Gauge_ExHard != null && TJAPlayer3.ConfigIni.eGaugeMode == EGaugeMode.ExHard)
-                    Gauge = TJAPlayer3.Tx.Result_Gauge_ExHard;
+                    gauge = TJAPlayer3.Tx.Result_Gauge_ExHard;
                 else if (TJAPlayer3.Tx.Result_Gauge_Hard != null && (TJAPlayer3.ConfigIni.eGaugeMode == EGaugeMode.Hard || TJAPlayer3.ConfigIni.eGaugeMode == EGaugeMode.ExHard))
-                    Gauge = TJAPlayer3.Tx.Result_Gauge_Hard;
+                    gauge = TJAPlayer3.Tx.Result_Gauge_Hard;
                 else
-                    Gauge = TJAPlayer3.Tx.Result_Gauge;
+                    gauge = TJAPlayer3.Tx.Result_Gauge;
 
-                if ( Rate > 2 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 4 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 12, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 6 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 24, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 8 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 36, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 10 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 49, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 12 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 62, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 14 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 74, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 16 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 86, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 18 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 99, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 20 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 112, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 22 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 125, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 24 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 138, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 26 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 150, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 28 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 162, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 30 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 175, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 32 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 187, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 34 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 200, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 36 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 212, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 38 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 225, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 40 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 238, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 42 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 251, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 44 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 263, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 46 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 276, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 48 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 288, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 50 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 301, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 52 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 313, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 54 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 326, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 56 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 339, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 58 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 352, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 60 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 364, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 62 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 377, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 64 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 390, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 66 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 402, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 68 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 415, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 70 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 427, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 72 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 440, 145, new Rectangle( 0, 20, 12, 20 ) );
-                if( Rate > 74 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 452, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 76 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 465, 145, new Rectangle( 12, 20, 13, 20 ) );
-                if( Rate > 78 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 478, 145, new Rectangle( 12, 20, 13, 20 ) );
+                if (gauge != null)
+                {
+                    if ( Rate > 2 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 4 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 12, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 6 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 24, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 8 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 36, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 10 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 49, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 12 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 62, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 14 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 74, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 16 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 86, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 18 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 99, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 20 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 112, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 22 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 125, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 24 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 138, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 26 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 150, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 28 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 162, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 30 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 175, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 32 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 187, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 34 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 200, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 36 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 212, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 38 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 225, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 40 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 238, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 42 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 251, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 44 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 263, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 46 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 276, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 48 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 288, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 50 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 301, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 52 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 313, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 54 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 326, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 56 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 339, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 58 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 352, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 60 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 364, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 62 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 377, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 64 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 390, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 66 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 402, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 68 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 415, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 70 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 427, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 72 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 440, 145, new Rectangle( 0, 20, 12, 20 ) );
+                    if( Rate > 74 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 452, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 76 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 465, 145, new Rectangle( 12, 20, 13, 20 ) );
+                    if( Rate > 78 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 478, 145, new Rectangle( 12, 20, 13, 20 ) );
 
-                if( Rate > 80 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 491, 125, new Rectangle( 25, 0, 12, 40 ) );
-                if( Rate > 82 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 503, 125, new Rectangle( 49, 0, 13, 40 ) );
-                if( Rate > 84 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 516, 125, new Rectangle( 37, 0, 12, 40 ) );
-                if( Rate > 86 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 528, 125, new Rectangle( 49, 0, 13, 40 ) );
-                if( Rate > 88 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 541, 125, new Rectangle( 37, 0, 12, 40 ) );
-                if( Rate > 90 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 553, 125, new Rectangle( 49, 0, 13, 40 ) );
-                if( Rate > 92 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 566, 125, new Rectangle( 49, 0, 13, 40 ) );
-                if( Rate > 94 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 579, 125, new Rectangle( 37, 0, 12, 40 ) );
-                if( Rate > 96 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 591, 125, new Rectangle( 49, 0, 13, 40 ) );
-                if( Rate > 98 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 604, 125, new Rectangle( 37, 0, 12, 40 ) );
-                if( Rate >= 100 )
-                    Gauge.t2D描画( TJAPlayer3.app.Device, 559 + 616, 125, new Rectangle( 49, 0, 10, 40 ) );
+                    if( Rate > 80 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 491, 125, new Rectangle( 25, 0, 12, 40 ) );
+                    if( Rate > 82 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 503, 125, new Rectangle( 49, 0, 13, 40 ) );
+                    if( Rate > 84 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 516, 125, new Rectangle( 37, 0, 12, 40 ) );
+                    if( Rate > 86 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 528, 125, new Rectangle( 49, 0, 13, 40 ) );
+                    if( Rate > 88 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 541, 125, new Rectangle( 37, 0, 12, 40 ) );
+                    if( Rate > 90 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 553, 125, new Rectangle( 49, 0, 13, 40 ) );
+                    if( Rate > 92 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 566, 125, new Rectangle( 49, 0, 13, 40 ) );
+                    if( Rate > 94 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 579, 125, new Rectangle( 37, 0, 12, 40 ) );
+                    if( Rate > 96 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 591, 125, new Rectangle( 49, 0, 13, 40 ) );
+                    if( Rate > 98 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 604, 125, new Rectangle( 37, 0, 12, 40 ) );
+                    if( Rate >= 100 )
+                        gauge.t2D描画( TJAPlayer3.app.Device, 559 + 616, 125, new Rectangle( 49, 0, 10, 40 ) );
+                }
 
                 #endregion
             }
@@ -397,7 +397,6 @@ namespace TJAPlayer3
 		private readonly ST文字位置[] st小文字位置;
         private ST文字位置[] stScoreFont;
 
-        private CTexture Gauge = null;
         private CTexture Dan_Plate;
 
 		private void t小文字表示( int x, int y, string str )

--- a/TJAPlayer3/Stages/08.Result/CActResultParameterPanel.cs
+++ b/TJAPlayer3/Stages/08.Result/CActResultParameterPanel.cs
@@ -165,22 +165,11 @@ namespace TJAPlayer3
 				base.b初めての進行描画 = false;
 			}
 			this.ct表示用.t進行();
-			if(TJAPlayer3.Tx.Result_Panel != null )
-			{
-                TJAPlayer3.Tx.Result_Panel.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nResultPanelP1X, TJAPlayer3.Skin.nResultPanelP1Y );
-			}
-			if(TJAPlayer3.Tx.Result_Score_Text != null )
-			{
-                TJAPlayer3.Tx.Result_Score_Text.t2D描画( TJAPlayer3.app.Device, 753, 249 ); //点
-			}
-            if(TJAPlayer3.Tx.Result_Judge != null )
-            {
-                TJAPlayer3.Tx.Result_Judge.t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nResultJudge1_P1X, TJAPlayer3.Skin.nResultJudge1_P1Y );
-            }
-            if(TJAPlayer3.Tx.Result_Judge != null )
-            {
-                //CDTXMania.Tx.Result_Judge.t2D描画( CDTXMania.app.Device, CDTXMania.Skin.nResultJudge2_P1X, CDTXMania.Skin.nResultJudge2_P1Y );
-            }
+            
+            TJAPlayer3.Tx.Result_Panel?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nResultPanelP1X, TJAPlayer3.Skin.nResultPanelP1Y);
+            TJAPlayer3.Tx.Result_Score_Text?.t2D描画(TJAPlayer3.app.Device, 753, 249); //点
+            TJAPlayer3.Tx.Result_Judge?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nResultJudge1_P1X, TJAPlayer3.Skin.nResultJudge1_P1Y);
+
             if(TJAPlayer3.Tx.Result_Gauge_Base != null && TJAPlayer3.Tx.Result_Gauge != null )
             {
 
@@ -412,12 +401,9 @@ namespace TJAPlayer3
 
 					if( this.st小文字位置[ i ].ch == ch )
 					{
-						Rectangle rectangle = new Rectangle( this.st小文字位置[ i ].pt.X, this.st小文字位置[ i ].pt.Y, 32, 38 );
-						if(TJAPlayer3.Tx.Result_Number != null )
-						{
-                            TJAPlayer3.Tx.Result_Number.t2D描画( TJAPlayer3.app.Device, x, y, rectangle );
-						}
-						break;
+                        var rectangle = new Rectangle( this.st小文字位置[ i ].pt.X, this.st小文字位置[ i ].pt.Y, 32, 38 );
+                        TJAPlayer3.Tx.Result_Number?.t2D描画(TJAPlayer3.app.Device, x, y, rectangle);
+                        break;
 					}
 				}
 				x += 22;
@@ -432,11 +418,8 @@ namespace TJAPlayer3
                 {
                     if (this.stScoreFont[i].ch == ch)
                     {
-                        Rectangle rectangle = new Rectangle(this.stScoreFont[ i ].pt.X, 0, 24, 40);
-                        if (TJAPlayer3.Tx.Result_Score_Number != null)
-                        {
-                            TJAPlayer3.Tx.Result_Score_Number.t2D描画(TJAPlayer3.app.Device, x, y, rectangle);
-                        }
+                        var rectangle = new Rectangle(this.stScoreFont[ i ].pt.X, 0, 24, 40);
+                        TJAPlayer3.Tx.Result_Score_Number?.t2D描画(TJAPlayer3.app.Device, x, y, rectangle);
                         break;
                     }
                 }

--- a/TJAPlayer3/Stages/08.Result/CStage結果.cs
+++ b/TJAPlayer3/Stages/08.Result/CStage結果.cs
@@ -335,7 +335,7 @@ namespace TJAPlayer3
 				}
 
                 #region ネームプレート
-                for (int i = 0; i < TJAPlayer3.ConfigIni.nPlayerCount; i++)
+                for (int i = 0; i < Math.Min(TJAPlayer3.ConfigIni.nPlayerCount, TJAPlayer3.Tx.NamePlate.Length); i++)
                 {
                     TJAPlayer3.Tx.NamePlate[i]?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Result_NamePlate_X[i], TJAPlayer3.Skin.Result_NamePlate_Y[i]);
                 }

--- a/TJAPlayer3/Stages/08.Result/CStage結果.cs
+++ b/TJAPlayer3/Stages/08.Result/CStage結果.cs
@@ -302,11 +302,9 @@ namespace TJAPlayer3
 
 				// 描画
 
-				if(TJAPlayer3.Tx.Result_Background != null )
-				{
-                    TJAPlayer3.Tx.Result_Background.t2D描画( TJAPlayer3.app.Device, 0, 0 );
-				}
-				if( this.ct登場用.b進行中 && ( TJAPlayer3.Tx.Result_Header != null ) )
+                TJAPlayer3.Tx.Result_Background?.t2D描画(TJAPlayer3.app.Device, 0, 0);
+
+                if( this.ct登場用.b進行中 && ( TJAPlayer3.Tx.Result_Header != null ) )
 				{
 					double num2 = ( (double) this.ct登場用.n現在の値 ) / 100.0;
 					double num3 = Math.Sin( Math.PI / 2 * num2 );

--- a/TJAPlayer3/Stages/08.Result/CStage結果.cs
+++ b/TJAPlayer3/Stages/08.Result/CStage結果.cs
@@ -274,7 +274,6 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-				int num;
 				if( base.b初めての進行描画 )
 				{
 					this.ct登場用 = new CCounter( 0, 100, 5, TJAPlayer3.Timer );
@@ -304,20 +303,8 @@ namespace TJAPlayer3
 
                 TJAPlayer3.Tx.Result_Background?.t2D描画(TJAPlayer3.app.Device, 0, 0);
 
-                if( this.ct登場用.b進行中 && ( TJAPlayer3.Tx.Result_Header != null ) )
-				{
-					double num2 = ( (double) this.ct登場用.n現在の値 ) / 100.0;
-					double num3 = Math.Sin( Math.PI / 2 * num2 );
-					num = ( (int) ( TJAPlayer3.Tx.Result_Header.sz画像サイズ.Height * num3 ) ) - TJAPlayer3.Tx.Result_Header.sz画像サイズ.Height;
-				}
-				else
-				{
-					num = 0;
-				}
-				if(TJAPlayer3.Tx.Result_Header != null )
-				{
-                    TJAPlayer3.Tx.Result_Header.t2D描画( TJAPlayer3.app.Device, 0, 0 );
-				}
+                TJAPlayer3.Tx.Result_Header?.t2D描画(TJAPlayer3.app.Device, 0, 0);
+
                 if ( this.actResultImage.On進行描画() == 0 )
 				{
 					this.bアニメが完了 = false;

--- a/TJAPlayer3/Stages/09.Ending/CStage終了.cs
+++ b/TJAPlayer3/Stages/09.Ending/CStage終了.cs
@@ -101,21 +101,10 @@ namespace TJAPlayer3
 
 				this.ct時間稼ぎ.t進行();
 
-				if( TJAPlayer3.Tx.Exit_Background != null )
-				{
-                    //if( this.ds背景 != null )
-                    //{
-                    //    if( this.ds背景.b上下反転 )
-                    //        this.tx背景.t2D上下反転描画( CDTXMania.app.Device, 0, 0 );
-                    //    else
-                    //        this.tx背景.t2D描画( CDTXMania.app.Device, 0, 0 );
-                    //}
-                    //else
-                    TJAPlayer3.Tx.Exit_Background.t2D描画( TJAPlayer3.app.Device, 0, 0 );
-				}
+                TJAPlayer3.Tx.Exit_Background?.t2D描画(TJAPlayer3.app.Device, 0, 0);
 
 
-           //     if( this.ct時間稼ぎ.n現在の値 < 2000 )
+                //     if( this.ct時間稼ぎ.n現在の値 < 2000 )
            //     {
            //         if( this.tx文字 != null )
            //         {

--- a/TJAPlayer3/Stages/09.Ending/CStage終了.cs
+++ b/TJAPlayer3/Stages/09.Ending/CStage終了.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Diagnostics;
-using DirectShowLib;
-using SlimDX;
+﻿using System.Diagnostics;
 using FDK;
 
 namespace TJAPlayer3
@@ -55,12 +50,6 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-    //            this.tx文字 = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\9_text.png" ) );
-    //            this.tx文字2 = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\9_text.png" ) );
-    //            this.tx文字3 = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\9_text.png" ) );
-				//this.tx背景 = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\9_background.jpg" ), false );
-    //            this.tx白 = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\Tile white 64x64.png" ), false );
-    //            this.ds背景 = CDTXMania.t失敗してもスキップ可能なDirectShowを生成する( CSkin.Path( @"Graphics\9_background.mp4" ), CDTXMania.app.WindowHandle, true );
 				base.OnManagedリソースの作成();
 			}
 		}
@@ -68,12 +57,6 @@ namespace TJAPlayer3
 		{
 			if( !base.b活性化してない )
 			{
-				//CDTXMania.tテクスチャの解放( ref this.tx背景 );
-    //            CDTXMania.tテクスチャの解放( ref this.tx文字 );
-    //            CDTXMania.tテクスチャの解放( ref this.tx文字2 );
-    //            CDTXMania.tテクスチャの解放( ref this.tx文字3 );
-    //            CDTXMania.tテクスチャの解放( ref this.tx白 );
-    //            CDTXMania.t安全にDisposeする( ref this.ds背景 );
 				base.OnManagedリソースの解放();
 			}
 		}
@@ -83,12 +66,7 @@ namespace TJAPlayer3
             {
                 return 1;
             }
-            //if( this.ds背景 != null )
-            //{
-            //    this.ds背景.t再生開始();
-                
-            //    this.ds背景.t現時点における最新のスナップイメージをTextureに転写する( this.tx背景 );
-            //}
+
 			if( !base.b活性化してない )
 			{
 				if( base.b初めての進行描画 )
@@ -103,48 +81,6 @@ namespace TJAPlayer3
 
                 TJAPlayer3.Tx.Exit_Background?.t2D描画(TJAPlayer3.app.Device, 0, 0);
 
-
-                //     if( this.ct時間稼ぎ.n現在の値 < 2000 )
-           //     {
-           //         if( this.tx文字 != null )
-           //         {
-           //             this.tx文字2.fZ軸中心回転 = -0.8f;
-           //             this.tx文字3.fZ軸中心回転 = ( -1.6f * ( this.ct時間稼ぎ.n現在の値 / 1280.0f ) ) >= -1.6f ? ( -1.6f * ( this.ct時間稼ぎ.n現在の値 / 1280.0f ) ) : -1.6f ;
-           //             this.tx文字2.vc拡大縮小倍率 = new Vector3( 4.0f, 4.0f, 1.0f );
-           //             this.tx文字3.vc拡大縮小倍率 = new Vector3( 4.0f, 4.0f, 1.0f );
-
-           //             this.tx文字2.t2D描画( CDTXMania.app.Device, 1100 - (int)( 1.30f * this.ct時間稼ぎ.n現在の値), 1600 - (int)( 1.6f * this.ct時間稼ぎ.n現在の値), new System.Drawing.Rectangle( 0, 0, 620, 92 )  );
-           //             this.tx文字3.t2D描画( CDTXMania.app.Device, -250 + (int)( 1.10f * this.ct時間稼ぎ.n現在の値), 1600 - (int)( 1.6f * this.ct時間稼ぎ.n現在の値), new System.Drawing.Rectangle( 0, 92, 620, 94 )  );
-           //         }
-           //     }
-           //     else
-           //     {
-
-           //         if( this.tx文字 != null )
-           //         {
-           //             this.tx文字2.fZ軸中心回転 = 0f;
-           //             this.tx文字3.fZ軸中心回転 = 0f;
-           //             this.tx文字2.vc拡大縮小倍率 = new Vector3( 1.3f, 1.3f, 1.0f );
-           //             this.tx文字3.vc拡大縮小倍率 = new Vector3( 1.3f, 1.3f, 1.0f );
-
-           //             this.tx文字2.t2D描画( CDTXMania.app.Device, 480, 376, new System.Drawing.Rectangle( 0, 0, 620, 92 )  );
-           //             this.tx文字3.t2D描画( CDTXMania.app.Device, 500, 486, new System.Drawing.Rectangle( 0, 92, 620, 95 )  );
-           //             this.tx文字.t2D描画( CDTXMania.app.Device, 662, 613, new System.Drawing.Rectangle( 0, 187, 620, 44 )  );
-           //         }
-
-           //         if( this.tx白 != null )
-			        //{
-				       // this.tx白.n透明度 = ( 2255 + 300 ) - ( this.ct時間稼ぎ.n現在の値 );
-				       // for( int i = 0; i <= ( SampleFramework.GameWindowSize.Width / 64 ); i++ )
-				       // {
-					      //  for( int j = 0; j <= ( SampleFramework.GameWindowSize.Height / 64 ); j++ )
-					      //  {
-           //                     this.tx白.t2D描画( CDTXMania.app.Device, i * 64, j * 64 );
-					      //  }
-				       // }
-			        //}
-           //     }
-
                 if( this.ct時間稼ぎ.b終了値に達した && !TJAPlayer3.Skin.soundゲーム終了音.b再生中 )
 				{
 					return 1;
@@ -153,19 +89,6 @@ namespace TJAPlayer3
 			return 0;
 		}
 
-
-		// その他
-
-		#region [ private ]
-		//-----------------
 		private CCounter ct時間稼ぎ;
-		//private CTexture tx背景;
-  //      private CTexture tx文字;
-  //      private CTexture tx文字2;
-  //      private CTexture tx文字3;
-  //      private CDirectShow ds背景;
-  //      private CTexture tx白;
-		//-----------------
-		#endregion
 	}
 }


### PR DESCRIPTION
- Overhaul texture loading in TextureLoader, for both single textures as well as arrays of textures.
- Always initialize and return from TextureLoader non-null texture arrays, rather than a mix of null and non-null arrays of textures.
- Manage TextureLoader textures in a way that should reduce or eliminate any remaining texture leaks, as well as reduce the chances of various texture-related crashes, especially after switching skins.
- Update code using textures to more consistently perform null checks (often via null-conditional access) to ensure that referenced textures were actually loaded, rather than assuming they were. This too should reduce the chances of various texture-related crashes, especially for users creating or using custom skins.

Fixes #42