### PR TITLE
Disambiguate specific types of error reports from custom skin users

### DIFF
--- a/TJAPlayer3.Tests/TJAPlayer3.Tests.csproj
+++ b/TJAPlayer3.Tests/TJAPlayer3.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -428,6 +428,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
 </Project>

--- a/TJAPlayer3.Tests/packages.config
+++ b/TJAPlayer3.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
   <package id="NUnit" version="3.12.0" targetFramework="net48" />
-  <package id="NUnit3TestAdapter" version="3.16.1" targetFramework="net48" developmentDependency="true" />
+  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net48" developmentDependency="true" />
 </packages>

--- a/TJAPlayer3/ErrorReporting/ErrorReporter.cs
+++ b/TJAPlayer3/ErrorReporting/ErrorReporter.cs
@@ -50,7 +50,14 @@ namespace TJAPlayer3.ErrorReporting
                     // ignored
                 }
 
-                o.ShutdownTimeout = TimeSpan.FromSeconds(5);
+                try
+                {
+                    o.ShutdownTimeout = TimeSpan.FromSeconds(5);
+                }
+                catch
+                {
+                    // ignored
+                }
             }))
             {
                 try

--- a/TJAPlayer3/ErrorReporting/ErrorReporter.cs
+++ b/TJAPlayer3/ErrorReporting/ErrorReporter.cs
@@ -21,22 +21,51 @@ namespace TJAPlayer3.ErrorReporting
 
         public static void WithErrorReporting(Action action)
         {
-            var appInformationalVersion = TJAPlayer3.AppInformationalVersion;
-
             using (SentrySdk.Init(o =>
             {
-                o.Dsn = new Dsn("https://d13a7e78ae024f678e110c64bbf7e7f2@sentry.io/3365560");
-                o.Environment = GetEnvironment(appInformationalVersion);
-                o.ServerName = ToSha256InBase64(Environment.MachineName);
+                try
+                {
+                    o.Dsn = new Dsn("https://d13a7e78ae024f678e110c64bbf7e7f2@sentry.io/3365560");
+                }
+                catch
+                {
+                    // ignored
+                }
+
+                try
+                {
+                    o.Environment = GetEnvironment(TJAPlayer3.AppInformationalVersion);
+                }
+                catch
+                {
+                    // ignored
+                }
+
+                try
+                {
+                    o.ServerName = ToSha256InBase64(Environment.MachineName);
+                }
+                catch
+                {
+                    // ignored
+                }
+
                 o.ShutdownTimeout = TimeSpan.FromSeconds(5);
             }))
             {
                 try
                 {
-                    SentrySdk.ConfigureScope(scope =>
+                    try
                     {
-                        scope.User.Username = ToSha256InBase64(Environment.UserName);
-                    });
+                        SentrySdk.ConfigureScope(scope =>
+                        {
+                            scope.User.Username = ToSha256InBase64(Environment.UserName);
+                        });
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
 
                     Application.ThreadException += (sender, args) =>
                     {
@@ -48,7 +77,14 @@ namespace TJAPlayer3.ErrorReporting
                         ReportError(args.Exception);
                     };
 
-                    SentrySdk.CaptureMessage("Startup");
+                    try
+                    {
+                        SentrySdk.CaptureMessage("Startup");
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
 
                     action();
                 }
@@ -58,7 +94,14 @@ namespace TJAPlayer3.ErrorReporting
 
                     var task = SentrySdk.FlushAsync(TimeSpan.FromSeconds(5));
 
-                    NotifyUserOfError(e);
+                    try
+                    {
+                        NotifyUserOfError(e);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
 
                     task.Wait();
                 }

--- a/TJAPlayer3/ErrorReporting/ErrorReporter.cs
+++ b/TJAPlayer3/ErrorReporting/ErrorReporter.cs
@@ -84,15 +84,6 @@ namespace TJAPlayer3.ErrorReporting
                         ReportError(args.Exception);
                     };
 
-                    try
-                    {
-                        SentrySdk.CaptureMessage("Startup");
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
-
                     action();
                 }
                 catch (Exception e)
@@ -111,10 +102,6 @@ namespace TJAPlayer3.ErrorReporting
                     }
 
                     task.Wait();
-                }
-                finally
-                {
-                    SentrySdk.CaptureMessage("Shutdown");
                 }
             }
         }

--- a/TJAPlayer3/TJAPlayer3.csproj
+++ b/TJAPlayer3/TJAPlayer3.csproj
@@ -102,29 +102,14 @@
       <HintPath>..\packages\SlimDX.4.0.13.44\lib\NET40\SlimDX.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.7.1\lib\net461\System.Collections.Immutable.dll</HintPath>
-    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
@@ -356,7 +341,6 @@ move /y "$(TargetDir)FDK.pdb" "$(SolutionDir)Test\dll\"
 move /y "$(TargetDir)Newtonsoft.Json.*" "$(SolutionDir)Test\dll\"
 move /y "$(TargetDir)Sentry.*" "$(SolutionDir)Test\dll\"
 move /y "$(TargetDir)SlimDX.dll" "$(SolutionDir)Test\dll\"
