### PR TITLE
Fix impossible notes before `#BRANCHSTART`

### DIFF
--- a/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
+++ b/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
@@ -1960,7 +1960,7 @@ namespace TJAPlayer3
             #endregion
 
             #region 過去のノーツが見つかったらそれを返却、そうでなければ未来のノーツを返却
-            if ((pastJudge == E判定.Miss || pastJudge == E判定.Poor) && (pastJudge != E判定.Miss && pastJudge != E判定.Poor))
+            if ((pastJudge == E判定.Miss || pastJudge == E判定.Poor) && (futureJudge != E判定.Miss && futureJudge != E判定.Poor))
             {
                 // 過去の判定が不可で、未来の判定が可以上なら未来を返却。
                 nearestChip = futureChip;
@@ -2109,7 +2109,7 @@ namespace TJAPlayer3
             #endregion
 
             #region 過去のノーツが見つかったらそれを返却、そうでなければ未来のノーツを返却
-            if ((pastJudge == E判定.Miss || pastJudge == E判定.Poor) && (pastJudge != E判定.Miss && pastJudge != E判定.Poor))
+            if ((pastJudge == E判定.Miss || pastJudge == E判定.Poor) && (futureJudge != E判定.Miss && futureJudge != E判定.Poor))
             {
                 // 過去の判定が不可で、未来の判定が可以上なら未来を返却。
                 nearestChip = futureChip;

--- a/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
+++ b/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
@@ -1885,7 +1885,7 @@ namespace TJAPlayer3
                     break;
                 }
                 var processingChip = chips[pastNote];
-                if(!processingChip.IsHitted && processingChip.nコース == n現在のコース[player]) // まだ判定されてない音符
+                if(!processingChip.IsHitted && processingChip.b可視) // まだ判定されてない音符
                 {
                     if (((0x11 <= processingChip.nチャンネル番号) && (processingChip.nチャンネル番号 <= 0x18))
                         || processingChip.nチャンネル番号 == 0x1A
@@ -1909,7 +1909,7 @@ namespace TJAPlayer3
                         }
                     }
                 }
-                if (processingChip.IsHitted && processingChip.nコース == n現在のコース[player]) // 連打
+                if (processingChip.IsHitted && processingChip.b可視) // 連打
                 {
                     if ((0x15 <= processingChip.nチャンネル番号) && (processingChip.nチャンネル番号 <= 0x17))
                     {
@@ -1932,7 +1932,7 @@ namespace TJAPlayer3
                     break;
                 }
                 var processingChip = chips[futureNote];
-                if (!processingChip.IsHitted && processingChip.nコース == n現在のコース[player]) // まだ判定されてない音符
+                if (!processingChip.IsHitted && processingChip.b可視) // まだ判定されてない音符
                 {
                     if (((0x11 <= processingChip.nチャンネル番号) && (processingChip.nチャンネル番号 <= 0x18))
                         || processingChip.nチャンネル番号 == 0x1A
@@ -2040,7 +2040,7 @@ namespace TJAPlayer3
                     break;
                 }
                 var processingChip = chips[pastNote];
-                if (!processingChip.IsHitted && processingChip.nコース == n現在のコース[player]) // まだ判定されてない音符
+                if (!processingChip.IsHitted && processingChip.b可視) // まだ判定されてない音符
                 {
                     if (don ? GetDon(processingChip) : GetKatsu(processingChip)) // 音符のチャンネルである
                     {
@@ -2061,7 +2061,7 @@ namespace TJAPlayer3
                         }
                     }
                 }
-                if (processingChip.IsHitted && processingChip.nコース == n現在のコース[player]) // 連打
+                if (processingChip.IsHitted && processingChip.b可視) // 連打
                 {
                     if ((0x15 <= processingChip.nチャンネル番号) && (processingChip.nチャンネル番号 <= 0x17))
                     {
@@ -2084,7 +2084,7 @@ namespace TJAPlayer3
                     break;
                 }
                 var processingChip = chips[futureNote];
-                if (!processingChip.IsHitted && processingChip.nコース == n現在のコース[player]) // まだ判定されてない音符
+                if (!processingChip.IsHitted && processingChip.b可視) // まだ判定されてない音符
                 {
                     if (don ? GetDon(processingChip) : GetKatsu(processingChip)) // 音符のチャンネルである
                     {


### PR DESCRIPTION
This PR fixes the issue that some notes are impossible to hit before `#BRANCHSTART`.

- Minimal chart files for checking the issue: [test_tja_files.zip](https://github.com/twopointzero/TJAPlayer3/files/5517152/test_tja_files.zip)
- For checking the issue with practical charts, you might want to try charts with many `#BRANCHSTART`s, e.g., _卓球de脱臼_ ([Link to the chart preview](https://www.wikihouse.com/taiko/index.php?%C6%F1%B0%D7%C5%D9%C9%BD%2F%A4%AA%A4%CB%2F%C2%EE%B5%E5de%C3%A6%B1%B1#score)).

For more details on the issue, please refer to the commit message.