### PR TITLE
Improve file stream handling

### DIFF
--- a/FDK19/コード/03.サウンド/CSound.cs
+++ b/FDK19/コード/03.サウンド/CSound.cs
@@ -1795,37 +1795,38 @@ Debug.WriteLine("更に再生に失敗: " + Path.GetFileName(this.strファイ�
 					// wave headerを書き込む
 
 					int wfx拡張領域_Length = 0;
-					var ms = new MemoryStream();
-					var bw = new BinaryWriter( ms );
-					bw.Write( new byte[] { 0x52, 0x49, 0x46, 0x46 } );		// 'RIFF'
-					bw.Write( (UInt32) totalPCMSize + 44 - 8 );				// ファイルサイズ - 8 [byte]；今は不明なので後で上書きする。
-					bw.Write( new byte[] { 0x57, 0x41, 0x56, 0x45 } );		// 'WAVE'
-					bw.Write( new byte[] { 0x66, 0x6D, 0x74, 0x20 } );		// 'fmt '
-					bw.Write( (UInt32) ( 16 + ( ( wfx拡張領域_Length > 0 ) ? ( 2/*sizeof(WAVEFORMATEX.cbSize)*/ + wfx拡張領域_Length ) : 0 ) ) );	// fmtチャンクのサイズ[byte]
-					bw.Write( (UInt16) wfx.wFormatTag );					// フォーマットID（リニアPCMなら1）
-					bw.Write( (UInt16) wfx.nChannels );						// チャンネル数
-					bw.Write( (UInt32) wfx.nSamplesPerSec );				// サンプリングレート
-					bw.Write( (UInt32) wfx.nAvgBytesPerSec );				// データ速度
-					bw.Write( (UInt16) wfx.nBlockAlign );					// ブロックサイズ
-					bw.Write( (UInt16) wfx.wBitsPerSample );				// サンプルあたりのビット数
-					//if ( wfx拡張領域_Length > 0 )
-					//{
-					//    bw.Write( (UInt16) wfx拡張領域.Length );			// 拡張領域のサイズ[byte]
-					//    bw.Write( wfx拡張領域 );							// 拡張データ
-					//}
-					bw.Write( new byte[] { 0x64, 0x61, 0x74, 0x61 } );		// 'data'
-					//int nDATAチャンクサイズ位置 = (int) ms.Position;
-					bw.Write( (UInt32) totalPCMSize );						// dataチャンクのサイズ[byte]
+                    using (var ms = new MemoryStream())
+                    using (var bw = new BinaryWriter(ms))
+                    {
+                        bw.Write(new byte[] {0x52, 0x49, 0x46, 0x46}); // 'RIFF'
+                        bw.Write((UInt32) totalPCMSize + 44 - 8); // ファイルサイズ - 8 [byte]；今は不明なので後で上書きする。
+                        bw.Write(new byte[] {0x57, 0x41, 0x56, 0x45}); // 'WAVE'
+                        bw.Write(new byte[] {0x66, 0x6D, 0x74, 0x20}); // 'fmt '
+                        bw.Write((UInt32) (16 + ((wfx拡張領域_Length > 0)
+                            ? (2 /*sizeof(WAVEFORMATEX.cbSize)*/ + wfx拡張領域_Length)
+                            : 0))); // fmtチャンクのサイズ[byte]
+                        bw.Write((UInt16) wfx.wFormatTag); // フォーマットID（リニアPCMなら1）
+                        bw.Write((UInt16) wfx.nChannels); // チャンネル数
+                        bw.Write((UInt32) wfx.nSamplesPerSec); // サンプリングレート
+                        bw.Write((UInt32) wfx.nAvgBytesPerSec); // データ速度
+                        bw.Write((UInt16) wfx.nBlockAlign); // ブロックサイズ
+                        bw.Write((UInt16) wfx.wBitsPerSample); // サンプルあたりのビット数
+                        //if ( wfx拡張領域_Length > 0 )
+                        //{
+                        //    bw.Write( (UInt16) wfx拡張領域.Length );			// 拡張領域のサイズ[byte]
+                        //    bw.Write( wfx拡張領域 );							// 拡張データ
+                        //}
+                        bw.Write(new byte[] {0x64, 0x61, 0x74, 0x61}); // 'data'
+                        //int nDATAチャンクサイズ位置 = (int) ms.Position;
+                        bw.Write((UInt32) totalPCMSize); // dataチャンクのサイズ[byte]
 
-					byte[] bs = ms.ToArray();
+                        byte[] bs = ms.ToArray();
 
-					bw.Close();
-					ms.Close();
-
-					for ( int i = 0; i < bs.Length; i++ )
-					{
-						buffer[ i ] = bs[ i ];
-					}
+                        for ( int i = 0; i < bs.Length; i++ )
+                        {
+                            buffer[ i ] = bs[ i ];
+                        }
+                    }
 				}
 				int s = ( bIntegrateWaveHeader ) ? 44 : 0;
 				for ( int i = 0; i < totalPCMSize; i++ )

--- a/FDK19/コード/03.サウンド/CSound.cs
+++ b/FDK19/コード/03.サウンド/CSound.cs
@@ -776,15 +776,14 @@ namespace FDK
 				{
 					#region [ ファイルを読み込んで byArrWAVファイルイメージへ格納。]
 					//-----------------
-					var fs = File.Open( strファイル名, FileMode.Open, FileAccess.Read );
-					var br = new BinaryReader( fs );
+                    using (var fs = File.Open( strファイル名, FileMode.Open, FileAccess.Read ))
+                    using (var br = new BinaryReader(fs))
+                    {
+                        byArrWAVファイルイメージ = new byte[fs.Length];
+                        br.Read(byArrWAVファイルイメージ, 0, (int) fs.Length);
+                    }
 
-					byArrWAVファイルイメージ = new byte[ fs.Length ];
-					br.Read( byArrWAVファイルイメージ, 0, (int) fs.Length );
-
-					br.Close();
-					fs.Close();
-					//-----------------
+                    //-----------------
 					#endregion
 				}
 				else

--- a/FDK19/コード/03.サウンド/CSound.cs
+++ b/FDK19/コード/03.サウンド/CSound.cs
@@ -843,10 +843,8 @@ namespace FDK
 	
 			#region [ byArrWAVファイルイメージ[] から上記３つのデータを取得。]
 			//-----------------
-			var ms = new MemoryStream( byArrWAVファイルイメージ );
-			var br = new BinaryReader( ms );
-
-			try
+			using (var ms = new MemoryStream( byArrWAVファイルイメージ ))
+			using (var br = new BinaryReader( ms ))
 			{
 				// 'RIFF'＋RIFFデータサイズ
 
@@ -923,11 +921,7 @@ namespace FDK
 				if( nPCMサイズbyte < 0 )
 					throw new InvalidDataException( "data チャンクが存在しません。不正なサウンドデータです。" );
 			}
-			finally
-			{
-				ms.Close();
-				br.Close();
-			}
+
 			//-----------------
 			#endregion
 

--- a/FDK19/コード/03.サウンド/CSoundDeviceDirectSound.cs
+++ b/FDK19/コード/03.サウンド/CSoundDeviceDirectSound.cs
@@ -146,28 +146,28 @@ namespace FDK
 				// 単位繰り上げ間隔[秒]の長さを持つ無音のサウンドを作成。
 
 				uint nデータサイズbyte = n単位繰り上げ間隔sec * 44100 * 2 * 2;
-				var ms = new MemoryStream();
-				var bw = new BinaryWriter( ms );
-				bw.Write( (uint) 0x46464952 );						// 'RIFF'
-				bw.Write( (uint) ( 44 + nデータサイズbyte - 8 ) );	// ファイルサイズ - 8
-				bw.Write( (uint) 0x45564157 );						// 'WAVE'
-				bw.Write( (uint) 0x20746d66 );						// 'fmt '
-				bw.Write( (uint) 16 );								// バイト数
-				bw.Write( (ushort) 1 );								// フォーマットID(リニアPCM)
-				bw.Write( (ushort) 2 );								// チャンネル数
-				bw.Write( (uint) 44100 );							// サンプリング周波数
-				bw.Write( (uint) ( 44100 * 2 * 2 ) );				// bytes/sec
-				bw.Write( (ushort) ( 2 * 2 ) );						// blockサイズ
-				bw.Write( (ushort) 16 );							// bit/sample
-				bw.Write( (uint) 0x61746164 );						// 'data'
-				bw.Write( (uint) nデータサイズbyte );				// データ長
-				for ( int i = 0; i < nデータサイズbyte / sizeof( long ); i++ )	// PCMデータ
-					bw.Write( (long) 0 );
-				var byArrWaveFleImage = ms.ToArray();
-				bw.Close();
-				ms = null;
-				bw = null;
-				this.sd経過時間計測用サウンドバッファ = this.tサウンドを作成する( byArrWaveFleImage, ESoundGroup.Unknown );
+				using (var ms = new MemoryStream())
+                using (var bw = new BinaryWriter(ms))
+                {
+                    bw.Write((uint) 0x46464952); // 'RIFF'
+                    bw.Write((uint) (44 + nデータサイズbyte - 8)); // ファイルサイズ - 8
+                    bw.Write((uint) 0x45564157); // 'WAVE'
+                    bw.Write((uint) 0x20746d66); // 'fmt '
+                    bw.Write((uint) 16); // バイト数
+                    bw.Write((ushort) 1); // フォーマットID(リニアPCM)
+                    bw.Write((ushort) 2); // チャンネル数
+                    bw.Write((uint) 44100); // サンプリング周波数
+                    bw.Write((uint) (44100 * 2 * 2)); // bytes/sec
+                    bw.Write((ushort) (2 * 2)); // blockサイズ
+                    bw.Write((ushort) 16); // bit/sample
+                    bw.Write((uint) 0x61746164); // 'data'
+                    bw.Write((uint) nデータサイズbyte); // データ長
+                    for (int i = 0; i < nデータサイズbyte / sizeof(long); i++) // PCMデータ
+                        bw.Write((long) 0);
+                    var byArrWaveFleImage = ms.ToArray();
+
+                    this.sd経過時間計測用サウンドバッファ = this.tサウンドを作成する( byArrWaveFleImage, ESoundGroup.Unknown );
+                }
 
 				CSound.listインスタンス.Remove( this.sd経過時間計測用サウンドバッファ );	// 特殊用途なのでインスタンスリストからは除外する。
 

--- a/FDK19/コード/03.サウンド/LoudnessMetadataScanner.cs
+++ b/FDK19/コード/03.サウンド/LoudnessMetadataScanner.cs
@@ -293,8 +293,8 @@ namespace FDK
                 WorkingDirectory = workingDirectory ?? ""
             };
 