-move /y "$(TargetDir)System.*" "$(SolutionDir)Test\dll\"
 </PostBuildEvent>
   </PropertyGroup>
   <Import Project="packages\SharpDX.2.6.3\build\SharpDX.targets" Condition="Exists('packages\SharpDX.2.6.3\build\SharpDX.targets')" />

--- a/TJAPlayer3/TJAPlayer3.csproj
+++ b/TJAPlayer3/TJAPlayer3.csproj
@@ -89,14 +89,14 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sentry, Version=2.1.1.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sentry.2.1.1\lib\net461\Sentry.dll</HintPath>
+    <Reference Include="Sentry, Version=2.1.6.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sentry.2.1.6\lib\net461\Sentry.dll</HintPath>
     </Reference>
-    <Reference Include="Sentry.PlatformAbstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sentry.PlatformAbstractions.1.1.0\lib\net471\Sentry.PlatformAbstractions.dll</HintPath>
+    <Reference Include="Sentry.PlatformAbstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sentry.PlatformAbstractions.1.1.1\lib\net471\Sentry.PlatformAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Sentry.Protocol, Version=2.1.1.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sentry.Protocol.2.1.1\lib\net46\Sentry.Protocol.dll</HintPath>
+    <Reference Include="Sentry.Protocol, Version=2.1.6.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sentry.Protocol.2.1.6\lib\net46\Sentry.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="SlimDX, Version=4.0.13.43, Culture=neutral, PublicKeyToken=b1b0c32fd1ffe4f9, processorArchitecture=x86">
       <HintPath>..\packages\SlimDX.4.0.13.44\lib\NET40\SlimDX.dll</HintPath>
@@ -106,7 +106,7 @@
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.7.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\packages\System.Collections.Immutable.1.7.1\lib\net461\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -360,11 +360,11 @@ move /y "$(TargetDir)System.*" "$(SolutionDir)Test\dll\"
 </PostBuildEvent>
   </PropertyGroup>
   <Import Project="packages\SharpDX.2.6.3\build\SharpDX.targets" Condition="Exists('packages\SharpDX.2.6.3\build\SharpDX.targets')" />
-  <Import Project="..\packages\LargeAddressAware.1.0.4\build\LargeAddressAware.targets" Condition="Exists('..\packages\LargeAddressAware.1.0.4\build\LargeAddressAware.targets')" />
+  <Import Project="..\packages\LargeAddressAware.1.0.5\build\LargeAddressAware.targets" Condition="Exists('..\packages\LargeAddressAware.1.0.5\build\LargeAddressAware.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LargeAddressAware.1.0.4\build\LargeAddressAware.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LargeAddressAware.1.0.4\build\LargeAddressAware.targets'))" />
+    <Error Condition="!Exists('..\packages\LargeAddressAware.1.0.5\build\LargeAddressAware.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LargeAddressAware.1.0.5\build\LargeAddressAware.targets'))" />
   </Target>
 </Project>

--- a/TJAPlayer3/packages.config
+++ b/TJAPlayer3/packages.config
@@ -7,9 +7,4 @@
   <package id="Sentry.PlatformAbstractions" version="1.1.1" targetFramework="net48" />
   <package id="Sentry.Protocol" version="2.1.6" targetFramework="net48" />
   <package id="SlimDX" version="4.0.13.44" targetFramework="net48" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
-  <package id="System.Collections.Immutable" version="1.7.1" targetFramework="net48" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net48" />
 </packages>

--- a/TJAPlayer3/packages.config
+++ b/TJAPlayer3/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CSharpTest.Net.Collections" version="14.906.1403.1082" targetFramework="net48" />
-  <package id="LargeAddressAware" version="1.0.4" targetFramework="net48" />
+  <package id="LargeAddressAware" version="1.0.5" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
-  <package id="Sentry" version="2.1.1" targetFramework="net48" />
-  <package id="Sentry.PlatformAbstractions" version="1.1.0" targetFramework="net48" />
-  <package id="Sentry.Protocol" version="2.1.1" targetFramework="net48" />
+  <package id="Sentry" version="2.1.6" targetFramework="net48" />
+  <package id="Sentry.PlatformAbstractions" version="1.1.1" targetFramework="net48" />
+  <package id="Sentry.Protocol" version="2.1.6" targetFramework="net48" />
   <package id="SlimDX" version="4.0.13.44" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
-  <package id="System.Collections.Immutable" version="1.7.0" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="1.7.1" targetFramework="net48" />
   <package id="System.Memory" version="4.5.4" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net48" />


### PR DESCRIPTION
Users creating and/or customizing custom skins encounter different patterns of errors than other users, they do so much more often, there's nothing that can be done about such errors, and the noise makes it harder to diagnose issues for other users.

As of this pull request, when a terminal exception is encountered TJAPlayer3 now determines whether or not the user is likely running a custom skin and, if so, reports the following exception types at warning level rather than error level, making such error reports easier to manage in Sentry (e.g. via filtering)

- `SlimDX.Direct3D9.Direct3D9Exception`
- `System.AccessViolationException`
- `System.OutOfMemoryException`

This pull request also updates a few NuGet packages, including an update to one which removes its dependency on some others, allowing them to be removed. This in turn reduces compressed and uncompressed package sizes somewhat, which is always nice.