### PR TITLE
Adjust sound initialization failure thrown exception type to minimize confusion

### DIFF
--- a/TJAPlayer3/Common/TJAPlayer3.cs
+++ b/TJAPlayer3/Common/TJAPlayer3.cs
@@ -1809,7 +1809,7 @@ for (int i = 0; i < 3; i++) {
 			}
 			catch (Exception e)
 			{
-                throw new NullReferenceException("サウンドデバイスがひとつも有効になっていないため、サウンドデバイスの初期化ができませんでした。", e);
+                throw new Exception("サウンドデバイスがひとつも有効になっていないため、サウンドデバイスの初期化ができませんでした。", e);
 			}
 			finally
 			{


### PR DESCRIPTION
In TJAPlayer3.cs, replace the NullReferenceException thrown upon sound initialization failure with just Exception, so as to avoid confusion for an actual NullReferenceException.