-            var stdoutWriter = new StringWriter();
-            var stderrWriter = new StringWriter();
+            using (var stdoutWriter = new StringWriter())
+            using (var stderrWriter = new StringWriter())
             using (var process = Process.Start(processStartInfo))
             {
                 process.OutputDataReceived += (s, e) =>

--- a/TJAPlayer3/Songs/CBoxDef.cs
+++ b/TJAPlayer3/Songs/CBoxDef.cs
@@ -66,56 +66,57 @@ namespace TJAPlayer3
 
 		private CBoxDef(DirectoryInfo directoryInfo, string boxdefファイル名)
 		{
-			StreamReader reader = new StreamReader( boxdefファイル名, Encoding.GetEncoding( "Shift_JIS" ) );
-			string str = null;
-			while( ( str = reader.ReadLine() ) != null )
-			{
-				if( str.Length != 0 )
-				{
-					try
-					{
-						char[] ignoreCharsWoColon = new char[] { ' ', '\t' };
+            using (var reader = new StreamReader(boxdefファイル名, Encoding.GetEncoding("Shift_JIS")))
+            {
+                string str = null;
+                while ((str = reader.ReadLine()) != null)
+                {
+                    if (str.Length != 0)
+                    {
+                        try
+                        {
+                            char[] ignoreCharsWoColon = new char[] {' ', '\t'};
 
-						str = str.TrimStart( ignoreCharsWoColon );
-						if( ( str[ 0 ] == '#' ) && ( str[ 0 ] != ';' ) )
-						{
-							if( str.IndexOf( ';' ) != -1 )
-							{
-								str = str.Substring( 0, str.IndexOf( ';' ) );
-							}
-                        
-							char[] ignoreChars = new char[] { ':', ' ', '\t' };
-		
-							if ( str.StartsWith( "#TITLE", StringComparison.OrdinalIgnoreCase ) )
+                            str = str.TrimStart(ignoreCharsWoColon);
+                            if ((str[0] == '#') && (str[0] != ';'))
                             {
-                                var title = str.Substring( 6 ).Trim( ignoreChars );
-                                if (!string.IsNullOrEmpty(title))
+                                if (str.IndexOf(';') != -1)
                                 {
-                                    this.Title = title;
+                                    str = str.Substring(0, str.IndexOf(';'));
+                                }
+
+                                char[] ignoreChars = new char[] {':', ' ', '\t'};
+
+                                if (str.StartsWith("#TITLE", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    var title = str.Substring(6).Trim(ignoreChars);
+                                    if (!string.IsNullOrEmpty(title))
+                                    {
+                                        this.Title = title;
+                                    }
+                                }
+                                else if (str.StartsWith("#GENRE", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    this.Genre = str.Substring(6).Trim(ignoreChars);
+                                }
+                                else if (str.StartsWith("#FORECOLOR", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    this.ForeColor = ColorTranslator.FromHtml(str.Substring(10).Trim(ignoreChars));
+                                }
+                                else if (str.StartsWith("#BACKCOLOR", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    this.BackColor = ColorTranslator.FromHtml(str.Substring(10).Trim(ignoreChars));
                                 }
                             }
-							else if( str.StartsWith( "#GENRE", StringComparison.OrdinalIgnoreCase ) )
-							{
-								this.Genre = str.Substring( 6 ).Trim( ignoreChars );
-							}
-                            else if (str.StartsWith("#FORECOLOR", StringComparison.OrdinalIgnoreCase))
-                            {
-                                this.ForeColor = ColorTranslator.FromHtml(str.Substring(10).Trim(ignoreChars));
-                            }
-                            else if (str.StartsWith("#BACKCOLOR", StringComparison.OrdinalIgnoreCase))
-                            {
-                                this.BackColor = ColorTranslator.FromHtml(str.Substring(10).Trim(ignoreChars));
-                            }
                         }
-					}
-					catch (Exception e)
-					{
-					    Trace.TraceError( e.ToString() );
-					    Trace.TraceError( "例外が発生しましたが処理を継続します。 (178a9a36-a59e-4264-8e4c-b3c3459db43c)" );
-					}
-				}
-			}
-			reader.Close();
+                        catch (Exception e)
+                        {
+                            Trace.TraceError(e.ToString());
+                            Trace.TraceError("例外が発生しましたが処理を継続します。 (178a9a36-a59e-4264-8e4c-b3c3459db43c)");
+                        }
+                    }
+                }
+            }
 
             if (Genre == null || Title == null || ForeColor == null || BackColor == null)
             {

--- a/TJAPlayer3/Songs/CScoreIni.cs
+++ b/TJAPlayer3/Songs/CScoreIni.cs
@@ -1132,100 +1132,105 @@ namespace TJAPlayer3
 		}
 		internal void t書き出し( string iniファイル名 )
 		{
-			StreamWriter writer = new StreamWriter( iniファイル名, false, Encoding.GetEncoding( "Shift_JIS" ) );
-			writer.WriteLine( "[File]" );
-			writer.WriteLine( "Title={0}", this.stファイル.Title );
-			writer.WriteLine( "Name={0}", this.stファイル.Name );
-			writer.WriteLine( "PlayCountDrums={0}", this.stファイル.PlayCountDrums );
-			writer.WriteLine( "PlayCountGuitars={0}", this.stファイル.PlayCountGuitar );
-            writer.WriteLine( "PlayCountBass={0}", this.stファイル.PlayCountBass );
-            writer.WriteLine( "ClearCountDrums={0}", this.stファイル.ClearCountDrums );       // #23596 10.11.16 add ikanick
-            writer.WriteLine( "ClearCountGuitars={0}", this.stファイル.ClearCountGuitar );    //
-            writer.WriteLine( "ClearCountBass={0}", this.stファイル.ClearCountBass );         //
-			writer.WriteLine( "BestRankDrums={0}", this.stファイル.BestRank.Drums );		// #24459 2011.2.24 yyagi
-			writer.WriteLine( "BestRankGuitar={0}", this.stファイル.BestRank.Guitar );		//
-			writer.WriteLine( "BestRankBass={0}", this.stファイル.BestRank.Bass );			//
-			writer.WriteLine( "HistoryCount={0}", this.stファイル.HistoryCount );
-			writer.WriteLine( "History0={0}", this.stファイル.History[ 0 ] );
-			writer.WriteLine( "History1={0}", this.stファイル.History[ 1 ] );
-			writer.WriteLine( "History2={0}", this.stファイル.History[ 2 ] );
-			writer.WriteLine( "History3={0}", this.stファイル.History[ 3 ] );
-			writer.WriteLine( "History4={0}", this.stファイル.History[ 4 ] );
-			writer.WriteLine( "BGMAdjust={0}", this.stファイル.BGMAdjust );
-			writer.WriteLine();
-			for( int i = 0; i < 9; i++ )
-			{
-                string[] strArray = { "HiScore.Drums", "HiSkill.Drums", "HiScore.Guitar", "HiSkill.Guitar", "HiScore.Bass", "HiSkill.Bass", "LastPlay.Drums", "LastPlay.Guitar", "LastPlay.Bass" };
-				writer.WriteLine( "[{0}]", strArray[ i ] );
-				writer.WriteLine( "Score={0}", this.stセクション[ i ].nスコア );
-				writer.WriteLine( "PlaySkill={0}", this.stセクション[ i ].db演奏型スキル値 );
-				writer.WriteLine( "Skill={0}", this.stセクション[ i ].dbゲーム型スキル値 );
-				writer.WriteLine( "Perfect={0}", this.stセクション[ i ].nPerfect数 );
-				writer.WriteLine( "Great={0}", this.stセクション[ i ].nGreat数 );
-				writer.WriteLine( "Good={0}", this.stセクション[ i ].nGood数 );
-				writer.WriteLine( "Poor={0}", this.stセクション[ i ].nPoor数 );
-				writer.WriteLine( "Miss={0}", this.stセクション[ i ].nMiss数 );
-				writer.WriteLine( "MaxCombo={0}", this.stセクション[ i ].n最大コンボ数 );
-				writer.WriteLine( "TotalChips={0}", this.stセクション[ i ].n全チップ数 );
-				writer.Write( "AutoPlay=" );
-				for ( int j = 0; j < (int) Eレーン.MAX; j++ )
-				{
-					writer.Write( this.stセクション[ i ].bAutoPlay[ j ] ? 1 : 0 );
-				}
-				writer.WriteLine();
-				writer.WriteLine( "Risky={0}", this.stセクション[ i ].nRisky );
-				writer.WriteLine( "SuddenDrums={0}", this.stセクション[ i ].bSudden.Drums ? 1 : 0 );
-				writer.WriteLine( "SuddenGuitar={0}", this.stセクション[ i ].bSudden.Guitar ? 1 : 0 );
-				writer.WriteLine( "SuddenBass={0}", this.stセクション[ i ].bSudden.Bass ? 1 : 0 );
-				writer.WriteLine( "HiddenDrums={0}", this.stセクション[ i ].bHidden.Drums ? 1 : 0 );
-				writer.WriteLine( "HiddenGuitar={0}", this.stセクション[ i ].bHidden.Guitar ? 1 : 0 );
-				writer.WriteLine( "HiddenBass={0}", this.stセクション[ i ].bHidden.Bass ? 1 : 0 );
-				writer.WriteLine( "InvisibleDrums={0}", (int) this.stセクション[ i ].eInvisible.Drums );
-				writer.WriteLine( "InvisibleGuitar={0}", (int) this.stセクション[ i ].eInvisible.Guitar );
-				writer.WriteLine( "InvisibleBass={0}", (int) this.stセクション[ i ].eInvisible.Bass );
-				writer.WriteLine( "ReverseDrums={0}", this.stセクション[ i ].bReverse.Drums ? 1 : 0 );
-				writer.WriteLine( "ReverseGuitar={0}", this.stセクション[ i ].bReverse.Guitar ? 1 : 0 );
-				writer.WriteLine( "ReverseBass={0}", this.stセクション[ i ].bReverse.Bass ? 1 : 0 );
-				writer.WriteLine( "TightDrums={0}", this.stセクション[ i ].bTight ? 1 : 0 );
-				writer.WriteLine( "RandomGuitar={0}", (int) this.stセクション[ i ].eRandom.Guitar );
-				writer.WriteLine( "RandomBass={0}", (int) this.stセクション[ i ].eRandom.Bass );
-				writer.WriteLine( "LightGuitar={0}", this.stセクション[ i ].bLight.Guitar ? 1 : 0 );
-				writer.WriteLine( "LightBass={0}", this.stセクション[ i ].bLight.Bass ? 1 : 0 );
-				writer.WriteLine( "LeftGuitar={0}", this.stセクション[ i ].bLeft.Guitar ? 1 : 0 );
-				writer.WriteLine( "LeftBass={0}", this.stセクション[ i ].bLeft.Bass ? 1 : 0 );
-				writer.WriteLine( "Dark={0}", (int) this.stセクション[ i ].eDark );
-				writer.WriteLine( "ScrollSpeedDrums={0}", this.stセクション[ i ].f譜面スクロール速度.Drums );
-				writer.WriteLine( "ScrollSpeedGuitar={0}", this.stセクション[ i ].f譜面スクロール速度.Guitar );
-				writer.WriteLine( "ScrollSpeedBass={0}", this.stセクション[ i ].f譜面スクロール速度.Bass );
-				writer.WriteLine( "PlaySpeed={0}/{1}", this.stセクション[ i ].n演奏速度分子, this.stセクション[ i ].n演奏速度分母 );
-				writer.WriteLine( "Guitar={0}", this.stセクション[ i ].bGuitar有効 ? 1 : 0 );
-				writer.WriteLine( "Drums={0}", this.stセクション[ i ].bDrums有効 ? 1 : 0 );
-				writer.WriteLine( "StageFailed={0}", this.stセクション[ i ].bSTAGEFAILED有効 ? 1 : 0 );
-				writer.WriteLine( "DamageLevel={0}", (int) this.stセクション[ i ].eダメージレベル );
-				writer.WriteLine( "UseKeyboard={0}", this.stセクション[ i ].b演奏にキーボードを使用した ? 1 : 0 );
-				writer.WriteLine( "UseMIDIIN={0}", this.stセクション[ i ].b演奏にMIDI入力を使用した ? 1 : 0 );
-				writer.WriteLine( "UseJoypad={0}", this.stセクション[ i ].b演奏にジョイパッドを使用した ? 1 : 0 );
-				writer.WriteLine( "UseMouse={0}", this.stセクション[ i ].b演奏にマウスを使用した ? 1 : 0 );
-				writer.WriteLine( "PerfectRange={0}", this.stセクション[ i ].nPerfectになる範囲ms );
-				writer.WriteLine( "GreatRange={0}", this.stセクション[ i ].nGreatになる範囲ms );
-				writer.WriteLine( "GoodRange={0}", this.stセクション[ i ].nGoodになる範囲ms );
-				writer.WriteLine( "PoorRange={0}", this.stセクション[ i ].nPoorになる範囲ms );
-				writer.WriteLine( "DTXManiaVersion={0}", this.stセクション[ i ].strDTXManiaのバージョン );
-				writer.WriteLine( "DateTime={0}", this.stセクション[ i ].最終更新日時 );
-                writer.WriteLine( "HiScore1={0}", this.stセクション[ i ].nハイスコア[ 0 ] );
-                writer.WriteLine( "HiScore2={0}", this.stセクション[ i ].nハイスコア[ 1 ] );
-                writer.WriteLine( "HiScore3={0}", this.stセクション[ i ].nハイスコア[ 2 ] );
-                writer.WriteLine( "HiScore4={0}", this.stセクション[ i ].nハイスコア[ 3 ] );
-                writer.WriteLine( "HiScore5={0}", this.stセクション[ i ].nハイスコア[ 4 ] );
-                writer.WriteLine( "Roll1={0}", this.stセクション[ i ].n連打[ 0 ] );
-                writer.WriteLine( "Roll2={0}", this.stセクション[ i ].n連打[ 1 ] );
-                writer.WriteLine( "Roll3={0}", this.stセクション[ i ].n連打[ 2 ] );
-                writer.WriteLine( "Roll4={0}", this.stセクション[ i ].n連打[ 3 ] );
-                writer.WriteLine( "Roll5={0}", this.stセクション[ i ].n連打[ 4 ] );
-			}
+            using (var writer = new StreamWriter(iniファイル名, false, Encoding.GetEncoding("Shift_JIS")))
+            {
+                writer.WriteLine("[File]");
+                writer.WriteLine("Title={0}", this.stファイル.Title);
+                writer.WriteLine("Name={0}", this.stファイル.Name);
+                writer.WriteLine("PlayCountDrums={0}", this.stファイル.PlayCountDrums);
+                writer.WriteLine("PlayCountGuitars={0}", this.stファイル.PlayCountGuitar);
+                writer.WriteLine("PlayCountBass={0}", this.stファイル.PlayCountBass);
+                writer.WriteLine("ClearCountDrums={0}", this.stファイル.ClearCountDrums); // #23596 10.11.16 add ikanick
+                writer.WriteLine("ClearCountGuitars={0}", this.stファイル.ClearCountGuitar); //
+                writer.WriteLine("ClearCountBass={0}", this.stファイル.ClearCountBass); //
+                writer.WriteLine("BestRankDrums={0}", this.stファイル.BestRank.Drums); // #24459 2011.2.24 yyagi
+                writer.WriteLine("BestRankGuitar={0}", this.stファイル.BestRank.Guitar); //
+                writer.WriteLine("BestRankBass={0}", this.stファイル.BestRank.Bass); //
+                writer.WriteLine("HistoryCount={0}", this.stファイル.HistoryCount);
+                writer.WriteLine("History0={0}", this.stファイル.History[0]);
+                writer.WriteLine("History1={0}", this.stファイル.History[1]);
+                writer.WriteLine("History2={0}", this.stファイル.History[2]);
+                writer.WriteLine("History3={0}", this.stファイル.History[3]);
+                writer.WriteLine("History4={0}", this.stファイル.History[4]);
+                writer.WriteLine("BGMAdjust={0}", this.stファイル.BGMAdjust);
+                writer.WriteLine();
+                for (int i = 0; i < 9; i++)
+                {
+                    string[] strArray =
+                    {
+                        "HiScore.Drums", "HiSkill.Drums", "HiScore.Guitar", "HiSkill.Guitar", "HiScore.Bass", 
+                        "HiSkill.Bass", "LastPlay.Drums", "LastPlay.Guitar", "LastPlay.Bass"
+                    };
+                    writer.WriteLine("[{0}]", strArray[i]);
+                    writer.WriteLine("Score={0}", this.stセクション[i].nスコア);
+                    writer.WriteLine("PlaySkill={0}", this.stセクション[i].db演奏型スキル値);
+                    writer.WriteLine("Skill={0}", this.stセクション[i].dbゲーム型スキル値);
+                    writer.WriteLine("Perfect={0}", this.stセクション[i].nPerfect数);
+                    writer.WriteLine("Great={0}", this.stセクション[i].nGreat数);
+                    writer.WriteLine("Good={0}", this.stセクション[i].nGood数);
+                    writer.WriteLine("Poor={0}", this.stセクション[i].nPoor数);
+                    writer.WriteLine("Miss={0}", this.stセクション[i].nMiss数);
+                    writer.WriteLine("MaxCombo={0}", this.stセクション[i].n最大コンボ数);
+                    writer.WriteLine("TotalChips={0}", this.stセクション[i].n全チップ数);
+                    writer.Write("AutoPlay=");
+                    for (int j = 0; j < (int) Eレーン.MAX; j++)
+                    {
+                        writer.Write(this.stセクション[i].bAutoPlay[j] ? 1 : 0);
+                    }
 
-			writer.Close();
-		}
+                    writer.WriteLine();
+                    writer.WriteLine("Risky={0}", this.stセクション[i].nRisky);
+                    writer.WriteLine("SuddenDrums={0}", this.stセクション[i].bSudden.Drums ? 1 : 0);
+                    writer.WriteLine("SuddenGuitar={0}", this.stセクション[i].bSudden.Guitar ? 1 : 0);
+                    writer.WriteLine("SuddenBass={0}", this.stセクション[i].bSudden.Bass ? 1 : 0);
+                    writer.WriteLine("HiddenDrums={0}", this.stセクション[i].bHidden.Drums ? 1 : 0);
+                    writer.WriteLine("HiddenGuitar={0}", this.stセクション[i].bHidden.Guitar ? 1 : 0);
+                    writer.WriteLine("HiddenBass={0}", this.stセクション[i].bHidden.Bass ? 1 : 0);
+                    writer.WriteLine("InvisibleDrums={0}", (int) this.stセクション[i].eInvisible.Drums);
+                    writer.WriteLine("InvisibleGuitar={0}", (int) this.stセクション[i].eInvisible.Guitar);
+                    writer.WriteLine("InvisibleBass={0}", (int) this.stセクション[i].eInvisible.Bass);
+                    writer.WriteLine("ReverseDrums={0}", this.stセクション[i].bReverse.Drums ? 1 : 0);
+                    writer.WriteLine("ReverseGuitar={0}", this.stセクション[i].bReverse.Guitar ? 1 : 0);
+                    writer.WriteLine("ReverseBass={0}", this.stセクション[i].bReverse.Bass ? 1 : 0);
+                    writer.WriteLine("TightDrums={0}", this.stセクション[i].bTight ? 1 : 0);
+                    writer.WriteLine("RandomGuitar={0}", (int) this.stセクション[i].eRandom.Guitar);
+                    writer.WriteLine("RandomBass={0}", (int) this.stセクション[i].eRandom.Bass);
+                    writer.WriteLine("LightGuitar={0}", this.stセクション[i].bLight.Guitar ? 1 : 0);
+                    writer.WriteLine("LightBass={0}", this.stセクション[i].bLight.Bass ? 1 : 0);
+                    writer.WriteLine("LeftGuitar={0}", this.stセクション[i].bLeft.Guitar ? 1 : 0);
+                    writer.WriteLine("LeftBass={0}", this.stセクション[i].bLeft.Bass ? 1 : 0);
+                    writer.WriteLine("Dark={0}", (int) this.stセクション[i].eDark);
+                    writer.WriteLine("ScrollSpeedDrums={0}", this.stセクション[i].f譜面スクロール速度.Drums);
+                    writer.WriteLine("ScrollSpeedGuitar={0}", this.stセクション[i].f譜面スクロール速度.Guitar);
+                    writer.WriteLine("ScrollSpeedBass={0}", this.stセクション[i].f譜面スクロール速度.Bass);
+                    writer.WriteLine("PlaySpeed={0}/{1}", this.stセクション[i].n演奏速度分子, this.stセクション[i].n演奏速度分母);
+                    writer.WriteLine("Guitar={0}", this.stセクション[i].bGuitar有効 ? 1 : 0);
+                    writer.WriteLine("Drums={0}", this.stセクション[i].bDrums有効 ? 1 : 0);
+                    writer.WriteLine("StageFailed={0}", this.stセクション[i].bSTAGEFAILED有効 ? 1 : 0);
+                    writer.WriteLine("DamageLevel={0}", (int) this.stセクション[i].eダメージレベル);
+                    writer.WriteLine("UseKeyboard={0}", this.stセクション[i].b演奏にキーボードを使用した ? 1 : 0);
+                    writer.WriteLine("UseMIDIIN={0}", this.stセクション[i].b演奏にMIDI入力を使用した ? 1 : 0);
+                    writer.WriteLine("UseJoypad={0}", this.stセクション[i].b演奏にジョイパッドを使用した ? 1 : 0);
+                    writer.WriteLine("UseMouse={0}", this.stセクション[i].b演奏にマウスを使用した ? 1 : 0);
+                    writer.WriteLine("PerfectRange={0}", this.stセクション[i].nPerfectになる範囲ms);
+                    writer.WriteLine("GreatRange={0}", this.stセクション[i].nGreatになる範囲ms);
+                    writer.WriteLine("GoodRange={0}", this.stセクション[i].nGoodになる範囲ms);
+                    writer.WriteLine("PoorRange={0}", this.stセクション[i].nPoorになる範囲ms);
+                    writer.WriteLine("DTXManiaVersion={0}", this.stセクション[i].strDTXManiaのバージョン);
+                    writer.WriteLine("DateTime={0}", this.stセクション[i].最終更新日時);
+                    writer.WriteLine("HiScore1={0}", this.stセクション[i].nハイスコア[0]);
+                    writer.WriteLine("HiScore2={0}", this.stセクション[i].nハイスコア[1]);
+                    writer.WriteLine("HiScore3={0}", this.stセクション[i].nハイスコア[2]);
+                    writer.WriteLine("HiScore4={0}", this.stセクション[i].nハイスコア[3]);
+                    writer.WriteLine("HiScore5={0}", this.stセクション[i].nハイスコア[4]);
+                    writer.WriteLine("Roll1={0}", this.stセクション[i].n連打[0]);
+                    writer.WriteLine("Roll2={0}", this.stセクション[i].n連打[1]);
+                    writer.WriteLine("Roll3={0}", this.stセクション[i].n連打[2]);
+                    writer.WriteLine("Roll4={0}", this.stセクション[i].n連打[3]);
+                    writer.WriteLine("Roll5={0}", this.stセクション[i].n連打[4]);
+                }
+            }
+        }
 		internal void t全演奏記録セクションの整合性をチェックし不整合があればリセットする()
 		{
 			for( int i = 0; i < 9; i++ )

--- a/TJAPlayer3/Songs/CScoreIni.cs
+++ b/TJAPlayer3/Songs/CScoreIni.cs
@@ -523,603 +523,683 @@ namespace TJAPlayer3
 			if( File.Exists( iniファイル名 ) )
 			{
 				string str;
-				StreamReader reader = new StreamReader( iniファイル名, Encoding.GetEncoding( "Shift_JIS" ) );
-				while( ( str = reader.ReadLine() ) != null )
-				{
-					str = str.Replace( '\t', ' ' ).TrimStart( new char[] { '\t', ' ' } );
-					if( ( str.Length != 0 ) && ( str[ 0 ] != ';' ) )
-					{
-						try
-						{
-							string item;
-							string para;
-							C演奏記録 c演奏記録;
-							#region [ section ]
-							if ( str[ 0 ] == '[' )
-							{
-								StringBuilder builder = new StringBuilder( 0x20 );
-								int num = 1;
-								while( ( num < str.Length ) && ( str[ num ] != ']' ) )
-								{
-									builder.Append( str[ num++ ] );
-								}
-								string str2 = builder.ToString();
-								if( str2.Equals( "File" ) )
-								{
-									section = Eセクション種別.File;
-								}
-								else if( str2.Equals( "HiScore.Drums" ) )
-								{
-									section = Eセクション種別.HiScoreDrums;
-								}
-								else if( str2.Equals( "HiSkill.Drums" ) )
-								{
-									section = Eセクション種別.HiSkillDrums;
-								}
-								else if( str2.Equals( "HiScore.Guitar" ) )
-								{
-									section = Eセクション種別.HiScoreGuitar;
-								}
-								else if( str2.Equals( "HiSkill.Guitar" ) )
-								{
-									section = Eセクション種別.HiSkillGuitar;
-								}
-								else if( str2.Equals( "HiScore.Bass" ) )
-								{
-									section = Eセクション種別.HiScoreBass;
-                                }
-                                else if (str2.Equals("HiSkill.Bass"))
-                                {
-                                    section = Eセクション種別.HiSkillBass;
-                                }
-                                // #23595 2011.1.9 ikanick
-                                else if (str2.Equals("LastPlay.Drums"))
-                                {
-                                    section = Eセクション種別.LastPlayDrums;
-                                }
-                                else if (str2.Equals("LastPlay.Guitar"))
-                                {
-                                    section = Eセクション種別.LastPlayGuitar;
-                                }
-                                else if (str2.Equals("LastPlay.Bass"))
-                                {
-                                    section = Eセクション種別.LastPlayBass;
-                                }
-                                //----------------------------------------------------
-								else
-								{
-									section = Eセクション種別.Unknown;
-								}
-							}
-							#endregion
-							else
-							{
-								string[] strArray = str.Split( new char[] { '=' } );
-								if( strArray.Length == 2 )
-								{
-									item = strArray[ 0 ].Trim();
-									para = strArray[ 1 ].Trim();
-									switch( section )
-									{
-										case Eセクション種別.File:
-											{
-												if( !item.Equals( "Title" ) )
-												{
-													goto Label_01C7;
-												}
-												this.stファイル.Title = para;
-												continue;
-											}
-										case Eセクション種別.HiScoreDrums:
-										case Eセクション種別.HiSkillDrums:
-										case Eセクション種別.HiScoreGuitar:
-										case Eセクション種別.HiSkillGuitar:
-										case Eセクション種別.HiScoreBass:
-                                        case Eセクション種別.HiSkillBass:
-                                        case Eセクション種別.LastPlayDrums:// #23595 2011.1.9 ikanick
-                                        case Eセクション種別.LastPlayGuitar:
-                                        case Eセクション種別.LastPlayBass:
-											{
-												c演奏記録 = this.stセクション[ (int) section ];
-												if( !item.Equals( "Score" ) )
-												{
-													goto Label_03B9;
-												}
-												c演奏記録.nスコア = long.Parse( para );
-                                                
+                using (var reader = new StreamReader(iniファイル名, Encoding.GetEncoding("Shift_JIS")))
+                {
+                    while ((str = reader.ReadLine()) != null)
+                    {
+                        str = str.Replace('\t', ' ').TrimStart(new char[] {'\t', ' '});
+                        if ((str.Length != 0) && (str[0] != ';'))
+                        {
+                            try
+                            {
+                                string item;
+                                string para;
+                                C演奏記録 c演奏記録;
 
-												continue;
-											}
-									}
-								}
-							}
-							continue;
-							#region [ File section ]
-						Label_01C7:
-							if( item.Equals( "Name" ) )
-							{
-								this.stファイル.Name = para;
-							}
-							else if( item.Equals( "PlayCountDrums" ) )
-							{
-								this.stファイル.PlayCountDrums = C変換.n値を文字列から取得して範囲内に丸めて返す( para, 0, 99999999, 0 );
-							}
-							else if( item.Equals( "PlayCountGuitars" ) )// #23596 11.2.5 changed ikanick
-							{
-								this.stファイル.PlayCountGuitar = C変換.n値を文字列から取得して範囲内に丸めて返す( para, 0, 99999999, 0 );
-							}
-							else if( item.Equals( "PlayCountBass" ) )
-							{
-								this.stファイル.PlayCountBass = C変換.n値を文字列から取得して範囲内に丸めて返す( para, 0, 99999999, 0 );
-                            }
-                            // #23596 10.11.16 add ikanick------------------------------------/
-                            else if (item.Equals("ClearCountDrums"))
-                            {
-                                this.stファイル.ClearCountDrums = C変換.n値を文字列から取得して範囲内に丸めて返す(para, 0, 99999999, 0);
-                            }
-                            else if (item.Equals("ClearCountGuitars"))// #23596 11.2.5 changed ikanick
-                            {
-                                this.stファイル.ClearCountGuitar = C変換.n値を文字列から取得して範囲内に丸めて返す(para, 0, 99999999, 0);
-                            }
-                            else if (item.Equals("ClearCountBass"))
-                            {
-                                this.stファイル.ClearCountBass = C変換.n値を文字列から取得して範囲内に丸めて返す(para, 0, 99999999, 0);
-                            }
-                            // #24459 2011.2.24 yyagi-----------------------------------------/
-							else if ( item.Equals( "BestRankDrums" ) )
-							{
-								this.stファイル.BestRank.Drums = C変換.n値を文字列から取得して範囲内に丸めて返す( para, (int) ERANK.SS, (int) ERANK.E, (int) ERANK.UNKNOWN );
-							}
-							else if ( item.Equals( "BestRankGuitar" ) )
-							{
-								this.stファイル.BestRank.Guitar = C変換.n値を文字列から取得して範囲内に丸めて返す( para, (int) ERANK.SS, (int) ERANK.E, (int) ERANK.UNKNOWN );
-							}
-							else if ( item.Equals( "BestRankBass" ) )
-							{
-								this.stファイル.BestRank.Bass = C変換.n値を文字列から取得して範囲内に丸めて返す( para, (int) ERANK.SS, (int) ERANK.E, (int) ERANK.UNKNOWN );
-							}
-							//----------------------------------------------------------------/
-							else if ( item.Equals( "History0" ) )
-							{
-								this.stファイル.History[ 0 ] = para;
-							}
-							else if( item.Equals( "History1" ) )
-							{
-								this.stファイル.History[ 1 ] = para;
-							}
-							else if( item.Equals( "History2" ) )
-							{
-								this.stファイル.History[ 2 ] = para;
-							}
-							else if( item.Equals( "History3" ) )
-							{
-								this.stファイル.History[ 3 ] = para;
-							}
-							else if( item.Equals( "History4" ) )
-							{
-								this.stファイル.History[ 4 ] = para;
-							}
-							else if( item.Equals( "HistoryCount" ) )
-							{
-								this.stファイル.HistoryCount = C変換.n値を文字列から取得して範囲内に丸めて返す( para, 0, 99999999, 0 );
-							}
-							else if( item.Equals( "BGMAdjust" ) )
-							{
-								this.stファイル.BGMAdjust = C変換.n値を文字列から取得して返す( para, 0 );
-							}
-							continue;
-							#endregion
-							#region [ Score section ]
-						Label_03B9:
-                                                if ( item.Equals( "HiScore1" ) )
-											    {
-												    c演奏記録.nハイスコア[ 0 ] = int.Parse( para );
-											    }
-											    else if ( item.Equals( "HiScore2" ) )
-											    {
-										    		c演奏記録.nハイスコア[ 1 ] = int.Parse( para );
-									    		}
-								    			else if ( item.Equals( "HiScore3" ) )
-							    				{
-						    						c演奏記録.nハイスコア[ 2 ] = int.Parse( para );
-					    						}
-				    							else if ( item.Equals( "HiScore4" ) )
-											    {
-			    									c演奏記録.nハイスコア[ 3 ] = int.Parse( para );
-		    									}
-	    										else if ( item.Equals( "HiScore5" ) )
-    											{
-												    c演奏記録.nハイスコア[ 4 ] = int.Parse( para );
-											    }
-							if( item.Equals( "PlaySkill" ) )
-							{
-                                try
+                                #region [ section ]
+
+                                if (str[0] == '[')
                                 {
-								    c演奏記録.db演奏型スキル値 = (double) decimal.Parse( para );
+                                    StringBuilder builder = new StringBuilder(0x20);
+                                    int num = 1;
+                                    while ((num < str.Length) && (str[num] != ']'))
+                                    {
+                                        builder.Append(str[num++]);
+                                    }
+
+                                    string str2 = builder.ToString();
+                                    if (str2.Equals("File"))
+                                    {
+                                        section = Eセクション種別.File;
+                                    }
+                                    else if (str2.Equals("HiScore.Drums"))
+                                    {
+                                        section = Eセクション種別.HiScoreDrums;
+                                    }
+                                    else if (str2.Equals("HiSkill.Drums"))
+                                    {
+                                        section = Eセクション種別.HiSkillDrums;
+                                    }
+                                    else if (str2.Equals("HiScore.Guitar"))
+                                    {
+                                        section = Eセクション種別.HiScoreGuitar;
+                                    }
+                                    else if (str2.Equals("HiSkill.Guitar"))
+                                    {
+                                        section = Eセクション種別.HiSkillGuitar;
+                                    }
+                                    else if (str2.Equals("HiScore.Bass"))
+                                    {
+                                        section = Eセクション種別.HiScoreBass;
+                                    }
+                                    else if (str2.Equals("HiSkill.Bass"))
+                                    {
+                                        section = Eセクション種別.HiSkillBass;
+                                    }
+                                    // #23595 2011.1.9 ikanick
+                                    else if (str2.Equals("LastPlay.Drums"))
+                                    {
+                                        section = Eセクション種別.LastPlayDrums;
+                                    }
+                                    else if (str2.Equals("LastPlay.Guitar"))
+                                    {
+                                        section = Eセクション種別.LastPlayGuitar;
+                                    }
+                                    else if (str2.Equals("LastPlay.Bass"))
+                                    {
+                                        section = Eセクション種別.LastPlayBass;
+                                    }
+                                    //----------------------------------------------------
+                                    else
+                                    {
+                                        section = Eセクション種別.Unknown;
+                                    }
                                 }
-                                catch
+
+                                #endregion
+
+                                else
                                 {
-                                    c演奏記録.db演奏型スキル値 = 0.0;
-                                }
-							}
-							else if( item.Equals( "Skill" ) )
-							{
-                                try
-                                {
-								    c演奏記録.dbゲーム型スキル値 = (double) decimal.Parse( para );
-                                }
-                                catch
-                                {
-                                    c演奏記録.dbゲーム型スキル値 = 0.0;
-                                }
-							}
-							else if( item.Equals( "Perfect" ) )
-							{
-								c演奏記録.nPerfect数 = int.Parse( para );
-							}
-							else if( item.Equals( "Great" ) )
-							{
-								c演奏記録.nGreat数 = int.Parse( para );
-							}
-							else if( item.Equals( "Good" ) )
-							{
-								c演奏記録.nGood数 = int.Parse( para );
-							}
-							else if( item.Equals( "Poor" ) )
-							{
-								c演奏記録.nPoor数 = int.Parse( para );
-							}
-							else if( item.Equals( "Miss" ) )
-							{
-								c演奏記録.nMiss数 = int.Parse( para );
-							}
-                            else if( item.Equals( "Roll" ) )
-                            {
-								c演奏記録.n連打数 = int.Parse( para );
-                            }
-							else if( item.Equals( "MaxCombo" ) )
-							{
-								c演奏記録.n最大コンボ数 = int.Parse( para );
-							}
-							else if( item.Equals( "TotalChips" ) )
-							{
-								c演奏記録.n全チップ数 = int.Parse( para );
-							}
-							else if( item.Equals( "AutoPlay" ) )
-							{
-								// LCなし               LCあり               CYとRDが別           Gt/Bs autolane/pick
-								if( para.Length == 9 || para.Length == 10 || para.Length == 11 || para.Length == 21 )
-								{
-									for( int i = 0; i < para.Length; i++ )
-									{
-										c演奏記録.bAutoPlay[ i ] = this.ONorOFF( para[ i ] );
-									}
-								}
-							}
-							else if ( item.Equals( "Risky" ) )
-							{
-								c演奏記録.nRisky = int.Parse( para );
-							}
-							else if ( item.Equals( "TightDrums" ) )
-							{
-								c演奏記録.bTight = C変換.bONorOFF( para[ 0 ] );
-							}
-							else if ( item.Equals( "SuddenDrums" ) )
-							{
-								c演奏記録.bSudden.Drums = C変換.bONorOFF( para[ 0 ] );
-							}
-							else if ( item.Equals( "SuddenGuitar" ) )
-							{
-								c演奏記録.bSudden.Guitar = C変換.bONorOFF( para[ 0 ] );
-							}
-							else if ( item.Equals( "SuddenBass" ) )
-							{
-								c演奏記録.bSudden.Bass = C変換.bONorOFF( para[ 0 ] );
-							}
-							else if ( item.Equals( "HiddenDrums" ) )
-							{
-								c演奏記録.bHidden.Drums = C変換.bONorOFF( para[ 0 ] );
-							}
-							else if ( item.Equals( "HiddenGuitar" ) )
-							{
-								c演奏記録.bHidden.Guitar = C変換.bONorOFF( para[ 0 ] );
-							}
-							else if ( item.Equals( "HiddenBass" ) )
-							{
-								c演奏記録.bHidden.Bass = C変換.bONorOFF( para[ 0 ] );
-							}
-							else if ( item.Equals( "InvisibleDrums" ) )
-							{
-								c演奏記録.eInvisible.Drums = (EInvisible) int.Parse( para );
-							}
-							else if ( item.Equals( "InvisibleGuitar" ) )
-							{
-								c演奏記録.eInvisible.Guitar = (EInvisible) int.Parse( para );
-							}
-							else if ( item.Equals( "InvisibleBass" ) )
-							{
-								c演奏記録.eInvisible.Bass = (EInvisible) int.Parse( para );
-							}
-							else if ( item.Equals( "ReverseDrums" ) )
-							{
-								c演奏記録.bReverse.Drums = C変換.bONorOFF( para[ 0 ] );
-							}
-							else if ( item.Equals( "ReverseGuitar" ) )
-							{
-								c演奏記録.bReverse.Guitar = C変換.bONorOFF( para[ 0 ] );
-							}
-							else if ( item.Equals( "ReverseBass" ) )
-							{
-								c演奏記録.bReverse.Bass = C変換.bONorOFF( para[ 0 ] );
-							}
-							#endregion
-							else
-							{
-								#region [ RandomGuitar ]
-								if ( item.Equals( "RandomGuitar" ) )
-								{
-									switch ( int.Parse( para ) )
-									{
-										case (int) Eランダムモード.OFF:
-											{
-												c演奏記録.eRandom.Guitar = Eランダムモード.OFF;
-												continue;
-											}
-										case (int) Eランダムモード.RANDOM:
-											{
-												c演奏記録.eRandom.Guitar = Eランダムモード.RANDOM;
-												continue;
-											}
-										case (int) Eランダムモード.SUPERRANDOM:
-											{
-												c演奏記録.eRandom.Guitar = Eランダムモード.SUPERRANDOM;
-												continue;
-											}
-										case (int) Eランダムモード.HYPERRANDOM:		// #25452 2011.6.20 yyagi
-											{
-												c演奏記録.eRandom.Guitar = Eランダムモード.SUPERRANDOM;
-												continue;
-											}
-									}
-									throw new Exception( "RandomGuitar の値が無効です。" );
-								}
-								#endregion
-								#region [ RandomBass ]
-								if ( item.Equals( "RandomBass" ) )
-								{
-									switch ( int.Parse( para ) )
-									{
-										case (int) Eランダムモード.OFF:
-											{
-												c演奏記録.eRandom.Bass = Eランダムモード.OFF;
-												continue;
-											}
-										case (int) Eランダムモード.RANDOM:
-											{
-												c演奏記録.eRandom.Bass = Eランダムモード.RANDOM;
-												continue;
-											}
-										case (int) Eランダムモード.SUPERRANDOM:
-											{
-												c演奏記録.eRandom.Bass = Eランダムモード.SUPERRANDOM;
-												continue;
-											}
-										case (int) Eランダムモード.HYPERRANDOM:		// #25452 2011.6.20 yyagi
-											{
-												c演奏記録.eRandom.Bass = Eランダムモード.SUPERRANDOM;
-												continue;
-											}
-									}
-									throw new Exception( "RandomBass の値が無効です。" );
-								}
-								#endregion
-								#region [ LightGuitar ]
-								if ( item.Equals( "LightGuitar" ) )
-								{
-									c演奏記録.bLight.Guitar = C変換.bONorOFF( para[ 0 ] );
-								}
-								#endregion
-								#region [ LightBass ]
-								else if ( item.Equals( "LightBass" ) )
-								{
-									c演奏記録.bLight.Bass = C変換.bONorOFF( para[ 0 ] );
-								}
-								#endregion
-								#region [ LeftGuitar ]
-								else if ( item.Equals( "LeftGuitar" ) )
-								{
-									c演奏記録.bLeft.Guitar = C変換.bONorOFF( para[ 0 ] );
-								}
-								#endregion
-								#region [ LeftBass ]
-								else if ( item.Equals( "LeftBass" ) )
-								{
-									c演奏記録.bLeft.Bass = C変換.bONorOFF( para[ 0 ] );
-								}
-								#endregion
-								else
-								{
-									#region [ Dark ]
-									if ( item.Equals( "Dark" ) )
-									{
-										switch ( int.Parse( para ) )
-										{
-											case 0:
-												{
-													c演奏記録.eDark = Eダークモード.OFF;
-													continue;
-												}
-											case 1:
-												{
-													c演奏記録.eDark = Eダークモード.HALF;
-													continue;
-												}
-											case 2:
-												{
-													c演奏記録.eDark = Eダークモード.FULL;
-													continue;
-												}
-										}
-										throw new Exception( "Dark の値が無効です。" );
-									}
-									#endregion
-									#region [ ScrollSpeedDrums ]
-									if ( item.Equals( "ScrollSpeedDrums" ) )
-									{
-										c演奏記録.f譜面スクロール速度.Drums = (float) decimal.Parse( para );
-									}
-									#endregion
-									#region [ ScrollSpeedGuitar ]
-									else if ( item.Equals( "ScrollSpeedGuitar" ) )
-									{
-										c演奏記録.f譜面スクロール速度.Guitar = (float) decimal.Parse( para );
-									}
-									#endregion
-									#region [ ScrollSpeedBass ]
-									else if ( item.Equals( "ScrollSpeedBass" ) )
-									{
-										c演奏記録.f譜面スクロール速度.Bass = (float) decimal.Parse( para );
-									}
-									#endregion
-									#region [ PlaySpeed ]
-									else if ( item.Equals( "PlaySpeed" ) )
-									{
-										string[] strArray2 = para.Split( new char[] { '/' } );
-										if ( strArray2.Length == 2 )
-										{
-											c演奏記録.n演奏速度分子 = int.Parse( strArray2[ 0 ] );
-											c演奏記録.n演奏速度分母 = int.Parse( strArray2[ 1 ] );
-										}
-									}
-									#endregion
-									else
-									{
-										#region [ Guitar ]
-										if ( item.Equals( "Guitar" ) )
-										{
-											c演奏記録.bGuitar有効 = C変換.bONorOFF( para[ 0 ] );
-										}
-										#endregion
-										#region [ Drums ]
-										else if ( item.Equals( "Drums" ) )
-										{
-											c演奏記録.bDrums有効 = C変換.bONorOFF( para[ 0 ] );
-										}
-										#endregion
-										#region [ StageFailed ]
-										else if ( item.Equals( "StageFailed" ) )
-										{
-											c演奏記録.bSTAGEFAILED有効 = C変換.bONorOFF( para[ 0 ] );
-										}
-										#endregion
-										else
-										{
-											#region [ DamageLevel ]
-											if ( item.Equals( "DamageLevel" ) )
-											{
-												switch ( int.Parse( para ) )
-												{
-													case 0:
-														{
-															c演奏記録.eダメージレベル = Eダメージレベル.少ない;
-															continue;
-														}
-													case 1:
-														{
-															c演奏記録.eダメージレベル = Eダメージレベル.普通;
-															continue;
-														}
-													case 2:
-														{
-															c演奏記録.eダメージレベル = Eダメージレベル.大きい;
-															continue;
-														}
-												}
-												throw new Exception( "DamageLevel の値が無効です。" );
-											}
-											#endregion
-											if ( item.Equals( "UseKeyboard" ) )
-											{
-												c演奏記録.b演奏にキーボードを使用した = C変換.bONorOFF( para[ 0 ] );
-											}
-											else if ( item.Equals( "UseMIDIIN" ) )
-											{
-												c演奏記録.b演奏にMIDI入力を使用した = C変換.bONorOFF( para[ 0 ] );
-											}
-											else if ( item.Equals( "UseJoypad" ) )
-											{
-												c演奏記録.b演奏にジョイパッドを使用した = C変換.bONorOFF( para[ 0 ] );
-											}
-											else if ( item.Equals( "UseMouse" ) )
-											{
-												c演奏記録.b演奏にマウスを使用した = C変換.bONorOFF( para[ 0 ] );
-											}
-											else if ( item.Equals( "PerfectRange" ) )
-											{
-												c演奏記録.nPerfectになる範囲ms = int.Parse( para );
-											}
-											else if ( item.Equals( "GreatRange" ) )
-											{
-												c演奏記録.nGreatになる範囲ms = int.Parse( para );
-											}
-											else if ( item.Equals( "GoodRange" ) )
-											{
-												c演奏記録.nGoodになる範囲ms = int.Parse( para );
-											}
-											else if ( item.Equals( "PoorRange" ) )
-											{
-												c演奏記録.nPoorになる範囲ms = int.Parse( para );
-											}
-											else if ( item.Equals( "DTXManiaVersion" ) )
-											{
-												c演奏記録.strDTXManiaのバージョン = para;
-											}
-											else if ( item.Equals( "DateTime" ) )
-											{
-												c演奏記録.最終更新日時 = para;
-											}
-											else if ( item.Equals( "9LaneMode" ) )
-											{
-												c演奏記録.レーン9モード = C変換.bONorOFF( para[ 0 ] );
-											}
-                                            else if ( item.Equals( "HiScore1" ) )
+                                    string[] strArray = str.Split(new char[] {'='});
+                                    if (strArray.Length == 2)
+                                    {
+                                        item = strArray[0].Trim();
+                                        para = strArray[1].Trim();
+                                        switch (section)
+                                        {
+                                            case Eセクション種別.File:
                                             {
-                                                c演奏記録.nハイスコア[ 0 ] = int.Parse( para );
+                                                if (!item.Equals("Title"))
+                                                {
+                                                    goto Label_01C7;
+                                                }
+
+                                                this.stファイル.Title = para;
+                                                continue;
                                             }
-                                            else if ( item.Equals( "HiScore2" ) )
+                                            case Eセクション種別.HiScoreDrums:
+                                            case Eセクション種別.HiSkillDrums:
+                                            case Eセクション種別.HiScoreGuitar:
+                                            case Eセクション種別.HiSkillGuitar:
+                                            case Eセクション種別.HiScoreBass:
+                                            case Eセクション種別.HiSkillBass:
+                                            case Eセクション種別.LastPlayDrums: // #23595 2011.1.9 ikanick
+                                            case Eセクション種別.LastPlayGuitar:
+                                            case Eセクション種別.LastPlayBass:
                                             {
-                                                c演奏記録.nハイスコア[ 1 ] = int.Parse( para );
-                                            }
-                                            else if ( item.Equals( "HiScore3" ) )
-                                            {
-                                                c演奏記録.nハイスコア[ 2 ] = int.Parse( para );
-                                            }
-                                            else if ( item.Equals( "HiScore4" ) )
-                                            {
-                                                c演奏記録.nハイスコア[ 3 ] = int.Parse( para );
-                                            }
-                                            //else if ( item.Equals( "HiScore5" ) )
-                                            //{
-                                            //    c演奏記録.nハイスコア[ 4 ] = int.Parse( para );
-                                            //}
+                                                c演奏記録 = this.stセクション[(int) section];
+                                                if (!item.Equals("Score"))
+                                                {
+                                                    goto Label_03B9;
+                                                }
+
+                                                c演奏記録.nスコア = long.Parse(para);
 
 
-										}
-									}
-								}
-							}
-							continue;
-						}
-						catch( Exception exception )
-						{
-							Trace.TraceError( exception.ToString() );
-							Trace.TraceError( "読み込みを中断します。({0})", iniファイル名 );
-							break;
-						}
-					}
-				}
-				reader.Close();
-			}
+                                                continue;
+                                            }
+                                        }
+                                    }
+                                }
+
+                                continue;
+
+                                #region [ File section ]
+
+                                Label_01C7:
+                                if (item.Equals("Name"))
+                                {
+                                    this.stファイル.Name = para;
+                                }
+                                else if (item.Equals("PlayCountDrums"))
+                                {
+                                    this.stファイル.PlayCountDrums = C変換.n値を文字列から取得して範囲内に丸めて返す(para, 0, 99999999, 0);
+                                }
+                                else if (item.Equals("PlayCountGuitars")) // #23596 11.2.5 changed ikanick
+                                {
+                                    this.stファイル.PlayCountGuitar = C変換.n値を文字列から取得して範囲内に丸めて返す(para, 0, 99999999, 0);
+                                }
+                                else if (item.Equals("PlayCountBass"))
+                                {
+                                    this.stファイル.PlayCountBass = C変換.n値を文字列から取得して範囲内に丸めて返す(para, 0, 99999999, 0);
+                                }
+                                // #23596 10.11.16 add ikanick------------------------------------/
+                                else if (item.Equals("ClearCountDrums"))
+                                {
+                                    this.stファイル.ClearCountDrums = C変換.n値を文字列から取得して範囲内に丸めて返す(para, 0, 99999999, 0);
+                                }
+                                else if (item.Equals("ClearCountGuitars")) // #23596 11.2.5 changed ikanick
+                                {
+                                    this.stファイル.ClearCountGuitar = C変換.n値を文字列から取得して範囲内に丸めて返す(para, 0, 99999999, 0);
+                                }
+                                else if (item.Equals("ClearCountBass"))
+                                {
+                                    this.stファイル.ClearCountBass = C変換.n値を文字列から取得して範囲内に丸めて返す(para, 0, 99999999, 0);
+                                }
+                                // #24459 2011.2.24 yyagi-----------------------------------------/
+                                else if (item.Equals("BestRankDrums"))
+                                {
+                                    this.stファイル.BestRank.Drums = C変換.n値を文字列から取得して範囲内に丸めて返す(
+                                        para,
+                                        (int) ERANK.SS,
+                                        (int) ERANK.E,
+                                        (int) ERANK.UNKNOWN);
+                                }
+                                else if (item.Equals("BestRankGuitar"))
+                                {
+                                    this.stファイル.BestRank.Guitar = C変換.n値を文字列から取得して範囲内に丸めて返す(
+                                        para,
+                                        (int) ERANK.SS,
+                                        (int) ERANK.E,
+                                        (int) ERANK.UNKNOWN);
+                                }
+                                else if (item.Equals("BestRankBass"))
+                                {
+                                    this.stファイル.BestRank.Bass = C変換.n値を文字列から取得して範囲内に丸めて返す(
+                                        para,
+                                        (int) ERANK.SS,
+                                        (int) ERANK.E,
+                                        (int) ERANK.UNKNOWN);
+                                }
+                                //----------------------------------------------------------------/
+                                else if (item.Equals("History0"))
+                                {
+                                    this.stファイル.History[0] = para;
+                                }
+                                else if (item.Equals("History1"))
+                                {
+                                    this.stファイル.History[1] = para;
+                                }
+                                else if (item.Equals("History2"))
+                                {
+                                    this.stファイル.History[2] = para;
+                                }
+                                else if (item.Equals("History3"))
+                                {
+                                    this.stファイル.History[3] = para;
+                                }
+                                else if (item.Equals("History4"))
+                                {
+                                    this.stファイル.History[4] = para;
+                                }
+                                else if (item.Equals("HistoryCount"))
+                                {
+                                    this.stファイル.HistoryCount = C変換.n値を文字列から取得して範囲内に丸めて返す(para, 0, 99999999, 0);
+                                }
+                                else if (item.Equals("BGMAdjust"))
+                                {
+                                    this.stファイル.BGMAdjust = C変換.n値を文字列から取得して返す(para, 0);
+                                }
+
+                                continue;
+
+                                #endregion
+
+                                #region [ Score section ]
+
+                                Label_03B9:
+                                if (item.Equals("HiScore1"))
+                                {
+                                    c演奏記録.nハイスコア[0] = int.Parse(para);
+                                }
+                                else if (item.Equals("HiScore2"))
+                                {
+                                    c演奏記録.nハイスコア[1] = int.Parse(para);
+                                }
+                                else if (item.Equals("HiScore3"))
+                                {
+                                    c演奏記録.nハイスコア[2] = int.Parse(para);
+                                }
+                                else if (item.Equals("HiScore4"))
+                                {
+                                    c演奏記録.nハイスコア[3] = int.Parse(para);
+                                }
+                                else if (item.Equals("HiScore5"))
+                                {
+                                    c演奏記録.nハイスコア[4] = int.Parse(para);
+                                }
+
+                                if (item.Equals("PlaySkill"))
+                                {
+                                    try
+                                    {
+                                        c演奏記録.db演奏型スキル値 = (double) decimal.Parse(para);
+                                    }
+                                    catch
+                                    {
+                                        c演奏記録.db演奏型スキル値 = 0.0;
+                                    }
+                                }
+                                else if (item.Equals("Skill"))
+                                {
+                                    try
+                                    {
+                                        c演奏記録.dbゲーム型スキル値 = (double) decimal.Parse(para);
+                                    }
+                                    catch
+                                    {
+                                        c演奏記録.dbゲーム型スキル値 = 0.0;
+                                    }
+                                }
+                                else if (item.Equals("Perfect"))
+                                {
+                                    c演奏記録.nPerfect数 = int.Parse(para);
+                                }
+                                else if (item.Equals("Great"))
+                                {
+                                    c演奏記録.nGreat数 = int.Parse(para);
+                                }
+                                else if (item.Equals("Good"))
+                                {
+                                    c演奏記録.nGood数 = int.Parse(para);
+                                }
+                                else if (item.Equals("Poor"))
+                                {
+                                    c演奏記録.nPoor数 = int.Parse(para);
+                                }
+                                else if (item.Equals("Miss"))
+                                {
+                                    c演奏記録.nMiss数 = int.Parse(para);
+                                }
+                                else if (item.Equals("Roll"))
+                                {
+                                    c演奏記録.n連打数 = int.Parse(para);
+                                }
+                                else if (item.Equals("MaxCombo"))
+                                {
+                                    c演奏記録.n最大コンボ数 = int.Parse(para);
+                                }
+                                else if (item.Equals("TotalChips"))
+                                {
+                                    c演奏記録.n全チップ数 = int.Parse(para);
+                                }
+                                else if (item.Equals("AutoPlay"))
+                                {
+                                    // LCなし               LCあり               CYとRDが別           Gt/Bs autolane/pick
+                                    if (para.Length == 9 || para.Length == 10 || para.Length == 11 || para.Length == 21)
+                                    {
+                                        for (int i = 0; i < para.Length; i++)
+                                        {
+                                            c演奏記録.bAutoPlay[i] = this.ONorOFF(para[i]);
+                                        }
+                                    }
+                                }
+                                else if (item.Equals("Risky"))
+                                {
+                                    c演奏記録.nRisky = int.Parse(para);
+                                }
+                                else if (item.Equals("TightDrums"))
+                                {
+                                    c演奏記録.bTight = C変換.bONorOFF(para[0]);
+                                }
+                                else if (item.Equals("SuddenDrums"))
+                                {
+                                    c演奏記録.bSudden.Drums = C変換.bONorOFF(para[0]);
+                                }
+                                else if (item.Equals("SuddenGuitar"))
+                                {
+                                    c演奏記録.bSudden.Guitar = C変換.bONorOFF(para[0]);
+                                }
+                                else if (item.Equals("SuddenBass"))
+                                {
+                                    c演奏記録.bSudden.Bass = C変換.bONorOFF(para[0]);
+                                }
+                                else if (item.Equals("HiddenDrums"))
+                                {
+                                    c演奏記録.bHidden.Drums = C変換.bONorOFF(para[0]);
+                                }
+                                else if (item.Equals("HiddenGuitar"))
+                                {
+                                    c演奏記録.bHidden.Guitar = C変換.bONorOFF(para[0]);
+                                }
+                                else if (item.Equals("HiddenBass"))
+                                {
+                                    c演奏記録.bHidden.Bass = C変換.bONorOFF(para[0]);
+                                }
+                                else if (item.Equals("InvisibleDrums"))
+                                {
+                                    c演奏記録.eInvisible.Drums = (EInvisible) int.Parse(para);
+                                }
+                                else if (item.Equals("InvisibleGuitar"))
+                                {
+                                    c演奏記録.eInvisible.Guitar = (EInvisible) int.Parse(para);
+                                }
+                                else if (item.Equals("InvisibleBass"))
+                                {
+                                    c演奏記録.eInvisible.Bass = (EInvisible) int.Parse(para);
+                                }
+                                else if (item.Equals("ReverseDrums"))
+                                {
+                                    c演奏記録.bReverse.Drums = C変換.bONorOFF(para[0]);
+                                }
+                                else if (item.Equals("ReverseGuitar"))
+                                {
+                                    c演奏記録.bReverse.Guitar = C変換.bONorOFF(para[0]);
+                                }
+                                else if (item.Equals("ReverseBass"))
+                                {
+                                    c演奏記録.bReverse.Bass = C変換.bONorOFF(para[0]);
+                                }
+
+                                #endregion
+
+                                else
+                                {
+                                    #region [ RandomGuitar ]
+
+                                    if (item.Equals("RandomGuitar"))
+                                    {
+                                        switch (int.Parse(para))
+                                        {
+                                            case (int) Eランダムモード.OFF:
+                                            {
+                                                c演奏記録.eRandom.Guitar = Eランダムモード.OFF;
+                                                continue;
+                                            }
+                                            case (int) Eランダムモード.RANDOM:
+                                            {
+                                                c演奏記録.eRandom.Guitar = Eランダムモード.RANDOM;
+                                                continue;
+                                            }
+                                            case (int) Eランダムモード.SUPERRANDOM:
+                                            {
+                                                c演奏記録.eRandom.Guitar = Eランダムモード.SUPERRANDOM;
+                                                continue;
+                                            }
+                                            case (int) Eランダムモード.HYPERRANDOM: // #25452 2011.6.20 yyagi
+                                            {
+                                                c演奏記録.eRandom.Guitar = Eランダムモード.SUPERRANDOM;
+                                                continue;
+                                            }
+                                        }
+
+                                        throw new Exception("RandomGuitar の値が無効です。");
+                                    }
+
+                                    #endregion
+
+                                    #region [ RandomBass ]
+
+                                    if (item.Equals("RandomBass"))
+                                    {
+                                        switch (int.Parse(para))
+                                        {
+                                            case (int) Eランダムモード.OFF:
+                                            {
+                                                c演奏記録.eRandom.Bass = Eランダムモード.OFF;
+                                                continue;
+                                            }
+                                            case (int) Eランダムモード.RANDOM:
+                                            {
+                                                c演奏記録.eRandom.Bass = Eランダムモード.RANDOM;
+                                                continue;
+                                            }
+                                            case (int) Eランダムモード.SUPERRANDOM:
+                                            {
+                                                c演奏記録.eRandom.Bass = Eランダムモード.SUPERRANDOM;
+                                                continue;
+                                            }
+                                            case (int) Eランダムモード.HYPERRANDOM: // #25452 2011.6.20 yyagi
+                                            {
+                                                c演奏記録.eRandom.Bass = Eランダムモード.SUPERRANDOM;
+                                                continue;
+                                            }
+                                        }
+
+                                        throw new Exception("RandomBass の値が無効です。");
+                                    }
+
+                                    #endregion
+
+                                    #region [ LightGuitar ]
+
+                                    if (item.Equals("LightGuitar"))
+                                    {
+                                        c演奏記録.bLight.Guitar = C変換.bONorOFF(para[0]);
+                                    }
+
+                                    #endregion
+
+                                    #region [ LightBass ]
+
+                                    else if (item.Equals("LightBass"))
+                                    {
+                                        c演奏記録.bLight.Bass = C変換.bONorOFF(para[0]);
+                                    }
+
+                                    #endregion
+
+                                    #region [ LeftGuitar ]
+
+                                    else if (item.Equals("LeftGuitar"))
+                                    {
+                                        c演奏記録.bLeft.Guitar = C変換.bONorOFF(para[0]);
+                                    }
+
+                                    #endregion
+
+                                    #region [ LeftBass ]
+
+                                    else if (item.Equals("LeftBass"))
+                                    {
+                                        c演奏記録.bLeft.Bass = C変換.bONorOFF(para[0]);
+                                    }
+
+                                    #endregion
+
+                                    else
+                                    {
+                                        #region [ Dark ]
+
+                                        if (item.Equals("Dark"))
+                                        {
+                                            switch (int.Parse(para))
+                                            {
+                                                case 0:
+                                                {
+                                                    c演奏記録.eDark = Eダークモード.OFF;
+                                                    continue;
+                                                }
+                                                case 1:
+                                                {
+                                                    c演奏記録.eDark = Eダークモード.HALF;
+                                                    continue;
+                                                }
+                                                case 2:
+                                                {
+                                                    c演奏記録.eDark = Eダークモード.FULL;
+                                                    continue;
+                                                }
+                                            }
+
+                                            throw new Exception("Dark の値が無効です。");
+                                        }
+
+                                        #endregion
+
+                                        #region [ ScrollSpeedDrums ]
+
+                                        if (item.Equals("ScrollSpeedDrums"))
+                                        {
+                                            c演奏記録.f譜面スクロール速度.Drums = (float) decimal.Parse(para);
+                                        }
+
+                                        #endregion
+
+                                        #region [ ScrollSpeedGuitar ]
+
+                                        else if (item.Equals("ScrollSpeedGuitar"))
+                                        {
+                                            c演奏記録.f譜面スクロール速度.Guitar = (float) decimal.Parse(para);
+                                        }
+
+                                        #endregion
+
+                                        #region [ ScrollSpeedBass ]
+
+                                        else if (item.Equals("ScrollSpeedBass"))
+                                        {
+                                            c演奏記録.f譜面スクロール速度.Bass = (float) decimal.Parse(para);
+                                        }
+
+                                        #endregion
+
+                                        #region [ PlaySpeed ]
+
+                                        else if (item.Equals("PlaySpeed"))
+                                        {
+                                            string[] strArray2 = para.Split(new char[] {'/'});
+                                            if (strArray2.Length == 2)
+                                            {
+                                                c演奏記録.n演奏速度分子 = int.Parse(strArray2[0]);
+                                                c演奏記録.n演奏速度分母 = int.Parse(strArray2[1]);
+                                            }
+                                        }
+
+                                        #endregion
+
+                                        else
+                                        {
+                                            #region [ Guitar ]
+
+                                            if (item.Equals("Guitar"))
+                                            {
+                                                c演奏記録.bGuitar有効 = C変換.bONorOFF(para[0]);
+                                            }
+
+                                            #endregion
+
+                                            #region [ Drums ]
+
+                                            else if (item.Equals("Drums"))
+                                            {
+                                                c演奏記録.bDrums有効 = C変換.bONorOFF(para[0]);
+                                            }
+
+                                            #endregion
+
+                                            #region [ StageFailed ]
+
+                                            else if (item.Equals("StageFailed"))
+                                            {
+                                                c演奏記録.bSTAGEFAILED有効 = C変換.bONorOFF(para[0]);
+                                            }
+
+                                            #endregion
+
+                                            else
+                                            {
+                                                #region [ DamageLevel ]
+
+                                                if (item.Equals("DamageLevel"))
+                                                {
+                                                    switch (int.Parse(para))
+                                                    {
+                                                        case 0:
+                                                        {
+                                                            c演奏記録.eダメージレベル = Eダメージレベル.少ない;
+                                                            continue;
+                                                        }
+                                                        case 1:
+                                                        {
+                                                            c演奏記録.eダメージレベル = Eダメージレベル.普通;
+                                                            continue;
+                                                        }
+                                                        case 2:
+                                                        {
+                                                            c演奏記録.eダメージレベル = Eダメージレベル.大きい;
+                                                            continue;
+                                                        }
+                                                    }
+
+                                                    throw new Exception("DamageLevel の値が無効です。");
+                                                }
+
+                                                #endregion
+
+                                                if (item.Equals("UseKeyboard"))
+                                                {
+                                                    c演奏記録.b演奏にキーボードを使用した = C変換.bONorOFF(para[0]);
+                                                }
+                                                else if (item.Equals("UseMIDIIN"))
+                                                {
+                                                    c演奏記録.b演奏にMIDI入力を使用した = C変換.bONorOFF(para[0]);
+                                                }
+                                                else if (item.Equals("UseJoypad"))
+                                                {
+                                                    c演奏記録.b演奏にジョイパッドを使用した = C変換.bONorOFF(para[0]);
+                                                }
+                                                else if (item.Equals("UseMouse"))
+                                                {
+                                                    c演奏記録.b演奏にマウスを使用した = C変換.bONorOFF(para[0]);
+                                                }
+                                                else if (item.Equals("PerfectRange"))
+                                                {
+                                                    c演奏記録.nPerfectになる範囲ms = int.Parse(para);
+                                                }
+                                                else if (item.Equals("GreatRange"))
+                                                {
+                                                    c演奏記録.nGreatになる範囲ms = int.Parse(para);
+                                                }
+                                                else if (item.Equals("GoodRange"))
+                                                {
+                                                    c演奏記録.nGoodになる範囲ms = int.Parse(para);
+                                                }
+                                                else if (item.Equals("PoorRange"))
+                                                {
+                                                    c演奏記録.nPoorになる範囲ms = int.Parse(para);
+                                                }
+                                                else if (item.Equals("DTXManiaVersion"))
+                                                {
+                                                    c演奏記録.strDTXManiaのバージョン = para;
+                                                }
+                                                else if (item.Equals("DateTime"))
+                                                {
+                                                    c演奏記録.最終更新日時 = para;
+                                                }
+                                                else if (item.Equals("9LaneMode"))
+                                                {
+                                                    c演奏記録.レーン9モード = C変換.bONorOFF(para[0]);
+                                                }
+                                                else if (item.Equals("HiScore1"))
+                                                {
+                                                    c演奏記録.nハイスコア[0] = int.Parse(para);
+                                                }
+                                                else if (item.Equals("HiScore2"))
+                                                {
+                                                    c演奏記録.nハイスコア[1] = int.Parse(para);
+                                                }
+                                                else if (item.Equals("HiScore3"))
+                                                {
+                                                    c演奏記録.nハイスコア[2] = int.Parse(para);
+                                                }
+                                                else if (item.Equals("HiScore4"))
+                                                {
+                                                    c演奏記録.nハイスコア[3] = int.Parse(para);
+                                                }
+                                                //else if ( item.Equals( "HiScore5" ) )
+                                                //{
+                                                //    c演奏記録.nハイスコア[ 4 ] = int.Parse( para );
+                                                //}
+
+
+                                            }
+                                        }
+                                    }
+                                }
+
+                                continue;
+                            }
+                            catch (Exception exception)
+                            {
+                                Trace.TraceError(exception.ToString());
+                                Trace.TraceError("読み込みを中断します。({0})", iniファイル名);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
 		}
 
 		internal void tヒストリを追加する( string str追加文字列 )

--- a/TJAPlayer3/Songs/CSong管理.cs
+++ b/TJAPlayer3/Songs/CSong管理.cs
@@ -1135,12 +1135,14 @@ namespace TJAPlayer3
 		{
 			this.nSongsDBへ出力できたスコア数 = 0;
 			try
-			{
-				BinaryWriter bw = new BinaryWriter( new FileStream( SongsDBファイル名, FileMode.Create, FileAccess.Write ) );
-				bw.Write( SONGSDB_VERSION );
-				this.tSongsDBにリストを１つ出力する( bw, this.list曲ルート );
-				bw.Close();
-			}
+            {
+                using (var fileStream = new FileStream(SongsDBファイル名, FileMode.Create, FileAccess.Write))
+                using (var bw = new BinaryWriter(fileStream))
+                {
+                    bw.Write(SONGSDB_VERSION);
+                    this.tSongsDBにリストを１つ出力する(bw, this.list曲ルート);
+                }
+            }
 			catch (Exception e)
 			{
 				Trace.TraceError( "songs.dbの出力に失敗しました。" );

--- a/TJAPlayer3/Songs/CSong管理.cs
+++ b/TJAPlayer3/Songs/CSong管理.cs
@@ -97,11 +97,10 @@ namespace TJAPlayer3
 		{
 			this.nSongsDBから取得できたスコア数 = 0;
 			if( File.Exists( SongsDBファイル名 ) )
-			{
-				BinaryReader br = null;
-				try
+            {
+                using (var fileStream = File.OpenRead( SongsDBファイル名 ))
+                using (var br = new BinaryReader( fileStream ))
 				{
-					br = new BinaryReader( File.OpenRead( SongsDBファイル名 ) );
 					if ( !br.ReadString().Equals( SONGSDB_VERSION ) )
 					{
 						throw new InvalidDataException( "ヘッダが異なります。" );
@@ -122,12 +121,7 @@ namespace TJAPlayer3
 						}
 					}
 				}
-				finally
-				{
-					if( br != null )
-						br.Close();
-				}
-			}
+            }
 		}
 		//-----------------
 		#endregion

--- a/TJAPlayer3/Stages/02.Title/CEnumSongs.cs
+++ b/TJAPlayer3/Stages/02.Title/CEnumSongs.cs
@@ -580,12 +580,12 @@ namespace TJAPlayer3
 		private static void SerializeSongList( CSongs管理 cs, string strPathSongList )
 		{
 			bool bSucceededSerialize = true;
-			Stream output = null;
 			try
 			{
-				output = File.Create( strPathSongList );
-				BinaryFormatter formatter = new BinaryFormatter();
-				formatter.Serialize( output, cs );
+                using (var output = File.Create(strPathSongList))
+                {
+                    new BinaryFormatter().Serialize( output, cs );
+                }
 			}
 			catch ( Exception e )
 			{
@@ -595,7 +595,6 @@ namespace TJAPlayer3
 			}
 			finally
 			{
-				output.Close();
 				if ( !bSucceededSerialize )
 				{
 					try


### PR DESCRIPTION
Some file stream handling, both for read and for write, was not making use of using semantics. This PR aligns a good number of such cases onto using semantics, though some remain, and may help eliminate or at least narrow down problems elsewhere (by properly closing writers/readers and streams when unwinding a call stack due to a recoverable error, whereas the previous code would have left the stream dangling and then been able to crash the code somewhere *else*)

This may address a CScoreIni issue in the Sentry error reports. That issue has been marked as resolved in the next release, and we'll just have to see if it automatically re-opens.